### PR TITLE
feat: NR-184027 Phase 1 slice for unified injected-bytecode method cache

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentShim.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentShim.cs
@@ -94,6 +94,33 @@ public class AgentShim
         return DeferInitializationOnTheseMethods.Contains(method);
     }
 
+    public static object GetFinishTracerDelegateFunc()
+    {
+        return (Func<object[], Action<object, Exception>>)GetFinishTracerDelegateParameterWrapper;
+    }
+
+    /// <summary>
+    /// This method is used to work around .net framework and .net &lt; 6.0 not supporting generic delegates
+    /// with 11 parameters.
+    /// </summary>
+    /// <param name="parameters">An array of boxed parameters for the GetFinishTracerDelegate method.</param>
+    /// <returns>The delegate to invoke when a method completes or results in an exception.</returns>
+    public static Action<object, Exception> GetFinishTracerDelegateParameterWrapper(object[] parameters)
+    {
+        return GetFinishTracerDelegate(
+            (string)parameters[0],
+            (uint)parameters[1],
+            (string)parameters[2],
+            (string)parameters[3],
+            (Type)parameters[4],
+            (string)parameters[5],
+            (string)parameters[6],
+            (string)parameters[7],
+            parameters[8],
+            (object[])parameters[9],
+            (ulong)parameters[10]);
+    }
+
     /// <summary>
     /// Creates a tracer (if appropriate) and returns a delegate for the tracer's finish method.
     /// This method is reflectively invoked from the injected bytecode if the CLR is greater than 2.0.

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.1.9"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.52.0.35"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
@@ -13,7 +13,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     class HelperFunctionManipulator : FunctionManipulator
     {
     public:
-        HelperFunctionManipulator(IFunctionPtr function) : 
+        HelperFunctionManipulator(IFunctionPtr function) :
             FunctionManipulator(function)
         {
             Initialize();
@@ -45,6 +45,18 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             else if (_function->GetFunctionName() == _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"))
             {
                 BuildGetMethodFromAppDomainStorageOrReflectionOrThrow();
+            }
+            else if (_function->GetFunctionName() == _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"))
+            {
+                BuildGetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow();
+            }
+            else if (_function->GetFunctionName() == _X("GetAgentShimFinishTracerDelegateFunc"))
+            {
+                BuildGetAgentShimFinishTracerDelegateFunc();
+            }
+            else if (_function->GetFunctionName() == _X("StoreAgentShimFinishTracerDelegateFunc"))
+            {
+                BuildStoreAgentShimFinishTracerDelegateFunc();
             }
             else
             {
@@ -107,7 +119,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         // because of security permissions.  The methods added onto an mscorlib exception
         // work around this.
         //
-        // void StoreMethodInAppDomainStorageOrThrow(MethodInfo method, String storageKey)
+        // void StoreMethodInAppDomainStorageOrThrow(object method, String storageKey)
         void BuildStoreMethodInAppDomainStorageOrThrow()
         {
             _instructions->Append(CEE_CALL, _X("class System.AppDomain System.AppDomain::get_CurrentDomain()"));
@@ -146,9 +158,76 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodViaReflectionOrThrow(string,string,string,class System.Type[])"));
             _instructions->Append(CEE_DUP);
             _instructions->Append(CEE_LDARG_0);
-            _instructions->Append(CEE_CALL, _X("void System.CannotUnloadAppDomainException::StoreMethodInAppDomainStorageOrThrow(class System.Reflection.MethodInfo,string)"));
+            _instructions->Append(CEE_CALL, _X("void System.CannotUnloadAppDomainException::StoreMethodInAppDomainStorageOrThrow(object,string)"));
 
             _instructions->AppendLabel(methodEnd);
+            _instructions->Append(CEE_RET);
+        }
+
+        // object GetAgentShimFinishTracerDelegateFunc()
+        // Fast-path: reads _agentShimFunc static field; falls back to AppDomain.GetData if null.
+        void BuildGetAgentShimFinishTracerDelegateFunc()
+        {
+            _instructions->Append(CEE_LDSFLD, _X("object __NRInitializer__::_agentShimFunc"));
+
+            _instructions->Append(CEE_DUP);
+            auto afterFallback = _instructions->AppendJump(CEE_BRTRUE);
+
+            _instructions->Append(CEE_POP);
+            _instructions->Append(CEE_CALL, _X("class System.AppDomain System.AppDomain::get_CurrentDomain()"));
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true);
+            _instructions->AppendString(_X("__NRInitializer__::_agentShimFunc"));
+            _instructions->Append(CEE_CALLVIRT, _X("instance object System.AppDomain::GetData(string)"));
+
+            _instructions->AppendLabel(afterFallback);
+
+            _instructions->Append(CEE_RET);
+        }
+
+        // void StoreAgentShimFinishTracerDelegateFunc(String assemblyPath)
+        // Resolves AgentShim.GetFinishTracerDelegateFunc via reflection, invokes it to get the
+        // Func delegate, stores to _agentShimFunc field and AppDomain storage.
+        void BuildStoreAgentShimFinishTracerDelegateFunc()
+        {
+            _instructions->Append(CEE_LDARG_0);
+            _instructions->AppendString(_X("NewRelic.Agent.Core.AgentShim"));
+            _instructions->AppendString(_X("GetFinishTracerDelegateFunc"));
+            _instructions->Append(CEE_LDNULL);
+            _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodViaReflectionOrThrow(string,string,string,class System.Type[])"));
+
+            _instructions->Append(CEE_LDNULL);
+            _instructions->Append(CEE_LDNULL);
+            _instructions->Append(CEE_CALLVIRT, _X("instance object System.Reflection.MethodBase::Invoke(object, object[])"));
+
+            _instructions->Append(CEE_DUP);
+            _instructions->Append(CEE_STSFLD, _X("object __NRInitializer__::_agentShimFunc"));
+            _instructions->AppendString(_X("__NRInitializer__::_agentShimFunc"));
+            _instructions->Append(CEE_CALL, _X("void System.CannotUnloadAppDomainException::StoreMethodInAppDomainStorageOrThrow(object,string)"));
+            _instructions->Append(CEE_RET);
+        }
+
+        // MethodInfo GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow(String storageKey, String assemblyPath, String typeName, String methodName, Type[] methodParameters)
+        // Fast-path: reads _agentShimMethodInfo static field; falls back to GetMethodFromAppDomainStorageOrReflectionOrThrow if null.
+        void BuildGetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow()
+        {
+            _instructions->Append(CEE_LDSFLD, _X("object __NRInitializer__::_agentShimMethodInfo"));
+
+            _instructions->Append(CEE_DUP);
+            auto afterFallback = _instructions->AppendJump(CEE_BRTRUE);
+
+            _instructions->Append(CEE_POP);
+            _instructions->Append(CEE_LDARG_0);
+            _instructions->Append(CEE_LDARG_1);
+            _instructions->Append(CEE_LDARG_2);
+            _instructions->Append(CEE_LDARG_3);
+            _instructions->Append(CEE_LDARG_S, (uint8_t)4);
+            _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodFromAppDomainStorageOrReflectionOrThrow(string,string,string,string,class System.Type[])"));
+
+            _instructions->Append(CEE_DUP);
+            _instructions->Append(CEE_STSFLD, _X("object __NRInitializer__::_agentShimMethodInfo"));
+
+            _instructions->AppendLabel(afterFallback);
+
             _instructions->Append(CEE_RET);
         }
     };

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstructionSet.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstructionSet.h
@@ -217,6 +217,14 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             {
                 Append(CEE_RETHROW);
             }
+            else if (instruction == _X("ldsfld"))
+            {
+                Append(CEE_LDSFLD, details);
+            }
+            else if (instruction == _X("stsfld"))
+            {
+                Append(CEE_STSFLD, details);
+            }
             else
             {
                 LogError(L"Encountered unsupported instruction while attempting to generate byte code. Instruction: ", instruction);

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -116,11 +116,20 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     // An instrumentor for the methods we inject into mscorlib
     struct HelperInstrumentor : public IInstrumentor
     {
+        // Proxy engagement counter: counts total HelperInstrumentor dispatch events.
+        // A nonzero value proves the mscorlib helper injection code path is engaged.
+        // Used by CorProfilerCallbackImpl to log AppDomainFallbackCache engagement.
+        // See AppDomainFallbackCache design in HelperFunctionManipulator.h.
+        // Note: this counter resets to 0 if MethodRewriter is re-instantiated during
+        // an instrumentation refresh; it is a per-MethodRewriter-instance count,
+        // not a process-lifetime count.
+        uint64_t GetHelperFireCount() const { return _helperFireCount.load(); }
+
         bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr) override
         {
             if (!Strings::EndsWith(function->GetModuleName(), _X("mscorlib.dll")))
                 return false;
-            
+
             if (function->GetTypeName() != _X("System.CannotUnloadAppDomainException"))
                 return false;
 
@@ -133,13 +142,20 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 function->GetFunctionName() != _X("GetMethodViaReflectionOrThrow") &&
                 function->GetFunctionName() != _X("GetMethodFromAppDomainStorage") &&
                 function->GetFunctionName() != _X("GetMethodFromAppDomainStorageOrReflectionOrThrow") &&
-                function->GetFunctionName() != _X("StoreMethodInAppDomainStorageOrThrow"))
+                function->GetFunctionName() != _X("StoreMethodInAppDomainStorageOrThrow") &&
+                function->GetFunctionName() != _X("GetAgentShimFinishTracerDelegateFunc") &&
+                function->GetFunctionName() != _X("StoreAgentShimFinishTracerDelegateFunc") &&
+                function->GetFunctionName() != _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"))
                 return false;
 
+            ++_helperFireCount;
             LogInfo(L"Instrumenting helper method: ", function->ToString());
             HelperFunctionManipulator manipulator(function);
             manipulator.InstrumentHelper();
             return false;
         }
+
+    private:
+        std::atomic<uint64_t> _helperFireCount{0};
     };
 }}}

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
@@ -51,6 +51,9 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
             _instrumentedFunctionNames->emplace(_X("GetTypeViaReflectionOrThrow"));
             _instrumentedFunctionNames->emplace(_X("LoadAssemblyOrThrow"));
             _instrumentedFunctionNames->emplace(_X("StoreMethodInAppDomainStorageOrThrow"));
+            _instrumentedFunctionNames->emplace(_X("GetAgentShimFinishTracerDelegateFunc"));
+            _instrumentedFunctionNames->emplace(_X("StoreAgentShimFinishTracerDelegateFunc"));
+            _instrumentedFunctionNames->emplace(_X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"));
 
             auto instrumentationPoints = _instrumentationConfiguration->GetInstrumentationPoints();
 
@@ -96,6 +99,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
         {
             return InSet(_instrumentedFunctionNames, functionName);
         }
+
+        // Returns the count of times HelperInstrumentor has dispatched.
+        // Proxy for AppDomainFallbackCache engagement -- see Instrumentors.h.
+        uint64_t GetHelperFireCount() const { return _helperInstrumentor->GetHelperFireCount(); }
 
         // instrument the provided method (if necessary)
         void Instrument(IFunctionPtr function)

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
@@ -10,6 +10,7 @@
 #include "MockFunction.h"
 #include "../MethodRewriter/FunctionManipulator.h"
 #include "../MethodRewriter/InstrumentFunctionManipulator.h"
+#include "../MethodRewriter/HelperFunctionManipulator.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -127,6 +128,63 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
         //{
         //    Assert::Fail(L"Test not implemented.");
         //}
+
+        TEST_METHOD(helper_method_GetAgentShimFinishTracerDelegateFunc)
+        {
+            auto function = std::make_shared<MockFunction>();
+            function->_functionName = _X("GetAgentShimFinishTracerDelegateFunc");
+
+            ByteVector capturedBytes;
+            function->_writeMethodHandler = [&capturedBytes](const ByteVector& bytes) {
+                capturedBytes = bytes;
+            };
+
+            HelperFunctionManipulator manipulator(function);
+            manipulator.InstrumentHelper();
+
+            // capturedBytes = 1-byte tiny header + IL body
+            // expected IL size: 45 bytes; first IL byte: CEE_LDSFLD (0x7E)
+            Assert::AreEqual((size_t)46, capturedBytes.size());
+            Assert::AreEqual((uint8_t)0x7E, capturedBytes[1]);
+        }
+
+        TEST_METHOD(helper_method_StoreAgentShimFinishTracerDelegateFunc)
+        {
+            auto function = std::make_shared<MockFunction>();
+            function->_functionName = _X("StoreAgentShimFinishTracerDelegateFunc");
+
+            ByteVector capturedBytes;
+            function->_writeMethodHandler = [&capturedBytes](const ByteVector& bytes) {
+                capturedBytes = bytes;
+            };
+
+            HelperFunctionManipulator manipulator(function);
+            manipulator.InstrumentHelper();
+
+            // capturedBytes = 1-byte tiny header + IL body
+            // expected IL size: 41 bytes; first IL byte: CEE_LDARG_0 (0x02)
+            Assert::AreEqual((size_t)42, capturedBytes.size());
+            Assert::AreEqual((uint8_t)0x02, capturedBytes[1]);
+        }
+
+        TEST_METHOD(helper_method_GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow)
+        {
+            auto function = std::make_shared<MockFunction>();
+            function->_functionName = _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow");
+
+            ByteVector capturedBytes;
+            function->_writeMethodHandler = [&capturedBytes](const ByteVector& bytes) {
+                capturedBytes = bytes;
+            };
+
+            HelperFunctionManipulator manipulator(function);
+            manipulator.InstrumentHelper();
+
+            // capturedBytes = 1-byte tiny header + IL body
+            // expected IL size: 30 bytes; first IL byte: CEE_LDSFLD (0x7E)
+            Assert::AreEqual((size_t)31, capturedBytes.size());
+            Assert::AreEqual((uint8_t)0x7E, capturedBytes[1]);
+        }
 
     private:
         Configuration::InstrumentationPointPtr CreateInstrumentationPointThatMatchesFunction(IFunctionPtr function)

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstructionSetTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstructionSetTest.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include "CppUnitTest.h"
 #include "../MethodRewriter/InstructionSet.h"
+#include "MockTokenizer.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -65,6 +66,46 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
                 0xDE,
                 0xEB,
                 0XBE
+            );
+            auto actualBytes = instructionSet.GetBytes();
+
+            VerifyBytes(expectedBytes, actualBytes);
+        }
+
+        TEST_METHOD(append_ldsfld)
+        {
+            auto tokenizer = std::make_shared<MockTokenizer>();
+            tokenizer->_fieldDefinitionToken = 0xDEADBEEF;
+            auto instructionSet = InstructionSet(tokenizer, nullptr);
+
+            instructionSet.Append(_X("ldsfld object __NRInitializer__::_agentShimMethodInfo"));
+
+            BYTEVECTOR(expectedBytes,
+                CEE_LDSFLD,
+                0xEF,
+                0xBE,
+                0xAD,
+                0xDE
+            );
+            auto actualBytes = instructionSet.GetBytes();
+
+            VerifyBytes(expectedBytes, actualBytes);
+        }
+
+        TEST_METHOD(append_stsfld)
+        {
+            auto tokenizer = std::make_shared<MockTokenizer>();
+            tokenizer->_fieldDefinitionToken = 0x01020304;
+            auto instructionSet = InstructionSet(tokenizer, nullptr);
+
+            instructionSet.Append(_X("stsfld object __NRInitializer__::_agentShimFunc"));
+
+            BYTEVECTOR(expectedBytes,
+                CEE_STSFLD,
+                0x04,
+                0x03,
+                0x02,
+                0x01
             );
             auto actualBytes = instructionSet.GetBytes();
 

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockFunction.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockFunction.h
@@ -47,7 +47,13 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             _signatureToken(0x456),
             _string(L"[MyAssembly]MyNamespace.MyClass.MyMethod"),
             _isGenericType(false),
-            _typeToken(0x045612345)
+            _typeToken(0x045612345),
+            _isCoreClr(false),
+            _shouldInjectMethodInstrumentation(false),
+            _shouldTrace(false),
+            _classAttributes(0),
+            _methodAttributes(0),
+            _isValid(true)
         {
             if (version.empty())
             {
@@ -138,14 +144,16 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return std::make_shared<MockFunctionHeaderInfo>((uint16_t)1);
         }
 
+        unsigned long _classAttributes;
         virtual unsigned long GetClassAttributes() override
         {
-            return 0;
+            return _classAttributes;
         }
 
+        unsigned long _methodAttributes;
         virtual unsigned long GetMethodAttributes() override
         {
-            return 0;
+            return _methodAttributes;
         }
 
         virtual bool Preprocess() override
@@ -153,9 +161,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return true;
         }
 
+        bool _shouldTrace;
         virtual bool ShouldTrace() override
         {
-            return false;
+            return _shouldTrace;
         }
 
         std::wstring _version;
@@ -171,9 +180,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             };
         }
 
+        bool _shouldInjectMethodInstrumentation;
         virtual bool ShouldInjectMethodInstrumentation() override
         {
-            return false;
+            return _shouldInjectMethodInstrumentation;
         }
 
         virtual uint32_t GetTracerFlags() override
@@ -181,14 +191,16 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return 0;
         }
 
+        bool _isValid;
         virtual bool IsValid() override
         {
-            return true;
+            return _isValid;
         }
 
+        bool _isCoreClr;
         virtual bool IsCoreClr() override
         {
-            return false;
+            return _isCoreClr;
         }
 
         uint32_t _typeToken;

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockTokenizer.h
@@ -19,6 +19,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             _typeSpecToken(0),
             _memberRefOrDefToken(0),
             _methodDefinitionToken(0),
+            _fieldDefinitionToken(0),
             _methodSpecToken(0),
             _stringToken(0),
             _instantiationSignature(nullptr),
@@ -82,6 +83,14 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             name;
             signature;
             return _methodDefinitionToken;
+        }
+
+        uint32_t _fieldDefinitionToken;
+        virtual uint32_t GetFieldDefinitionToken(const uint32_t& typeDefinitionToken, const std::wstring& name) override
+        {
+            typeDefinitionToken;
+            name;
+            return _fieldDefinitionToken;
         }
 
         uint32_t _methodSpecToken;

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/IModule.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/IModule.h
@@ -5,7 +5,13 @@
 #pragma once
 #include <string>
 #include <memory>
+
+#ifdef PAL_STDCPP_COMPAT
+#include <atl.h>
+#else // PAL_STDCPP_COMPAT (not)
 #include <atlcomcli.h>
+#endif // PAL_STDCPP_COMPAT
+
 #include "../Common/Macros.h"
 #include "../Sicily/codegen/ITokenizer.h"
 
@@ -14,21 +20,16 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
     class IModule
     {
     public:
-        virtual std::wstring GetModuleName() = 0;
-        virtual void InjectPlatformInvoke(const std::wstring& methodName, const std::wstring& className, const std::wstring& moduleName, const ByteVector& signature) = 0;
-        virtual void InjectStaticSecuritySafeMethod(const std::wstring& methodName, const std::wstring& className, const ByteVector& signature) = 0;
-        virtual void InjectMscorlibSecuritySafeMethodReference(const std::wstring& methodName, const std::wstring& className, const ByteVector& signature) = 0;
+        virtual xstring_t GetModuleName() = 0;
+        virtual void InjectPlatformInvoke(const xstring_t& methodName, const xstring_t& className, const xstring_t& moduleName, const ByteVector& signature) = 0;
+        virtual void InjectStaticSecuritySafeMethod(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) = 0;
+        virtual void InjectStaticSecuritySafeCtor(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) = 0;
+        virtual void InjectCoreLibSecuritySafeMethodReference(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) = 0;
+        virtual void InjectNRHelperType() = 0;
+        virtual bool InjectReferenceToCoreLib() = 0;
 
-        virtual bool GetHasRefMscorlib() = 0;
-        virtual bool GetHasRefSysRuntime() = 0;
-        virtual bool GetHasRefNetStandard() = 0;
-
-        virtual void SetMscorlibAssemblyRef(mdAssembly assemblyRefToken) = 0;
-
-        virtual bool GetIsThisTheMscorlibAssembly() = 0;
-        virtual bool GetIsThisTheNetStandardAssembly() = 0;
-
-        virtual CComPtr<IMetaDataAssemblyEmit> GetMetaDataAssemblyEmit() = 0;
+        virtual bool NeedsReferenceToCoreLib() = 0;
+        virtual bool GetIsThisTheCoreLibAssembly() = 0;
 
         virtual sicily::codegen::ITokenizerPtr GetTokenizer() = 0;
     };

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
@@ -8,6 +8,7 @@
 #include "../Common/CorStandIn.h"
 #include "../Common/Strings.h"
 #include "../Logging/Logger.h"
+#include "../Profiler/Exceptions.h"
 #include "../Sicily/Sicily.h"
 #include "IModule.h"
 
@@ -19,7 +20,7 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
         struct ManagedMethodToInject
         {
             //null terminated character string NTCS
-            using ntcs_t = const wchar_t* const;
+            using ntcs_t = const xchar_t* const;
             ntcs_t TypeName;
             ntcs_t MethodName;
             ntcs_t ReturnType;
@@ -30,52 +31,97 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
         };
 
     public:
-        static void InjectIntoModule(IModule& module)
+        static void InjectIntoModule(IModule& module, const bool isCoreClr = false)
         {
-            //for background on the methodology and rationale, see:
-            //  https://social.msdn.microsoft.com/Forums/en-US/f8bf431a-7a83-4dfb-bbf7-ef23b1e30904/profiling-silverlight-with-securitysafecriticalattributesecuritycriticalattribute-and-injected-il
+            // When injecting method REFERENCES into an assembly, theses references should have
+            // the external assembly identifier to System.Private.CoreLib
+            constexpr std::array<ManagedMethodToInject, 13> methodReferencesToInjectCoreClr{
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.Assembly"), _X("string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Type"), _X("string,string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,class [System.Private.CoreLib]System.Type[]")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[]")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[]")),
+                //ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo,string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"),_X("EnsureInitialized"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[],class [System.Private.CoreLib]System.Type,object[]")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
+            };
 
             // When injecting method REFERENCES into an assembly, theses references should have
             // the external assembly identifier to mscorlib
-            constexpr std::array<ManagedMethodToInject, 6> methodReferencesToInject{
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"LoadAssemblyOrThrow", L"class [mscorlib]System.Reflection.Assembly", L"string"),
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"GetTypeViaReflectionOrThrow", L"class [mscorlib]System.Type", L"string,string"),
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"GetMethodViaReflectionOrThrow", L"class [mscorlib]System.Reflection.MethodInfo", L"string,string,string,class [mscorlib]System.Type[]"),
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"GetMethodFromAppDomainStorage", L"class [mscorlib]System.Reflection.MethodInfo", L"string"),
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"GetMethodFromAppDomainStorageOrReflectionOrThrow", L"class [mscorlib]System.Reflection.MethodInfo", L"string,string,string,string,class [mscorlib]System.Type[]"),
-                ManagedMethodToInject(L"[mscorlib]System.CannotUnloadAppDomainException", L"StoreMethodInAppDomainStorageOrThrow", L"void", L"class [mscorlib]System.Reflection.MethodInfo,string")
+            constexpr std::array<ManagedMethodToInject, 13> methodReferencesToInjectNetFramework{
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [mscorlib]System.Reflection.Assembly"), _X("string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [mscorlib]System.Type"), _X("string,string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,class [mscorlib]System.Type[]")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [mscorlib]System.Type[]")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [mscorlib]System.Type[]")),
+                //ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("class [mscorlib]System.Reflection.MethodInfo,string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("EnsureInitialized"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class [mscorlib]System.Type[],class [mscorlib]System.Type,object[]")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
             };
 
-            // When injecting HELPER METHODS into the mscorlib assembly, theses references should be local.
-            // They cannot reference [mscorlib] since these methods are being rewritten in mscorlib.
-            constexpr std::array<ManagedMethodToInject, 6> methodImplsToInject {
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"LoadAssemblyOrThrow", L"class System.Reflection.Assembly", L"string"),
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"GetTypeViaReflectionOrThrow", L"class System.Type", L"string,string"),
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"GetMethodViaReflectionOrThrow", L"class System.Reflection.MethodInfo", L"string,string,string,class System.Type[]"),
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"GetMethodFromAppDomainStorage", L"class System.Reflection.MethodInfo", L"string"),
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"GetMethodFromAppDomainStorageOrReflectionOrThrow", L"class System.Reflection.MethodInfo", L"string,string,string,string,class System.Type[]"),
-                ManagedMethodToInject(L"System.CannotUnloadAppDomainException", L"StoreMethodInAppDomainStorageOrThrow", L"void", L"class System.Reflection.MethodInfo,string")
+            // When injecting HELPER METHODS into the Core Lib assembly, theses references should be local.
+            // They cannot reference an assembly since these methods are being rewritten in the Core Lib so only types available in that lib can be used.
+            constexpr std::array<ManagedMethodToInject, 13> methodImplsToInject{
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class System.Reflection.Assembly"), _X("string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class System.Type"), _X("string,string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,class System.Type[]")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class System.Reflection.MethodInfo"), _X("string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,string,class System.Type[]")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,string,class System.Type[]")),
+                //ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("class System.Reflection.MethodInfo,string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("EnsureInitialized"), _X("void"), _X("string")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class System.Type[],class System.Type,object[]")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
             };
 
-            const auto is_mscorlib = module.GetIsThisTheMscorlibAssembly();
+            const auto is_coreLib = module.GetIsThisTheCoreLibAssembly();
 
-            // If instrumenting mscorlib, use local (to the assembly) references
+            // If instrumenting Core Lib, use local (to the assembly) references
             // otherwise use external references
-            auto methods = is_mscorlib
+            auto methods = is_coreLib
                 ? methodImplsToInject
-                : methodReferencesToInject;
+                : (isCoreClr ? methodReferencesToInjectCoreClr : methodReferencesToInjectNetFramework);
 
-            if (!is_mscorlib && !EnsureReferenceToMscorlib(module))
+            if (!is_coreLib && !EnsureReferenceToCoreLib(module))
             {
-                LogInfo(L"Unable to inject reference to mscorlib into ", module.GetModuleName(), L".  This module will not be instrumented.");
+                LogInfo(L"Unable to inject reference to Core Library into ", module.GetModuleName(), L".  This module will not be instrumented.");
                 return;
             }
 
-            LogDebug(L"Injecting ", ((is_mscorlib) ? L"" : L"references to "), L"helper methods into ", module.GetModuleName());
+            if (is_coreLib)
+            {
+                LogDebug(L"Injecting New Relic helper type into ", module.GetModuleName());
+                try
+                {
+                    module.InjectNRHelperType();
+                }
+                catch (NewRelic::Profiler::Win32Exception&)
+                {
+                    LogError(L"Failed to inject New Relic helper type into ", module.GetModuleName());
+                }
+            }
 
-            //inject the methods if mscorlib and inject references into all other assemblies. (pointer to member function to select method to call in loop)
-            const auto workerFunc{ (is_mscorlib) ? &IModule::InjectStaticSecuritySafeMethod : &IModule::InjectMscorlibSecuritySafeMethodReference };
-            std::wstring signatum;
+            LogDebug(L"Injecting ", ((is_coreLib) ? L"" : L"references to "), L"helper methods into ", module.GetModuleName());
+
+            //inject the methods if this is the Core Lib and inject references into all other assemblies. (pointer to member function to select method to call in loop)
+            const auto workerFunc{ (is_coreLib) ? &IModule::InjectStaticSecuritySafeMethod : &IModule::InjectCoreLibSecuritySafeMethodReference };
+            xstring_t signatum;
             signatum.reserve(200);
             for (const auto& managedMethod : methods)
             {
@@ -83,10 +129,10 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
                 {
                     //create standard signature string
                     signatum.assign(managedMethod.ReturnType)
-                        .append(1, L' ').append(managedMethod.TypeName)
-                        .append(L"::", 2).append(managedMethod.MethodName)
-                        .append(1, L'(').append(managedMethod.ParameterTypes)
-                        .append(1, L')');
+                        .append(1, _X(' ')).append(managedMethod.TypeName)
+                        .append(_X("::"), 2).append(managedMethod.MethodName)
+                        .append(1, _X('(')).append(managedMethod.ParameterTypes)
+                        .append(1, _X(')'));
                     auto signature = ToSignature(signatum, module.GetTokenizer());
 
                     //inject method or references...
@@ -94,22 +140,49 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
                 }
                 catch (NewRelic::Profiler::Win32Exception&)
                 {
-                    //exception in an error if we are injecting methods, otherwise, just neat to know.
-                    //if is mscorlib, allow the loop to proceed.  if not, break out of the loop
-                    if (is_mscorlib)
+                    if (is_coreLib)
                     {
                         LogError(L"Failed to tokenize method signature: ", signatum, L". Proceeding to next method.");
                     }
-                    else 
+                    else
                     {
                         LogTrace(L"Failed to tokenize method signature: ", signatum, L". Skipping injection of other method references for this module.");
                     }
                 }
             }
+
+            //if (is_coreLib)
+            //{
+            //    auto managedMethod = ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X(".cctor"), _X("void"), _X(""));
+            //    try
+            //    {
+            //        //create standard signature string
+            //        signatum.assign(managedMethod.ReturnType)
+            //            .append(1, _X(' ')).append(managedMethod.TypeName)
+            //            .append(_X("::"), 2).append(managedMethod.MethodName)
+            //            .append(1, _X('(')).append(managedMethod.ParameterTypes)
+            //            .append(1, _X(')'));
+            //        auto signature = ToSignature(signatum, module.GetTokenizer());
+
+            //        //inject method or references...
+            //        module.InjectStaticSecuritySafeCtor(managedMethod.MethodName, managedMethod.TypeName, signature);
+            //    }
+            //    catch (NewRelic::Profiler::Win32Exception&)
+            //    {
+            //        if (is_coreLib)
+            //        {
+            //            LogError(L"Failed to tokenize method signature: ", signatum, L". Proceeding to next method.");
+            //        }
+            //        else
+            //        {
+            //            LogTrace(L"Failed to tokenize method signature: ", signatum, L". Skipping injection of other method references for this module.");
+            //        }
+            //    }
+            //}
         }
 
     private:
-        static ByteVector ToSignature(const std::wstring& signature, const sicily::codegen::ITokenizerPtr& tokenizer)
+        static ByteVector ToSignature(const xstring_t& signature, const sicily::codegen::ITokenizerPtr& tokenizer)
         {
             sicily::Scanner scanner(signature);
             sicily::Parser parser;
@@ -118,51 +191,14 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
             return generator.TypeToBytes(type);
         }
 
-        static bool EnsureReferenceToMscorlib(IModule& module)
+        static bool EnsureReferenceToCoreLib(IModule& module)
         {
-            // If this is the NetStandard assembly, it already has a reference to mscorlib, so no need to do anything
-            // Otherwise if this already has a reference to mscorlib, nothing to do.
-            if (module.GetIsThisTheNetStandardAssembly() || module.GetHasRefMscorlib())
+            if (!module.NeedsReferenceToCoreLib())
             {
                 return true;
             }
 
-            try
-            {
-                LogDebug(L"Attempting to Inject reference to mscorlib into netstandard Module  ", module.GetModuleName());
-
-                // if the assembly wasn't in the existing references try to define a new one
-                ASSEMBLYMETADATA amd;
-                ZeroMemory(&amd, sizeof(amd));
-                amd.usMajorVersion = 4;
-                amd.usMinorVersion = 0;
-                amd.usBuildNumber = 0;
-                amd.usRevisionNumber = 0;
-
-                auto metaDataAssemblyEmit = module.GetMetaDataAssemblyEmit();
-                mdAssemblyRef assemblyToken;
-                const BYTE pubToken[] = { 0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89 };
-
-                auto injectResult = metaDataAssemblyEmit->DefineAssemblyRef(pubToken, sizeof(pubToken), L"mscorlib", &amd, NULL, 0, 0, &assemblyToken);
-                if (injectResult == S_OK)
-                {
-                    module.SetMscorlibAssemblyRef(assemblyToken);
-                    LogDebug(L"Attempting to Inject reference to mscorlib into netstandard Module  ", module.GetModuleName(), L" - Success: ", assemblyToken);
-
-                    return true;
-                }
-                else
-                {
-                    LogDebug(L"Attempting to Inject reference to mscorlib into netstandard Module  ", module.GetModuleName(), L" - FAIL: ", injectResult);
-
-                    return false;
-                }
-            }
-            catch (NewRelic::Profiler::Win32Exception& ex)
-            {
-                LogError(L"Attempting to Inject reference to mscorlib into netstandard Module  ", module.GetModuleName(), L" - ERROR: ", ex._message);
-                return false;
-            }
+            return module.InjectReferenceToCoreLib();
         }
 
     };

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/MockModule.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/MockModule.h
@@ -1,0 +1,97 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "../ModuleInjector/IModule.h"
+#include "../Sicily/SicilyTest/RealisticTokenizer.h"
+
+namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace Test
+{
+    class MockModule : public ModuleInjector::IModule
+    {
+    public:
+        MockModule() :
+            _moduleName(_X("MyModule")),
+            _needsReferenceToCoreLib(false),
+            _injectReferenceToCoreLib(true),
+            _isThisTheCoreLibAssembly(false),
+            _tokenizer(std::make_shared<sicily::codegen::RealisticTokenizer>())
+        {
+        }
+
+        xstring_t _moduleName;
+        virtual xstring_t GetModuleName() override
+        {
+            return _moduleName;
+        }
+
+        std::function<void(const xstring_t&, const xstring_t&, const xstring_t&, const ByteVector&)> _injectPlatformInvoke;
+        virtual void InjectPlatformInvoke(const xstring_t& methodName, const xstring_t& className, const xstring_t& moduleName, const ByteVector& signature) override
+        {
+            if (_injectPlatformInvoke)
+            {
+                _injectPlatformInvoke(methodName, className, moduleName, signature);
+            }
+        }
+
+        std::function<void(const xstring_t&, const xstring_t&, const ByteVector&)> _injectStaticSecuritySafeMethod;
+        virtual void InjectStaticSecuritySafeMethod(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
+        {
+            if (_injectStaticSecuritySafeMethod)
+            {
+                _injectStaticSecuritySafeMethod(methodName, className, signature);
+            }
+        }
+
+        std::function<void(const xstring_t&, const xstring_t&, const ByteVector&)> _injectStaticSecuritySafeCtor;
+        virtual void InjectStaticSecuritySafeCtor(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
+        {
+            if (_injectStaticSecuritySafeCtor)
+            {
+                _injectStaticSecuritySafeCtor(methodName, className, signature);
+            }
+        }
+
+        std::function<void(const xstring_t&, const xstring_t&, const ByteVector&)> _injectCoreLibSecuritySafeMethodReference;
+        virtual void InjectCoreLibSecuritySafeMethodReference(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
+        {
+            if (_injectCoreLibSecuritySafeMethodReference)
+            {
+                _injectCoreLibSecuritySafeMethodReference(methodName, className, signature);
+            }
+        }
+
+        std::function<void(void)> _injectNRHelperType;
+        virtual void InjectNRHelperType() override
+        {
+            if (_injectNRHelperType)
+            {
+                _injectNRHelperType();
+            }
+        }
+
+        bool _injectReferenceToCoreLib;
+        virtual bool InjectReferenceToCoreLib() override
+        {
+            return _injectReferenceToCoreLib;
+        }
+
+        bool _needsReferenceToCoreLib;
+        virtual bool NeedsReferenceToCoreLib() override
+        {
+            return _needsReferenceToCoreLib;
+        }
+
+        bool _isThisTheCoreLibAssembly;
+        virtual bool GetIsThisTheCoreLibAssembly() override
+        {
+            return _isThisTheCoreLibAssembly;
+        }
+
+        sicily::codegen::ITokenizerPtr _tokenizer;
+        virtual sicily::codegen::ITokenizerPtr GetTokenizer() override
+        {
+            return _tokenizer;
+        }
+    };
+}}}}

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
@@ -1,0 +1,219 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <memory>
+#include <exception>
+#include <functional>
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#define LOGGER_DEFINE_STDLOG
+#include <set>
+#include <array>
+#include "CppUnitTest.h"
+
+#include "MockModule.h"
+#include "../ModuleInjector/ModuleInjector.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace Test
+{
+    TEST_CLASS(ModuleInjectorTest)
+    {
+    public:
+        TEST_METHOD(ModuleInjector_CoreClr_DoesNotCrash_CannotEnsureReferenceToCoreLib)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_needsReferenceToCoreLib = true;
+            modulePtr->_injectReferenceToCoreLib = false;
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_DoesNotCrash_CannotEnsureReferenceToCoreLib)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_needsReferenceToCoreLib = true;
+            modulePtr->_injectReferenceToCoreLib = false;
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, false);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_InjectsHelperType)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = true;
+            bool wasHelperTypeInjected(false);
+            modulePtr->_injectNRHelperType = [&wasHelperTypeInjected]() { wasHelperTypeInjected = true; };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, true);
+
+            Assert::IsTrue(wasHelperTypeInjected);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_InjectsHelperType)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = true;
+            bool wasHelperTypeInjected(false);
+            modulePtr->_injectNRHelperType = [&wasHelperTypeInjected]() { wasHelperTypeInjected = true; };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, false);
+
+            Assert::IsTrue(wasHelperTypeInjected);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_InjectsHelperMethods_DoesNotThrow)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = true;
+            modulePtr->_injectNRHelperType = []() { throw NewRelic::Profiler::Win32Exception(E_UNEXPECTED); };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_InjectsHelperMethods_DoesNotThrow)
+        {
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = true;
+            modulePtr->_injectNRHelperType = []() { throw NewRelic::Profiler::Win32Exception(E_UNEXPECTED); };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, false);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_InjectsHelperMethods)
+        {
+            AssertHelperMethodsWereInjected(true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_InjectsHelperMethods)
+        {
+            AssertHelperMethodsWereInjected(false);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_AlwaysAttemptsToInjectAllMethods)
+        {
+            AssertHelperMethodsWereInjected(/*isCoreClr*/ true, /*throwsException*/ true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_AlwaysAttemptsToInjectAllMethods)
+        {
+            AssertHelperMethodsWereInjected(/*isCoreClr*/ false, /*throwsException*/ true);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_InjectsHelperMethodReferences)
+        {
+            AssertHelperMethodReferencesWereInjected(true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_InjectsHelperMethodReferences)
+        {
+            AssertHelperMethodReferencesWereInjected(false);
+        }
+
+        TEST_METHOD(ModuleInjector_CoreClr_AlwaysAttemptsToInjectAllMethodReferences)
+        {
+            AssertHelperMethodReferencesWereInjected(/*isCoreClr*/ true, /*throwsException*/ true);
+        }
+
+        TEST_METHOD(ModuleInjector_NetFramework_AlwaysAttemptsToInjectAllMethodReferences)
+        {
+            AssertHelperMethodReferencesWereInjected(/*isCoreClr*/ false, /*throwsException*/ true);
+        }
+
+    private:
+        void AssertHelperMethodsWereInjected(const bool isCoreClr)
+        {
+            AssertHelperMethodsWereInjected(isCoreClr, false);
+        }
+
+        void AssertHelperMethodsWereInjected(const bool isCoreClr, const bool throwsException)
+        {
+            std::array<xstring_t, 13> expectedMethods = {
+                _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
+                _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
+                _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
+                _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorage"),
+                _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorageOrReflectionOrThrow"),
+                _X("System.CannotUnloadAppDomainException.GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
+                _X("System.CannotUnloadAppDomainException.StoreMethodInAppDomainStorageOrThrow"),
+                _X("System.CannotUnloadAppDomainException.EnsureInitialized"),
+                _X("System.CannotUnloadAppDomainException.InvokeAgentMethodInvokerFunc"),
+                _X("System.CannotUnloadAppDomainException.GetAgentMethodInvokerObject"),
+                _X("System.CannotUnloadAppDomainException.GetAgentShimFinishTracerDelegateFunc"),
+                _X("System.CannotUnloadAppDomainException.StoreAgentShimFinishTracerDelegateFunc"),
+                _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc")
+            };
+
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = true;
+            std::set<xstring_t> injectedMethodNamesWithType;
+            modulePtr->_injectStaticSecuritySafeMethod = [&injectedMethodNamesWithType, throwsException](const xstring_t& methodName, const xstring_t& className, const ByteVector& /*signature*/)
+            {
+                injectedMethodNamesWithType.emplace(className + _X(".") + methodName);
+                if (throwsException)
+                {
+                    throw NewRelic::Profiler::Win32Exception(E_UNEXPECTED);
+                }
+            };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, isCoreClr);
+
+            Assert::AreEqual(expectedMethods.size(), injectedMethodNamesWithType.size());
+
+            for (const auto& expected : expectedMethods)
+            {
+                auto search = injectedMethodNamesWithType.find(expected);
+                Assert::IsTrue(search != injectedMethodNamesWithType.end(), (expected + _X(" was not found")).c_str());
+            }
+        }
+
+        void AssertHelperMethodReferencesWereInjected(const bool isCoreClr)
+        {
+            AssertHelperMethodReferencesWereInjected(isCoreClr, false);
+        }
+
+        void AssertHelperMethodReferencesWereInjected(const bool isCoreClr, const bool throwsException)
+        {
+            const xstring_t expectedAssembly = isCoreClr ? _X("[System.Private.CoreLib]") : _X("[mscorlib]");
+            std::array<xstring_t, 13> expectedMethods = {
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorage"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorageOrReflectionOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreMethodInAppDomainStorageOrThrow"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.EnsureInitialized"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentMethodInvokerObject"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.InvokeAgentMethodInvokerFunc"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentShimFinishTracerDelegateFunc"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreAgentShimFinishTracerDelegateFunc"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc")
+            };
+
+            auto modulePtr = std::make_shared<MockModule>();
+            modulePtr->_isThisTheCoreLibAssembly = false;
+            std::set<xstring_t> injectedMethodNamesWithType;
+            modulePtr->_injectCoreLibSecuritySafeMethodReference = [&injectedMethodNamesWithType, throwsException](const xstring_t& methodName, const xstring_t& className, const ByteVector& /*signature*/)
+            {
+                injectedMethodNamesWithType.emplace(className + _X(".") + methodName);
+                if (throwsException)
+                {
+                    throw NewRelic::Profiler::Win32Exception(E_UNEXPECTED);
+                }
+            };
+
+            ModuleInjector::ModuleInjector::InjectIntoModule(*modulePtr, isCoreClr);
+
+            Assert::AreEqual(expectedMethods.size(), injectedMethodNamesWithType.size());
+
+            for (const auto& expected : expectedMethods)
+            {
+                auto search = injectedMethodNamesWithType.find(expected);
+                Assert::IsTrue(search != injectedMethodNamesWithType.end(), (expected + _X(" was not found")).c_str());
+            }
+        }
+    };
+}}}}

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.vcxproj
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{1534117B-A2B3-4403-B391-20DCC8AAEE44}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ModuleInjectorTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <BrowseInformation>true</BrowseInformation>
+      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <Bscmake>
+      <PreserveSbr>true</PreserveSbr>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="MockModule.h" />
+    <ClInclude Include="UnreferencedFunctions.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ModuleInjectorTest.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Sicily\Sicily.vcxproj">
+      <Project>{27654994-8403-4bd4-9d1d-4bccc4e93de6}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.vcxproj
@@ -30,14 +30,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -45,14 +45,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/UnreferencedFunctions.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/UnreferencedFunctions.h
@@ -1,0 +1,98 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <CppUnitTest.h>
+
+// fix unreferenced local functions warning in CppUnitTest.h
+static inline void UseUnreferenced()
+{
+    std::wstring (*boolFunc)(const bool&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)boolFunc;
+    std::wstring (*intFunc)(const int&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)intFunc;
+    std::wstring (*longFunc)(const long&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)longFunc;
+    std::wstring (*shortFunc)(const short&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)shortFunc;
+    std::wstring (*charFunc)(const char&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)charFunc;
+    std::wstring (*wchar_tFunc)(const wchar_t&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)wchar_tFunc;
+    std::wstring (*signedCharFunc)(const signed char&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)signedCharFunc;
+    std::wstring (*unsignedIntFunc)(const unsigned int&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedIntFunc;
+    std::wstring (*unsignedLongFunc)(const unsigned long&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongFunc;
+    std::wstring (*unsignedLongLongFunc)(const unsigned long long&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongLongFunc;
+    std::wstring (*unsignedCharFunc)(const unsigned char&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedCharFunc;
+    std::wstring (*stringFunc)(const std::string&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)stringFunc;
+    std::wstring (*wstringFunc)(const std::wstring&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)wstringFunc;
+    std::wstring (*doubleFunc)(const double&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)doubleFunc;
+    std::wstring (*floatFunc)(const float&) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)floatFunc;
+
+    std::wstring (*boolFuncConstPtr)(const bool*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)boolFuncConstPtr;
+    std::wstring (*intFuncConstPtr)(const int*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)intFuncConstPtr;
+    std::wstring (*longFuncConstPtr)(const long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)longFuncConstPtr;
+    std::wstring (*shortFuncConstPtr)(const short*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)shortFuncConstPtr;
+    std::wstring (*signedCharFuncConstPtr)(const signed char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)signedCharFuncConstPtr;
+    std::wstring (*unsignedIntFuncConstPtr)(const unsigned int*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedIntFuncConstPtr;
+    std::wstring (*unsignedLongFuncConstPtr)(const unsigned long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongFuncConstPtr;
+    std::wstring (*unsignedLongLongFuncConstPtr)(const unsigned long long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongLongFuncConstPtr;
+    std::wstring (*unsignedCharFuncConstPtr)(const unsigned char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedCharFuncConstPtr;
+    std::wstring (*charFuncConstPtr)(const char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)charFuncConstPtr;
+    std::wstring (*wchar_tFuncConstPtr)(const wchar_t*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)wchar_tFuncConstPtr;
+    std::wstring (*doubleFuncConstPtr)(const double*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)doubleFuncConstPtr;
+    std::wstring (*floatFuncConstPtr)(const float*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)floatFuncConstPtr;
+    std::wstring (*voidFuncConstPtr)(const void*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)voidFuncConstPtr;
+
+    std::wstring (*boolFuncPtr)(bool*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)boolFuncPtr;
+    std::wstring (*intFuncPtr)(int*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)intFuncPtr;
+    std::wstring (*longFuncPtr)(long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)longFuncPtr;
+    std::wstring (*shortFuncPtr)(short*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)shortFuncPtr;
+    std::wstring (*signedCharFuncPtr)(signed char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)signedCharFuncPtr;
+    std::wstring (*unsignedIntFuncPtr)(unsigned int*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedIntFuncPtr;
+    std::wstring (*unsignedLongFuncPtr)(unsigned long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongFuncPtr;
+    std::wstring (*unsignedLongLongFuncPtr)(unsigned long long*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedLongLongFuncPtr;
+    std::wstring (*unsignedCharFuncPtr)(unsigned char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)unsignedCharFuncPtr;
+    std::wstring (*charFuncPtr)(char*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)charFuncPtr;
+    std::wstring (*wchar_tFuncPtr)(wchar_t*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)wchar_tFuncPtr;
+    std::wstring (*doubleFuncPtr)(double*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)doubleFuncPtr;
+    std::wstring (*floatFuncPtr)(float*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)floatFuncPtr;
+    std::wstring (*voidFuncPtr)(void*) = &Microsoft::VisualStudio::CppUnitTestFramework::ToString;
+    (void)voidFuncPtr;
+}

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/stdafx.cpp
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/stdafx.cpp
@@ -1,0 +1,4 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stdafx.h"

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/stdafx.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/stdafx.h
@@ -1,0 +1,10 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Headers for CppUnitTest
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <CppUnitTest.h>
+#include "UnreferencedFunctions.h"

--- a/src/Agent/NewRelic/Profiler/NewRelic.Profiler.sln
+++ b/src/Agent/NewRelic/Profiler/NewRelic.Profiler.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProfiledMethods", "Profiled
 		{DD9D2763-2E4F-48AA-BDFD-E23ABB9822AB} = {DD9D2763-2E4F-48AA-BDFD-E23ABB9822AB}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ModuleInjectorTest", "ModuleInjectorTest\ModuleInjectorTest.vcxproj", "{1534117B-A2B3-4403-B391-20DCC8AAEE44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -209,6 +211,14 @@ Global
 		{BA254DEB-EA81-428A-8BA7-BA55B0395D7A}.Release|Win32.Build.0 = Release|x86
 		{BA254DEB-EA81-428A-8BA7-BA55B0395D7A}.Release|x64.ActiveCfg = Release|x64
 		{BA254DEB-EA81-428A-8BA7-BA55B0395D7A}.Release|x64.Build.0 = Release|x64
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Debug|Win32.ActiveCfg = Debug|Win32
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Debug|Win32.Build.0 = Debug|Win32
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Debug|x64.ActiveCfg = Debug|x64
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Debug|x64.Build.0 = Debug|x64
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Release|Win32.ActiveCfg = Release|Win32
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Release|Win32.Build.0 = Release|Win32
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Release|x64.ActiveCfg = Release|x64
+		{1534117B-A2B3-4403-B391-20DCC8AAEE44}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -71,6 +71,13 @@ namespace NewRelic { namespace Profiler {
 
     private:
         std::atomic<int> _referenceCount;
+        // Proxy engagement counter: total JIT compilation events seen by this callback.
+        // Logged every 5000 events alongside helper_invocations to confirm
+        // AppDomainFallbackCache injection code path is engaged. See Section 6 of the
+        // NR-184027 spike doc. A nonzero helper_invocations confirms helper IL injection
+        // fired during JIT; zero means injection has not yet occurred or MethodRewriter
+        // was refreshed after injection (see Instrumentors.h note on refresh-reset).
+        std::atomic<uint64_t> _totalJitCount{0};
 
 #ifndef PAL_STDCPP_COMPAT
         std::shared_ptr<ModuleInjector::ModuleInjector> _moduleInjector;
@@ -533,6 +540,11 @@ namespace NewRelic { namespace Profiler {
             } catch (...) {
                 LogError(L"An exception was thrown while getting details about a function.");
                 return E_FAIL;
+            }
+
+            auto jitCount = ++_totalJitCount;
+            if (jitCount % 5000 == 0) {
+                LogInfo(_X("AppDomainFallbackCache proxy engagement: helper_invocations="), methodRewriter->GetHelperFireCount(), _X(" total_jit_calls="), jitCount);
             }
 
             try {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
@@ -107,6 +107,13 @@ namespace NewRelic { namespace Profiler
             return methodDefinitionToken;
         }
 
+        virtual uint32_t GetFieldDefinitionToken(const uint32_t& typeDefinitionToken, const xstring_t& name) override
+        {
+            uint32_t fieldDefinitionToken;
+            ThrowOnError(metaDataImport->FindField, typeDefinitionToken, ToWindowsString(name), nullptr, 0, &fieldDefinitionToken);
+            return fieldDefinitionToken;
+        }
+
         virtual uint32_t GetMethodSpecToken(uint32_t methodDefOrRefOrSpecToken, const ByteVector& instantiationSignature) override
         {
             uint32_t methodSpecToken;

--- a/src/Agent/NewRelic/Profiler/Profiler/Module.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Module.h
@@ -3,28 +3,33 @@
 
 #pragma once
 #include <corprof.h>
-#include <CorHdr.h>
+#include <corhdr.h>
 #include "../Logging/Logger.h"
 #include "../Common/OnDestruction.h"
 #include "../ModuleInjector/IModule.h"
+#include "../SignatureParser/ByteVectorManipulator.h"
 #include "CorTokenizer.h"
 #include "Win32Helpers.h"
+
+#define SYSTEM_PRIVATE_CORELIB_ASSEMBLYNAME _X("System.Private.CoreLib")
+#define MSCORLIB_ASSEMBLYNAME _X("mscorlib")
 
 namespace NewRelic { namespace Profiler
 {
     class Module : public ModuleInjector::IModule
     {
     public:
-        Module(CComPtr<ICorProfilerInfo4> profilerInfo, const ModuleID& moduleId) :
+        Module(CComPtr<ICorProfilerInfo4> profilerInfo, const ModuleID& moduleId, bool isCoreClr = false) :
             _profilerInfo(profilerInfo),
-            _moduleId(moduleId)
+            _moduleId(moduleId),
+            _isCoreClr(isCoreClr)
         {
             // get the module's name
             ULONG moduleNameLength = 0;
             ThrowOnError(_profilerInfo->GetModuleInfo, _moduleId, nullptr, 0, &moduleNameLength, nullptr, nullptr);
-            std::unique_ptr<wchar_t[]> moduleNameChars(new wchar_t[moduleNameLength]);
+            std::unique_ptr<xchar_t[]> moduleNameChars(new xchar_t[moduleNameLength]);
             ThrowOnError(_profilerInfo->GetModuleInfo, _moduleId, nullptr, moduleNameLength, nullptr, moduleNameChars.get(), nullptr);
-            _moduleName = std::wstring(moduleNameChars.get());
+            _moduleName = xstring_t(moduleNameChars.get());
 
             // get the necessary metadata interfaces
             ThrowOnError(_profilerInfo->GetModuleMetaData, moduleId, CorOpenFlags::ofWrite, IID_IMetaDataEmit2, (IUnknown**)&_metaDataEmit);
@@ -35,38 +40,34 @@ namespace NewRelic { namespace Profiler
             if (_metaDataEmit == nullptr || _metaDataImport == nullptr || _metaDataAssemblyImport == nullptr)
             {
                 LogWarn(L"Failed to get metadata from the module, it is likely a resource module.  ModuleName: ", _moduleName);
-                throw NewRelic::Profiler::MessageException(L"Failed to get a metadata from the module.");
+                throw NewRelic::Profiler::MessageException(_X("Failed to get a metadata from the module."));
             }
 
             // in .NET 2, the name may be empty for dynamic modules so fallback to the scope properties for the name
             if (_moduleName.empty())
             {
                 ThrowOnError(_metaDataImport->GetScopeProps, nullptr, 0, &moduleNameLength, nullptr);
-                moduleNameChars = std::unique_ptr<wchar_t[]>(new wchar_t[moduleNameLength]);
+                moduleNameChars = std::unique_ptr<xchar_t[]>(new xchar_t[moduleNameLength]);
                 ThrowOnError(_metaDataImport->GetScopeProps, moduleNameChars.get(), moduleNameLength, nullptr, nullptr);
-                _moduleName = std::wstring(moduleNameChars.get());
+                _moduleName = xstring_t(moduleNameChars.get());
             }
 
             CheckIfThisIsAFrameworkAssembly();
             IdentifyFrameworkAssemblyReferences();
 
-            _tokenizer.reset(new CorTokenizer(_metaDataAssemblyEmit, _metaDataEmit, _metaDataImport, _metaDataAssemblyImport));
+            _tokenizer = CreateCorTokenizer(_metaDataAssemblyEmit, _metaDataEmit, _metaDataImport, _metaDataAssemblyImport, _isCoreClr);
         }
 
-        virtual std::wstring GetModuleName() override { return _moduleName; }
+        virtual xstring_t GetModuleName() override { return _moduleName; }
 
-        virtual bool GetHasRefMscorlib() override { return _hasRefMscorlib; }
-        virtual bool GetHasRefSysRuntime() override { return _hasRefSysRuntime; }
-        virtual bool GetHasRefNetStandard() override { return _hasRefNetStandard; }
+        virtual bool NeedsReferenceToCoreLib() override
+        {
+            return !(_isMscorlib || _isNetStandard || _isSystemPrivateCoreLib || _hasCoreLibReference);
+        }
 
-        virtual void SetMscorlibAssemblyRef(mdAssembly assemblyRefToken) override { _mscorlibAssemblyRefToken = assemblyRefToken; }
+        virtual bool GetIsThisTheCoreLibAssembly() override { return _isCoreLibAssembly; }
 
-        virtual bool GetIsThisTheMscorlibAssembly() override { return _isMscorlib; }
-        virtual bool GetIsThisTheNetStandardAssembly() override { return _isNetStandard; }
-
-        virtual CComPtr<IMetaDataAssemblyEmit> GetMetaDataAssemblyEmit() override{ return _metaDataAssemblyEmit; }
-
-        virtual void InjectPlatformInvoke(const std::wstring& methodName, const std::wstring& className, const std::wstring& moduleName, const ByteVector& signature) override
+        virtual void InjectPlatformInvoke(const xstring_t& methodName, const xstring_t& className, const xstring_t& moduleName, const ByteVector& signature) override
         {
             auto interfaceAttributes = CorMethodAttr::mdStatic | CorMethodAttr::mdPublic | CorMethodAttr::mdPinvokeImpl;
             auto implementationAttributes = CorMethodImpl::miPreserveSig;
@@ -79,7 +80,7 @@ namespace NewRelic { namespace Profiler
             SetMethodAsPlatformInvoke(injectedMethodToken, mappingFlags, methodName, profilerDllToken);
         }
 
-        virtual void InjectStaticSecuritySafeMethod(const std::wstring& methodName, const std::wstring& className, const ByteVector& signature) override
+        virtual void InjectStaticSecuritySafeMethod(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
         {
             auto interfaceAttributes = CorMethodAttr::mdStatic | CorMethodAttr::mdPublic | CorMethodAttr::mdHideBySig;
             auto implementationAttributes = CorMethodImpl::miIL | CorMethodImpl::miNoInlining;
@@ -87,23 +88,103 @@ namespace NewRelic { namespace Profiler
             BYTEVECTOR(constructorSignature, CorCallingConvention::IMAGE_CEE_CS_CALLCONV_HASTHIS, 0, CorElementType::ELEMENT_TYPE_VOID);
 
             auto injectionTargetClassToken = GetTypeToken(className);
-            auto constructorCodeAddress = GetMethodCodeAddress(injectionTargetClassToken, L".ctor", constructorSignature);
+            auto constructorCodeAddress = GetMethodCodeAddress(injectionTargetClassToken, _X(".ctor"), constructorSignature);
             auto securitySafeCriticalConstructorToken = GetSecuritySafeCriticalConstructorToken();
             auto suppressUnmanagedCodeSecurityAttributeToken = GetSuppressUnmanagedCodeSecurityAttributeToken();
-            
+
             auto injectedMethodToken = AddMethodDefinition(methodName, injectionTargetClassToken, signature, interfaceAttributes, implementationAttributes, constructorCodeAddress);
             AddAttributeToMethod(injectedMethodToken, securitySafeCriticalConstructorToken);
             AddAttributeToMethod(injectedMethodToken, suppressUnmanagedCodeSecurityAttributeToken);
             AddPermissionSetAssertToMethod(injectedMethodToken, permissionBlob);
         }
 
-        virtual void InjectMscorlibSecuritySafeMethodReference(const std::wstring& methodName, const std::wstring& className, const ByteVector& signature) override
+        virtual void InjectStaticSecuritySafeCtor(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
         {
-            auto typeReferenceOrDefinitionToken = GetOrCreateTypeReferenceToken(_mscorlibAssemblyRefToken, className);
+            auto interfaceAttributes = CorMethodAttr::mdStatic | CorMethodAttr::mdPrivate | CorMethodAttr::mdHideBySig | CorMethodAttr::mdSpecialName | CorMethodAttr::mdRTSpecialName;
+            auto implementationAttributes = CorMethodImpl::miIL | CorMethodImpl::miNoInlining;
+            auto permissionBlob = GetPermissionBlob();
+            BYTEVECTOR(constructorSignature, CorCallingConvention::IMAGE_CEE_CS_CALLCONV_HASTHIS, 0, CorElementType::ELEMENT_TYPE_VOID);
+
+            auto injectionTargetClassToken = GetTypeToken(className);
+            auto constructorCodeAddress = GetMethodCodeAddress(injectionTargetClassToken, _X(".ctor"), constructorSignature);
+            auto securitySafeCriticalConstructorToken = GetSecuritySafeCriticalConstructorToken();
+            auto suppressUnmanagedCodeSecurityAttributeToken = GetSuppressUnmanagedCodeSecurityAttributeToken();
+
+            auto injectedMethodToken = AddMethodDefinition(methodName, injectionTargetClassToken, signature, interfaceAttributes, implementationAttributes, constructorCodeAddress);
+            AddAttributeToMethod(injectedMethodToken, securitySafeCriticalConstructorToken);
+            AddAttributeToMethod(injectedMethodToken, suppressUnmanagedCodeSecurityAttributeToken);
+            AddPermissionSetAssertToMethod(injectedMethodToken, permissionBlob);
+        }
+
+        virtual void InjectNRHelperType() override
+        {
+            auto objectTypeToken = GetTypeToken(_X("System.Object"));
+            mdTypeDef nrHelperType;
+            ThrowOnError(_metaDataEmit->DefineTypeDef, _X("__NRInitializer__"), CorTypeAttr::tdAbstract | CorTypeAttr::tdSealed, objectTypeToken, NULL, &nrHelperType);
+
+            //auto isVolatileTypeToken = GetTypeToken(_X("System.Runtime.CompilerServices.IsVolatile"));
+            //auto isVolatileSignature = Profiler::SignatureParser::CompressToken(isVolatileTypeToken);
+            auto dataFieldAttributes = CorFieldAttr::fdPublic | CorFieldAttr::fdStatic;
+            BYTEVECTOR(dataFieldSignature, CorCallingConvention::IMAGE_CEE_CS_CALLCONV_FIELD, CorElementType::ELEMENT_TYPE_OBJECT /*, CorElementType::ELEMENT_TYPE_CMOD_REQD*/);
+            //dataFieldSignature.insert(dataFieldSignature.end(), isVolatileSignature->begin(), isVolatileSignature->end());
+
+            mdFieldDef dataFieldToken;
+            ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentMethodFunc"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
+            ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentShimFunc"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
+            ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentShimMethodInfo"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
+
+            //BYTEVECTOR(intFieldSignature, CorCallingConvention::IMAGE_CEE_CS_CALLCONV_FIELD, CorElementType::ELEMENT_TYPE_I4);
+            //ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_isInitialized"), dataFieldAttributes, intFieldSignature.data(), (uint32_t)intFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
+        }
+
+        virtual void InjectCoreLibSecuritySafeMethodReference(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
+        {
+            auto typeReferenceOrDefinitionToken = GetOrCreateTypeReferenceToken(_coreLibAssemblyRefToken, className);
             GetOrCreateMemberReferenceToken(typeReferenceOrDefinitionToken, methodName, signature);
         }
 
-        virtual sicily::codegen::ITokenizerPtr GetTokenizer()
+        virtual bool InjectReferenceToCoreLib() override
+        {
+            const auto coreLibName = _isCoreClr ? SYSTEM_PRIVATE_CORELIB_ASSEMBLYNAME : MSCORLIB_ASSEMBLYNAME;
+            constexpr const BYTE pubTokenCoreClr[] = { 0x7C, 0xEC, 0x85, 0xD7, 0xBE, 0xA7, 0x79, 0x8E };
+            constexpr const BYTE pubTokenNetFramework[] = { 0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89 };
+
+            try
+            {
+                LogDebug(L"Attempting to Inject reference to ", coreLibName, L" into Module  ", GetModuleName());
+
+                // if the assembly wasn't in the existing references try to define a new one
+                ASSEMBLYMETADATA amd;
+                ZeroMemory(&amd, sizeof(amd));
+                amd.usMajorVersion = _isCoreClr ? 6 : 4;
+                amd.usMinorVersion = 0;
+                amd.usBuildNumber = 0;
+                amd.usRevisionNumber = 0;
+
+                auto pubToken = _isCoreClr ? pubTokenCoreClr : pubTokenNetFramework;
+
+                auto injectResult = _metaDataAssemblyEmit->DefineAssemblyRef(pubToken, sizeof(pubToken), coreLibName, &amd, NULL, 0, 0, &_coreLibAssemblyRefToken);
+                if (injectResult == S_OK)
+                {
+                    LogDebug(L"Attempting to Inject reference to ", coreLibName, L" into Module  ", GetModuleName(), L" - Success: ", _coreLibAssemblyRefToken);
+
+                    return true;
+                }
+                else
+                {
+                    LogDebug(L"Attempting to Inject reference to ", coreLibName, L" into Module  ", GetModuleName(), L" - FAIL: ", injectResult);
+
+                    return false;
+                }
+            }
+            catch (NewRelic::Profiler::Win32Exception& ex)
+            {
+                LogError(L"Attempting to Inject reference to ", coreLibName, L" into Module  ", GetModuleName(), L" - ERROR: ", ex._message);
+                return false;
+            }
+        }
+
+        virtual sicily::codegen::ITokenizerPtr GetTokenizer() override
         {
             return _tokenizer;
         }
@@ -116,67 +197,68 @@ namespace NewRelic { namespace Profiler
         CComPtr<IMetaDataAssemblyEmit> _metaDataAssemblyEmit;
         sicily::codegen::ITokenizerPtr _tokenizer;
         ModuleID _moduleId;
-        std::wstring _moduleName;
-        mdAssemblyRef _mscorlibAssemblyRefToken;
-        bool _hasRefMscorlib;
-        bool _hasRefSysRuntime;
-        bool _hasRefNetStandard;
+        xstring_t _moduleName;
+        mdAssemblyRef _coreLibAssemblyRefToken;
+        const bool _isCoreClr;
+        bool _hasCoreLibReference;
 
         bool _isMscorlib;
         bool _isNetStandard;
+        bool _isSystemPrivateCoreLib;
+        bool _isCoreLibAssembly;
 
         mdMethodDef GetSecuritySafeCriticalConstructorToken()
         {
-            return GetMethodTokenForDefaultConstructor(L"System.Security.SecuritySafeCriticalAttribute");
+            return GetMethodTokenForDefaultConstructor(_X("System.Security.SecuritySafeCriticalAttribute"));
         }
 
         mdMethodDef GetSuppressUnmanagedCodeSecurityAttributeToken()
         {
-            return GetMethodTokenForDefaultConstructor(L"System.Security.SuppressUnmanagedCodeSecurityAttribute");
+            return GetMethodTokenForDefaultConstructor(_X("System.Security.SuppressUnmanagedCodeSecurityAttribute"));
         }
 
-        mdMethodDef GetMethodTokenForDefaultConstructor(const std::wstring& className)
+        mdMethodDef GetMethodTokenForDefaultConstructor(const xstring_t& className)
         {
             BYTEVECTOR(constructorSignature, CorCallingConvention::IMAGE_CEE_CS_CALLCONV_HASTHIS, 0, CorElementType::ELEMENT_TYPE_VOID);
 
             auto typeToken = GetTypeToken(className);
-            return GetMethodToken(typeToken, L".ctor", constructorSignature);
+            return GetMethodToken(typeToken, _X(".ctor"), constructorSignature);
         }
 
-        mdTypeDef GetTypeToken(const std::wstring& typeName)
+        mdTypeDef GetTypeToken(const xstring_t& typeName)
         {
             mdTypeDef typeToken;
             ThrowOnError(_metaDataImport->FindTypeDefByName, typeName.c_str(), mdTypeDefNil, &typeToken);
             return typeToken;
         }
 
-        mdModuleRef AddModuleReference(const std::wstring& moduleName)
+        mdModuleRef AddModuleReference(const xstring_t& moduleName)
         {
             mdModuleRef moduleToken;
             ThrowOnError(_metaDataEmit->DefineModuleRef, moduleName.c_str(), &moduleToken);
             return moduleToken;
         }
 
-        mdMethodDef AddMethodDefinition(const std::wstring& methodName, const mdTypeDef& typeToken, const ByteVector& signature, const uint32_t& interfaceAttributes, const uint32_t& implementationAttributes, const uint32_t& methodCodeAddress)
+        mdMethodDef AddMethodDefinition(const xstring_t& methodName, const mdTypeDef& typeToken, const ByteVector& signature, const uint32_t& interfaceAttributes, const uint32_t& implementationAttributes, const uint32_t& methodCodeAddress)
         {
             mdMethodDef methodToken;
             ThrowOnError(_metaDataEmit->DefineMethod, typeToken, methodName.c_str(), interfaceAttributes, signature.data(), (uint32_t)signature.size(), methodCodeAddress, implementationAttributes, &methodToken);
             return methodToken;
         }
 
-        void SetMethodAsPlatformInvoke(const mdMethodDef& methodToken, const uint32_t& mappingFlags, const std::wstring& methodName, const mdModuleRef& nativeModuleToken)
+        void SetMethodAsPlatformInvoke(const mdMethodDef& methodToken, const uint32_t& mappingFlags, const xstring_t& methodName, const mdModuleRef& nativeModuleToken)
         {
             ThrowOnError(_metaDataEmit->DefinePinvokeMap, methodToken, mappingFlags, methodName.c_str(), nativeModuleToken);
         }
 
-        mdMethodDef GetMethodToken(const mdTypeDef& classToken, const std::wstring methodName, const ByteVector& signature)
+        mdMethodDef GetMethodToken(const mdTypeDef& classToken, const xstring_t& methodName, const ByteVector& signature)
         {
             mdMethodDef methodToken;
             ThrowOnError(_metaDataImport->FindMethod, classToken, methodName.c_str(), signature.data(), (uint32_t)signature.size(), &methodToken);
             return methodToken;
         }
 
-        ULONG GetMethodCodeAddress(const mdTypeDef& classToken, const std::wstring methodName, const ByteVector& signature)
+        ULONG GetMethodCodeAddress(const mdTypeDef& classToken, const xstring_t& methodName, const ByteVector& signature)
         {
             ULONG codeAddress;
             auto methodToken = GetMethodToken(classToken, methodName, signature);
@@ -198,20 +280,20 @@ namespace NewRelic { namespace Profiler
             ThrowOnError(_metaDataEmit->DefinePermissionSet, methodToken, CorDeclSecurity::dclAssert, permissionBlob.data(), (uint32_t)permissionBlob.size(), &permissionToken);
         }
 
-        std::wstring GetAssemblyName(const mdAssemblyRef& assemblyReferenceToken)
+        xstring_t GetAssemblyName(const mdAssemblyRef& assemblyReferenceToken)
         {
             ULONG assemblyNameLength = 0;
             ThrowOnError(_metaDataAssemblyImport->GetAssemblyRefProps, assemblyReferenceToken, nullptr, nullptr, nullptr, 0, &assemblyNameLength, nullptr, nullptr, nullptr, nullptr);
-            std::unique_ptr<wchar_t[]> assemblyName(new wchar_t[assemblyNameLength]);
+            std::unique_ptr<xchar_t[]> assemblyName(new xchar_t[assemblyNameLength]);
             ThrowOnError(_metaDataAssemblyImport->GetAssemblyRefProps, assemblyReferenceToken, nullptr, nullptr, assemblyName.get(), assemblyNameLength, nullptr, nullptr, nullptr, nullptr, nullptr);
             return assemblyName.get();
         }
 
         void IdentifyFrameworkAssemblyReferences()
         {
-            _hasRefMscorlib = false;
-            _hasRefNetStandard = false;
-            _hasRefSysRuntime = false;
+            _hasCoreLibReference = false;
+
+            const auto assemblyNameToFind = _isCoreClr ? SYSTEM_PRIVATE_CORELIB_ASSEMBLYNAME : MSCORLIB_ASSEMBLYNAME;
 
             HCORENUM enumerator = nullptr;
             mdAssemblyRef assemblyToken;
@@ -221,29 +303,23 @@ namespace NewRelic { namespace Profiler
             {
                 auto foundAssemblyName = GetAssemblyName(assemblyToken);
 
-                if (Strings::EndsWith(foundAssemblyName, L"mscorlib"))
+                if (Strings::EndsWith(foundAssemblyName, assemblyNameToFind))
                 {
-                    _hasRefMscorlib = true;
-                    _mscorlibAssemblyRefToken = assemblyToken;
-                }
-                else if (Strings::EndsWith(foundAssemblyName, L"netstandard"s))
-                {
-                    _hasRefNetStandard = true;
-                }
-                else if (Strings::EndsWith(foundAssemblyName, L"System.Runtime"s))
-                {
-                    _hasRefSysRuntime = true;
+                    _hasCoreLibReference = true;
+                    _coreLibAssemblyRefToken = assemblyToken;
                 }
             }
         }
 
         void CheckIfThisIsAFrameworkAssembly()
         {
-            _isMscorlib = Strings::EndsWith(GetModuleName(), L"mscorlib.dll");
-            _isNetStandard = Strings::EndsWith(GetModuleName(), L"netstandard.dll");
+            _isMscorlib = Strings::EndsWith(GetModuleName(), _X("mscorlib.dll"));
+            _isNetStandard = Strings::EndsWith(GetModuleName(), _X("netstandard.dll"));
+            _isSystemPrivateCoreLib = Strings::EndsWith(GetModuleName(), _X("System.Private.CoreLib.dll"));
+            _isCoreLibAssembly = _isCoreClr ? _isSystemPrivateCoreLib : _isMscorlib;
         }
 
-        mdAssemblyRef GetAssemblyReference(const std::wstring& assemblyName)
+        mdAssemblyRef GetAssemblyReference(const xstring_t& assemblyName)
         {
             HCORENUM enumerator = nullptr;
             mdAssemblyRef assemblyToken;
@@ -260,14 +336,14 @@ namespace NewRelic { namespace Profiler
 
             auto moduleName = GetModuleName();
             // When we run across RefEmit_InMemoryManifestModule we need to bail out but we don't want to log errors along the way.
-            if (moduleName == L"RefEmit_InMemoryManifestModule")
+            if (moduleName == _X("RefEmit_InMemoryManifestModule"))
                 throw NewRelic::Profiler::NonCriticalException();
 
             LogError(L"Unable to locate ", assemblyName, " reference in module ", moduleName, ".");
-            throw NewRelic::Profiler::MessageException(L"Unable to locate assembly reference in module.");
+            throw NewRelic::Profiler::MessageException(_X("Unable to locate assembly reference in module."));
         }
 
-        mdToken GetOrCreateTypeReferenceToken(const mdAssemblyRef& assemblyReferenceToken, const std::wstring& className)
+        mdToken GetOrCreateTypeReferenceToken(const mdAssemblyRef& assemblyReferenceToken, const xstring_t& className)
         {
             if (assemblyReferenceToken == mdAssemblyRefNil)
             {
@@ -283,7 +359,7 @@ namespace NewRelic { namespace Profiler
             }
         }
 
-        mdMemberRef GetOrCreateMemberReferenceToken(const mdToken& typeReferenceOrDefinitionToken, const std::wstring& memberName, const ByteVector& signature)
+        mdMemberRef GetOrCreateMemberReferenceToken(const mdToken& typeReferenceOrDefinitionToken, const xstring_t& memberName, const ByteVector& signature)
         {
             mdMemberRef memberReferenceToken;
             ThrowOnError(_metaDataEmit->DefineMemberRef, typeReferenceOrDefinitionToken, memberName.c_str(), signature.data(), (uint32_t)signature.size(), &memberReferenceToken);

--- a/src/Agent/NewRelic/Profiler/Sicily/Parser.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/Parser.cpp
@@ -58,6 +58,7 @@ namespace sicily {
         ast::TypeListPtr genericTypes = nullptr;
         ast::TypePtr returnType = nullptr;
         ast::ClassTypePtr targetType = nullptr;
+        ast::TypePtr requiredModifierType = nullptr;
         SemInfo sem;
         xstring_t name;
 
@@ -68,6 +69,12 @@ namespace sicily {
                 throw UnexpectedEndTokenException();
             }
             return returnType;
+        }
+
+        if (scanner.Maybe(TOK_MODREQ)) {
+            scanner.Expect(TOK_LBRACKET);
+            requiredModifierType = ParseTypeSignature(scanner, true);
+            scanner.Expect(TOK_RBRACKET);
         }
 
         auto tempTargetType = ParseTypeSignature(scanner, true);
@@ -91,6 +98,10 @@ namespace sicily {
         if (scanner.Maybe(TOK_LT)) {
             genericTypes = ParseTypeList(scanner);
             scanner.Expect(TOK_GT);
+        }
+
+        if (scanner.Peek(sem) == TOK_END) {
+            return std::make_shared<ast::FieldType>(ast::FieldType(targetType, name, returnType, requiredModifierType));
         }
 
         scanner.Expect(TOK_LBRACKET);
@@ -124,6 +135,9 @@ namespace sicily {
                 break;
             case TOK_UINT32:
                 result = std::make_shared<ast::PrimitiveType>(ast::PrimitiveType::PrimitiveKind::kU4);
+                break;
+            case TOK_INT32:
+                result = std::make_shared<ast::PrimitiveType>(ast::PrimitiveType::PrimitiveKind::kI4);
                 break;
             case TOK_STRING:
                 result = std::make_shared<ast::PrimitiveType>(ast::PrimitiveType::PrimitiveKind::kSTRING);

--- a/src/Agent/NewRelic/Profiler/Sicily/Scanner.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/Scanner.cpp
@@ -232,6 +232,12 @@ namespace sicily {
         else if (sem.id_ == _X("uint32")) {
             return TOK_UINT32;
         }
+        else if (sem.id_ == _X("int32")) {
+            return TOK_INT32;
+        }
+        else if (sem.id_ == _X("modreq")) {
+            return TOK_MODREQ;
+        }
         else {
             return TOK_ID;
         }

--- a/src/Agent/NewRelic/Profiler/Sicily/Scanner.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/Scanner.h
@@ -36,6 +36,8 @@ namespace sicily {
         TOK_VOID,
         TOK_BOOL,
         TOK_UINT32,
+        TOK_INT32,
+        TOK_MODREQ,
     };
 
     struct SemInfo {

--- a/src/Agent/NewRelic/Profiler/Sicily/Sicily.vcxproj
+++ b/src/Agent/NewRelic/Profiler/Sicily/Sicily.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="ast\PrimitiveType.cpp" />
     <ClCompile Include="ast\Type.cpp" />
     <ClCompile Include="ast\TypeList.cpp" />
+    <ClCompile Include="ast\FieldType.cpp" />
     <ClCompile Include="Parser.cpp" />
     <ClCompile Include="Scanner.cpp" />
   </ItemGroup>
@@ -165,6 +166,7 @@
     <ClInclude Include="ast\PrimitiveType.h" />
     <ClInclude Include="ast\Type.h" />
     <ClInclude Include="ast\TypeList.h" />
+    <ClInclude Include="ast\FieldType.h" />
     <ClInclude Include="ast\Types.h" />
     <ClInclude Include="codegen\ByteCodeGenerator.h" />
     <ClInclude Include="codegen\ITokenizer.h" />

--- a/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/ByteCodeGeneratorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/ByteCodeGeneratorTest.cpp
@@ -166,6 +166,37 @@ namespace sicily
                     Assert::AreEqual(expectedBytes, actualBytes);
                 }
 
+                TEST_METHOD(TestFieldTypeToBytes)
+                {
+                    ast::ClassTypePtr targetType(new ast::ClassType(L"MyClass", L"MyAssembly"));
+                    ast::PrimitiveTypePtr returnType(new ast::PrimitiveType(PrimitiveType::PrimitiveKind::kI4));
+                    ast::TypePtr type(new ast::FieldType(targetType, L"MyField", returnType, nullptr));
+
+                    auto actualBytes = CreateBadFoodByteCodeGenerator().TypeToBytes(type);
+                    // RetType
+                    // 0x08
+                    BYTEVECTOR(expectedBytes, 0x08);
+                    Assert::AreEqual(expectedBytes, actualBytes);
+                }
+
+                TEST_METHOD(TestVolatileFieldTypeToBytes)
+                {
+                    ast::ClassTypePtr targetType(new ast::ClassType(L"MyClass", L"MyAssembly"));
+                    ast::PrimitiveTypePtr returnType(new ast::PrimitiveType(PrimitiveType::PrimitiveKind::kOBJECT));
+                    ast::ClassTypePtr requiredModifierType(new ast::ClassType(L"System.Runtime.CompilerServices.IsVolatile", L"", true));
+                    ast::TypePtr type(new ast::FieldType(targetType, L"MyField", returnType, requiredModifierType));
+
+                    auto actualBytes = CreateBadFoodByteCodeGenerator().TypeToBytes(type);
+                    // RetType
+                    // 0x1c
+                    // modreq
+                    // 0x1f
+                    // modreq type
+                    // 0x00 (NullTokenizer resolves all type tokens to 0x00)
+                    BYTEVECTOR(expectedBytes, 0x1c, 0x1f, 0x00);
+                    Assert::AreEqual(expectedBytes, actualBytes);
+                }
+
                 TEST_METHOD(TestGenericMethodInstantiationToSignature)
                 {
                     ast::ClassTypePtr targetType(new ast::ClassType(L"MyClass", L"MyAssembly"));

--- a/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/BytecodeFromStringTest.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/BytecodeFromStringTest.cpp
@@ -63,6 +63,21 @@ namespace sicily
                     Assert::AreEqual(expectedSignature, methodSignature);
                 }
 
+                TEST_METHOD(TestField)
+                {
+                    // turn a CIL field into a token
+                    std::wstring fieldString(L"int32 MyNamespace.MyClass::MyField");
+                    codegen::RealisticTokenizerPtr tokenizer(new codegen::RealisticTokenizer());
+                    auto memberToken = GetMethodToken(fieldString, tokenizer);
+
+                    // use the token to lookup the parts in the tokenizer
+                    auto fieldDef = tokenizer->GetFieldDef(memberToken);
+                    auto fieldName = std::get<1>(fieldDef);
+
+                    // make sure the stuff in the tokenizer lines up with what we expect from the field string
+                    Assert::AreEqual(std::wstring(L"MyField"), fieldName);
+                }
+
                 TEST_METHOD(TestComplexMethod1)
                 {
                     std::wstring methodString(L"class [mscorlib]System.Tuple`2<!!0,!!1> [mscorlib]System.Tuple::Create<class [mscorlib]System.Action`1<object[]>,class [mscorlib]System.Action`1<object[]>>(!!0, !!1)");

--- a/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/NullTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/NullTokenizer.h
@@ -19,6 +19,7 @@ namespace sicily
             virtual uint32_t GetTypeSpecToken(const ByteVector& /*instantiationSignature*/) override final { return 0; }
             virtual uint32_t GetMemberRefOrDefToken(uint32_t /*parent*/, const std::wstring& /*methodName*/, const ByteVector& /*signature*/) override final { return 0; }
             virtual uint32_t GetMethodDefinitionToken(const uint32_t& /*typeDefinitionToken*/, const std::wstring& /*name*/, const ByteVector& /*signature*/) { return 0; }
+            virtual uint32_t GetFieldDefinitionToken(const uint32_t& /*typeDefinitionToken*/, const std::wstring& /*name*/) { return 0; }
             virtual uint32_t GetMethodSpecToken(uint32_t /*methodDefOrRefOrSpecToken*/, const ByteVector& /*instantiationSignature*/) override final { return 0; }
             virtual uint32_t GetStringToken(const std::wstring& /*string*/) override final { return 0; }
             virtual ~NullTokenizer() {}

--- a/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/ParserTest.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/ParserTest.cpp
@@ -185,6 +185,16 @@ namespace sicily
             {
                 TestParser(L"instance !0 class [mscorlib]System.Tuple`2<class [mscorlib]System.Action`1<object[]>, class [mscorlib]System.Action`1<object[]>>::get_Item1()");
             }
+
+            TEST_METHOD(TestField)
+            {
+                TestParser(L"int32 __NRInitializer__::_isAgentAssemblyLoaded");
+            }
+
+            TEST_METHOD(TestVolatileField)
+            {
+                TestParser(L"object modreq(System.Runtime.CompilerServices.IsVolatile) __NRInitializer__::_myField");
+            }
         };
     }
 }

--- a/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/RealisticTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/SicilyTest/RealisticTokenizer.h
@@ -72,6 +72,12 @@ namespace sicily
                 return GetToken(methodDef, methodDefs, 0x06);
             }
 
+            virtual uint32_t GetFieldDefinitionToken(const uint32_t& typeDefinitionToken, const std::wstring& name) override
+            {
+                FieldDefType fieldDef(typeDefinitionToken, name);
+                return GetToken(fieldDef, fieldDefs, 0x05);
+            }
+
             virtual uint32_t GetMethodSpecToken(uint32_t methodDefOrRefOrSpecToken, const ByteVector& instantiationSignature) override
             {
                 MethodSpecType methodSpec(methodDefOrRefOrSpecToken, instantiationSignature);
@@ -100,6 +106,9 @@ namespace sicily
             // vector of (<typeDef token> & <method name> & <method signature>), element position is its MethodDef token
             typedef std::tuple<uint32_t, std::wstring, ByteVector> MethodDefType;
             std::vector<MethodDefType> methodDefs;
+            //vector of (<typeDef token> & <field name>), element postion is its FieldDef token
+            typedef std::tuple<uint32_t, std::wstring> FieldDefType;
+            std::vector<FieldDefType> fieldDefs;
             // vector of (<MethodRef token> & <method instantiation signature>), element position is its MethodSpec token
             typedef std::tuple<uint32_t, ByteVector> MethodSpecType;
             std::vector<MethodSpecType> methodSpecs;
@@ -139,6 +148,11 @@ namespace sicily
             virtual MemberRefType GetMemberRef(uint32_t memberRefToken)
             {
                 return GetType(memberRefToken, memberRefs, 0x0a, L"MemberRef");
+            }
+
+            virtual FieldDefType GetFieldDef(uint32_t fieldDefToken)
+            {
+                return GetType(fieldDefToken, fieldDefs, 0x05, L"FieldDef");
             }
 
         private:

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/FieldType.cpp
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/FieldType.cpp
@@ -1,0 +1,71 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sstream>
+#include <cassert>
+
+#include "FieldType.h"
+#include "TypeList.h"
+
+namespace sicily {
+    namespace ast {
+        FieldType::FieldType(
+            ClassTypePtr targetType,
+            const xstring_t& fieldName,
+            TypePtr returnType,
+            TypePtr requiredModifierType
+        )
+            : Type(Type::Kind::kFIELD),
+            targetType_(targetType), fieldName_(fieldName),
+            returnType_(returnType), requiredModifierType_(requiredModifierType)
+        {
+            assert(targetType != nullptr);
+            assert(!fieldName.empty());
+            assert(returnType != nullptr);
+        }
+
+        FieldType::~FieldType()
+        {
+        }
+
+        ClassTypePtr
+            FieldType::GetTargetType() const
+        {
+            return targetType_;
+        }
+
+        xstring_t
+            FieldType::GetFieldName() const
+        {
+            return fieldName_;
+        }
+
+        TypePtr
+            FieldType::GetReturnType() const
+        {
+            return returnType_;
+        }
+
+        TypePtr
+            FieldType::GetRequiredModifierType() const
+        {
+            return requiredModifierType_;
+        }
+
+        xstring_t
+            FieldType::ToString() const
+        {
+            auto buf = xstring_t();
+
+            buf += GetReturnType()->ToString() + _X(" ");
+            if (requiredModifierType_ != nullptr)
+            {
+                buf += _X("modreq(") + GetRequiredModifierType()->ToString() + _X(") ");
+            }
+            buf += GetTargetType()->ToString() + _X("::");
+            buf += GetFieldName();
+
+            return buf;
+        }
+    };
+};

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/FieldType.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/FieldType.h
@@ -1,0 +1,41 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "Types.h"
+
+namespace sicily {
+    namespace ast {
+        class FieldType : public Type
+        {
+        public:
+            FieldType(
+                ClassTypePtr targetType,
+                const xstring_t& fieldName,
+                TypePtr returnType,
+                TypePtr requiredModifierType
+            );
+            virtual ~FieldType();
+
+            ClassTypePtr GetTargetType() const;
+            xstring_t GetFieldName() const;
+            TypePtr GetReturnType() const;
+            TypePtr GetRequiredModifierType() const;
+
+            xstring_t ToString() const;
+
+        private:
+            ClassTypePtr targetType_;
+            xstring_t fieldName_;
+            TypePtr returnType_;
+            TypePtr requiredModifierType_;
+        };
+
+        typedef std::shared_ptr<FieldType> FieldTypePtr;
+    };
+};

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/Type.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/Type.h
@@ -20,6 +20,7 @@ namespace sicily {
                     kCLASS,
                     kGENERICCLASS,
                     kGENERICPARAM,
+                    kFIELD,
                 };
 
                 Type(Kind kind);

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/Types.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/Types.h
@@ -9,5 +9,6 @@
 #include "GenericParamType.h"
 #include "GenericType.h"
 #include "MethodType.h"
+#include "FieldType.h"
 #include "PrimitiveType.h"
 #include "TypeList.h"

--- a/src/Agent/NewRelic/Profiler/Sicily/codegen/ByteCodeGenerator.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/codegen/ByteCodeGenerator.h
@@ -45,6 +45,10 @@ namespace sicily { namespace codegen
                 {
                     return TypeToTokenSpecific(std::dynamic_pointer_cast<ast::MethodType>(type));
                 }
+                case ast::Type::Kind::kFIELD:
+                {
+                    return TypeToTokenSpecific(std::dynamic_pointer_cast<ast::FieldType>(type));
+                }
                 case ast::Type::Kind::kCLASS:
                 {
                     return TypeToTokenSpecific(std::dynamic_pointer_cast<ast::ClassType, ast::Type>(type));
@@ -79,6 +83,10 @@ namespace sicily { namespace codegen
                 case ast::Type::Kind::kMETHOD:
                 {
                     return TypeToBytesSpecific(std::dynamic_pointer_cast<ast::MethodType>(type));
+                }
+                case ast::Type::Kind::kFIELD:
+                {
+                    return TypeToBytesSpecific(std::dynamic_pointer_cast<ast::FieldType>(type));
                 }
                 case ast::Type::Kind::kCLASS:
                 {
@@ -251,7 +259,7 @@ namespace sicily { namespace codegen
 
             // BOOLEAN | CHAR | I1 | U1 | I2 | U2 | I4 | U4 | I8 | U8 | R4 | R8 | I | U
             bytes.push_back((unsigned char)(type->GetPrimitiveKind()));
-            
+
             return bytes;
         }
 
@@ -367,6 +375,39 @@ namespace sicily { namespace codegen
             return bytes;
         }
 
+        ByteVector TypeToBytesSpecific(ast::FieldTypePtr type)
+        {
+            ByteVector bytes;
+
+            // return type
+            auto returnType = type->GetReturnType();
+            auto returnBytes = TypeToBytes(returnType);
+            bytes.insert(bytes.end(), returnBytes.begin(), returnBytes.end());
+
+            auto requiredModifierType = type->GetRequiredModifierType();
+            if (requiredModifierType != nullptr)
+            {
+                auto requiredModifierBytes = TypeToRequiredModifierBytesSpecific(std::dynamic_pointer_cast<ast::ClassType, ast::Type>(requiredModifierType));
+                bytes.insert(bytes.end(), requiredModifierBytes.begin(), requiredModifierBytes.end());
+            }
+
+            return bytes;
+        }
+
+        ByteVector TypeToRequiredModifierBytesSpecific(ast::ClassTypePtr type)
+        {
+            ByteVector bytes;
+
+            // modreq
+            bytes.push_back(0x1f);
+            // TypeDefOrRefOrSpecEncoded
+            auto typeToken = TypeToTokenSpecific(type);
+            auto compressedTypeToken = CorSigCompressToken(typeToken);
+            bytes.insert(bytes.end(), compressedTypeToken.begin(), compressedTypeToken.end());
+
+            return bytes;
+        }
+
         uint32_t TypeToTokenSpecific(ast::MethodTypePtr type)
         {
             auto signatureBytes = TypeToBytes(type);
@@ -379,6 +420,14 @@ namespace sicily { namespace codegen
             }
 
             return methodToken;
+        }
+
+        uint32_t TypeToTokenSpecific(ast::FieldTypePtr type)
+        {
+            auto targetTypeToken = TypeToToken(type->GetTargetType());
+            auto fieldToken = tokenizer->GetFieldDefinitionToken(targetTypeToken, type->GetFieldName());
+
+            return fieldToken;
         }
 
         uint32_t TypeToTokenSpecific(ast::ClassTypePtr type)

--- a/src/Agent/NewRelic/Profiler/Sicily/codegen/ITokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/codegen/ITokenizer.h
@@ -25,6 +25,7 @@ namespace sicily
             virtual uint32_t GetTypeSpecToken(const ByteVector& instantiationSignature) = 0;
             virtual uint32_t GetMemberRefOrDefToken(uint32_t parent, const xstring_t& methodName, const ByteVector& signature) = 0;
             virtual uint32_t GetMethodDefinitionToken(const uint32_t& typeDefinitionToken, const xstring_t& name, const ByteVector& signature) = 0;
+            virtual uint32_t GetFieldDefinitionToken(const uint32_t& typeDefinitionToken, const xstring_t& name) = 0;
             virtual uint32_t GetMethodSpecToken(uint32_t methodDefOrRefOrSpecToken, const ByteVector& instantiationSignature) = 0;
             virtual uint32_t GetStringToken(const xstring_t& string) = 0;
             virtual ~ITokenizer() {}


### PR DESCRIPTION
Phase 1 (FW-only) slice of the AppDomainFallbackCache mechanism from NR-184027 Milestone A: Sicily field-token support (parser, codegen, tokenizer), `__NRInitializer__` type with three static object fields injected into mscorlib, `HelperFunctionManipulator` shim-path IL builders (LDSFLD/STSFLD fast-path getters + writer, all under the 64-byte tiny-method limit), managed `AgentShim` hooks, and a native engagement counter.

Phase 1 perf gate passed: no regression vs main on realistic or high-thread regimes; thin/realistic scaling shapes reproduce. Call-site wiring (`InstrumentFunctionManipulator`) and `AgentCallStyle::Strategy` threading come in Phase 2.

## Test plan
- [ ] SicilyTest 126/126 pass
- [ ] ModuleInjectorTest 14/14 pass (new project)
- [ ] MethodRewriterTest 105/105 pass
- [ ] FullAgent.sln builds Debug clean
- [ ] Runtime attach to net481 test app: profiler loads, engagement counter fires