### PR TITLE
fix: Instrument new method for local log decoration in Serilog 4.4.0+

### DIFF
--- a/docs/net-agent-compatibility.md
+++ b/docs/net-agent-compatibility.md
@@ -77,7 +77,7 @@ The .NET agent [can be configured](https://docs.newrelic.com/docs/apm/agents/net
 | Library | NuGet package | Supported versions | Min agent version | Notes |
 | --- | --- | --- | --- | --- |
 | Log4Net | [log4net](https://www.nuget.org/packages/log4net/) | 2.0.10 – 3.3.2 | 9.7.0 |  |
-| Serilog | [Serilog](https://www.nuget.org/packages/Serilog/) | 2.5.0 – 4.3.1 | 9.7.0 |  |
+| Serilog | [Serilog](https://www.nuget.org/packages/Serilog/) | 2.5.0 – 4.4.0 | 9.7.0 |  |
 | NLog | [NLog](https://www.nuget.org/packages/NLog/) | 4.5.0 – 6.1.3 | 9.7.0 |  |
 | Microsoft.Extensions.Logging | [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/) | 3.0.0 – 10.0.9 | 10.0.0 |  |
 
@@ -189,7 +189,7 @@ The .NET agent [can be configured](https://docs.newrelic.com/docs/apm/agents/net
 | --- | --- | --- | --- | --- |
 | Log4Net | [log4net](https://www.nuget.org/packages/log4net/) | 1.2.10 – 3.3.2 | 9.7.0 |  |
 | Sitecore.Logging | Sitecore.Logging | 10.0.0 – 10.3.0 | 10.14.0 | <ul><li>`Sitecore.Logging` is a repackaged log4net; the agent instruments it through its log4net instrumentation.</li></ul> |
-| Serilog | [Serilog](https://www.nuget.org/packages/Serilog/) | 2.0.0 – 4.3.1 | 9.7.0 |  |
+| Serilog | [Serilog](https://www.nuget.org/packages/Serilog/) | 2.0.0 – 4.4.0 | 9.7.0 |  |
 | NLog | [NLog](https://www.nuget.org/packages/NLog/) | 4.1.0 – 6.1.3 | 9.7.0 |  |
 | Microsoft.Extensions.Logging | [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/) | 3.0.0 – 10.0.9 | 9.7.0 |  |
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/Instrumentation.xml
@@ -8,12 +8,17 @@ SPDX-License-Identifier: Apache-2.0
     <tracerFactory name="SerilogDispatchWrapper">
       <!-- For Serilog 1.x -->
       <match assemblyName="Serilog" className="Serilog.Core.Pipeline.Logger">
-        <exactMethodMatcher methodName="Dispatch" />
+        <exactMethodMatcher methodName="Dispatch" maxVersion="2.0.0"/>
       </match>
 
       <!-- For Serilog 2.x and above -->
       <match assemblyName="Serilog" className="Serilog.Core.Logger">
-        <exactMethodMatcher methodName="Dispatch" />
+        <exactMethodMatcher methodName="Dispatch" minVersion="2.0.0" maxVersion="4.4.0" />
+      </match>
+
+      <!-- For Serilog 4.4.0 and above -->
+      <match assemblyName="Serilog" className="Serilog.Core.Logger">
+        <exactMethodMatcher methodName="PostLevelCheckEmit" minVersion="4.4.0" />
       </match>
     </tracerFactory>
     

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -80,8 +80,8 @@
     <PackageReference Include="RabbitMQ.Client" Version="7.1.2" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
     <PackageReference Include="RestSharp" Version="114.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog" Version="4.3.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog" Version="4.3.1" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Serilog" Version="4.4.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="4.4.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />


### PR DESCRIPTION
## Description

Fix #3704 by adding a new instrumentation point for `PostCheckLevelEmit`, in `Serilog.Core.Logger`, which replaces `Dispatch` in version 4.4.0+.

Verified that the local log decoration integration tests for Serilog all passed on my dev system.