### PR TITLE
feat: NR-184027 Milestone B unified injected-method cache on .NET Core

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.52.0.36"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.52.0.39"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.52.0.38"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.52.0.36"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Common/Macros.h
+++ b/src/Agent/NewRelic/Profiler/Common/Macros.h
@@ -13,7 +13,7 @@ namespace NewRelic { namespace Profiler
     typedef std::shared_ptr<ByteVector> ByteVectorPtr;
 
     #define BYTEVECTOR(variableName, ...)\
-        unsigned char myTempBytes##variableName[] = {##__VA_ARGS__};\
+        unsigned char myTempBytes##variableName[] = {__VA_ARGS__};\
         std::vector<uint8_t> variableName(myTempBytes##variableName, myTempBytes##variableName + sizeof(myTempBytes##variableName) / sizeof(unsigned char));
 
     #define lengthof(x) sizeof(x)/sizeof(x[0])

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -310,9 +310,10 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             // exception helper methods and remove the `mscorlib` lookups.  Right now we try to find a reference
             // to the mscorlib library as we build class tokens, and mscorlib does not reference itself.
             // But the safest thing to do is disallow mscorlib instrumentation and make that very clear to users.
-            if (instrumentationPoint->AssemblyName == _X("mscorlib"))
+            if (instrumentationPoint->AssemblyName == _X("mscorlib") ||
+                instrumentationPoint->AssemblyName == _X("System.Private.CoreLib"))
             {
-                LogWarn(L"Skipping instrumentation targeted at the mscorlib assembly for class ", instrumentationPoint->ClassName);
+                LogWarn(L"Skipping instrumentation targeted at the core library assembly for class ", instrumentationPoint->ClassName);
                 return;
             }
 

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
@@ -324,6 +324,28 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsTrue(instrumentationPoint == nullptr);
         }
 
+        TEST_METHOD(system_private_corelib_instrumentation_is_skipped)
+        {
+            InstrumentationXmlSetPtr xmlSet(new InstrumentationXmlSet());
+            xmlSet->emplace(L"filename", L"\
+                <?xml version=\"1.0\" encoding=\"utf-8\"?>\
+                <extension>\
+                    <instrumentation>\
+                        <tracerFactory>\
+                            <match assemblyName=\"System.Private.CoreLib\" className=\"MyNamespace.MyClass\">\
+                                <exactMethodMatcher methodName=\"MyMethod\"/>\
+                            </match>\
+                        </tracerFactory>\
+                    </instrumentation>\
+                </extension>\
+                ");
+            InstrumentationConfiguration instrumentation(xmlSet, nullptr);
+            auto function = std::make_shared<MethodRewriter::Test::MockFunction>();
+            function->_assemblyName = L"System.Private.CoreLib";
+            auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(function);
+            Assert::IsTrue(instrumentationPoint == nullptr);
+        }
+
         TEST_METHOD(no_class_match)
         {
             InstrumentationXmlSetPtr xmlSet(new InstrumentationXmlSet());

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/AgentCallStyle.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/AgentCallStyle.h
@@ -40,6 +40,21 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             return _X("Reflection");
         }
 
+        // (F) graceful degradation: the AppDomainFallbackCache fast-path calls helper members
+        // that must be DEFINED into the core library. If that injection did not take, the process
+        // must fall back to Reflection (self-contained IL that needs no injected helpers).
+        // Pure decision, unit-tested; the metadata re-read that produces coreLibInjectionSucceeded
+        // lives in the profiler callback (integration-only).
+        static const Strategy ResolveEffectiveStrategy(const Strategy configuredStrategy, const bool coreLibInjectionSucceeded)
+        {
+            if (configuredStrategy == Strategy::AppDomainFallbackCache && !coreLibInjectionSucceeded)
+            {
+                return Strategy::Reflection;
+            }
+
+            return configuredStrategy;
+        }
+
     private:
         std::shared_ptr<ISystemCalls> _systemCalls;
     };

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/AgentCallStyleTests.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/AgentCallStyleTests.cpp
@@ -56,5 +56,26 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             const xstring_t expected = _X("Reflection");
             Assert::AreEqual(expected, AgentCallStyle::ToString(AgentCallStyle::Strategy::Reflection));
         }
+
+        TEST_METHOD(ResolveEffectiveStrategy_FallbackCache_InjectionFailed_DowngradesToReflection)
+        {
+            Assert::IsTrue(AgentCallStyle::ResolveEffectiveStrategy(
+                AgentCallStyle::Strategy::AppDomainFallbackCache, false) == AgentCallStyle::Strategy::Reflection);
+        }
+        TEST_METHOD(ResolveEffectiveStrategy_FallbackCache_InjectionSucceeded_StaysFallbackCache)
+        {
+            Assert::IsTrue(AgentCallStyle::ResolveEffectiveStrategy(
+                AgentCallStyle::Strategy::AppDomainFallbackCache, true) == AgentCallStyle::Strategy::AppDomainFallbackCache);
+        }
+        TEST_METHOD(ResolveEffectiveStrategy_Reflection_InjectionFailed_StaysReflection)
+        {
+            Assert::IsTrue(AgentCallStyle::ResolveEffectiveStrategy(
+                AgentCallStyle::Strategy::Reflection, false) == AgentCallStyle::Strategy::Reflection);
+        }
+        TEST_METHOD(ResolveEffectiveStrategy_Reflection_InjectionSucceeded_StaysReflection)
+        {
+            Assert::IsTrue(AgentCallStyle::ResolveEffectiveStrategy(
+                AgentCallStyle::Strategy::Reflection, true) == AgentCallStyle::Strategy::Reflection);
+        }
     };
 }}}}

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/IModule.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/IModule.h
@@ -31,6 +31,11 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
         virtual bool NeedsReferenceToCoreLib() = 0;
         virtual bool GetIsThisTheCoreLibAssembly() = 0;
 
+        // (F) After InjectIntoModule runs on the core library, re-read metadata to confirm the
+        // __NRInitializer__ helper type was actually defined. Used to decide whether to keep the
+        // AppDomainFallbackCache strategy or downgrade the process to Reflection.
+        virtual bool VerifyNRHelperTypeInjected() = 0;
+
         virtual sicily::codegen::ITokenizerPtr GetTokenizer() = 0;
     };
 

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/MockModule.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/MockModule.h
@@ -88,6 +88,12 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return _isThisTheCoreLibAssembly;
         }
 
+        bool _nrHelperTypeInjected = true;
+        virtual bool VerifyNRHelperTypeInjected() override
+        {
+            return _nrHelperTypeInjected;
+        }
+
         sicily::codegen::ITokenizerPtr _tokenizer;
         virtual sicily::codegen::ITokenizerPtr GetTokenizer() override
         {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -27,11 +27,12 @@
 #include <utility>
 #include <codecvt>
 
+#include "../ModuleInjector/ModuleInjector.h"
+#include "Module.h"
+
 #ifdef PAL_STDCPP_COMPAT
 #include "UnixSystemCalls.h"
 #else
-#include "../ModuleInjector/ModuleInjector.h"
-#include "Module.h"
 #include "SystemCalls.h"
 #include <shellapi.h>
 #endif
@@ -80,9 +81,8 @@ namespace NewRelic { namespace Profiler {
         // was refreshed after injection (see Instrumentors.h note on refresh-reset).
         std::atomic<uint64_t> _totalJitCount{0};
 
-#ifndef PAL_STDCPP_COMPAT
-        std::shared_ptr<ModuleInjector::ModuleInjector> _moduleInjector;
-#endif
+        // (F) counts corelib injection-failure downgrades to Reflection (native signal; no managed metric).
+        std::atomic<uint64_t> _injectionDowngradeCount{0};
 
     public:
         CorProfilerCallbackImpl()
@@ -276,13 +276,8 @@ namespace NewRelic { namespace Profiler {
 
                 _functionResolver = std::make_shared<FunctionResolver>(_corProfilerInfo4);
 
-                // On CoreCLR, ModuleLoadFinished does not inject the AppDomain-cache helper stubs
-                // into System.Private.CoreLib, so the AppDomainFallbackCache strategy has no target
-                // to call into. Force Reflection on Core; the configured strategy only applies to FW.
                 MethodRewriter::AgentCallStyle agentCallStyle(_systemCalls);
-                _agentCallStrategy = _isCoreClr
-                    ? MethodRewriter::AgentCallStyle::Strategy::Reflection
-                    : agentCallStyle.GetConfiguredCallingStrategy();
+                _agentCallStrategy = agentCallStyle.GetConfiguredCallingStrategy();
 
                 ConfigureEventMask(pICorProfilerInfoUnk);
 
@@ -301,81 +296,90 @@ namespace NewRelic { namespace Profiler {
 
         virtual HRESULT __stdcall ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) override
         {
+            if (FAILED(hrStatus))
+            {
+                return hrStatus;
+            }
+
+            // Core retains its ReJIT enumeration of app methods, in ADDITION to injection below.
             if (_isCoreClr)
             {
-                if (SUCCEEDED(hrStatus)) {
-                    try {
-                        auto assemblyName = GetAssemblyName(moduleId);
-
-                        if (GetMethodRewriter()->ShouldInstrumentAssembly(assemblyName)) {
-                            LogTrace("Assembly module loaded: ", assemblyName);
-
-                            auto instrumentationPoints = std::make_shared<Configuration::InstrumentationPointSet>(GetMethodRewriter()->GetAssemblyInstrumentation(assemblyName));
-                            auto methodDefs = GetMethodDefs(moduleId, instrumentationPoints);
-
-                            if (methodDefs != nullptr) {
-                                RejitModuleFunctions(moduleId, methodDefs);
-                            }
+                try
+                {
+                    auto assemblyName = GetAssemblyName(moduleId);
+                    if (GetMethodRewriter()->ShouldInstrumentAssembly(assemblyName))
+                    {
+                        LogTrace("Assembly module loaded: ", assemblyName);
+                        auto instrumentationPoints = std::make_shared<Configuration::InstrumentationPointSet>(GetMethodRewriter()->GetAssemblyInstrumentation(assemblyName));
+                        auto methodDefs = GetMethodDefs(moduleId, instrumentationPoints);
+                        if (methodDefs != nullptr)
+                        {
+                            RejitModuleFunctions(moduleId, methodDefs);
                         }
                     }
-                    catch (...) {
-                    }
                 }
-                return S_OK;
+                catch (...)
+                {
+                }
             }
-            else
+
+            // Injection is only needed for the AppDomainFallbackCache strategy; Reflection IL is
+            // self-contained and needs no injected corelib helpers.
+            if (_agentCallStrategy == MethodRewriter::AgentCallStyle::Strategy::Reflection)
             {
-#ifndef PAL_STDCPP_COMPAT
-
-                // if the module did not load correctly then we don't want to mess with it
-                if (FAILED(hrStatus))
-                {
-                    return hrStatus;
-                }
-
-                LogTrace("Module Injection Started. ", moduleId);
-
-                ModuleInjector::IModulePtr module;
-                try
-                {
-                    module = std::make_shared<Module>(_corProfilerInfo4, moduleId);
-                }
-                catch (const NewRelic::Profiler::MessageException& exception)
-                {
-                    (void)exception;
-                    return S_OK;
-                }
-                catch (...)
-                {
-                    LogError(L"An exception was thrown while getting details about a module.");
-                    return E_FAIL;
-                }
-
-                try
-                {
-                    _moduleInjector->InjectIntoModule(*module);
-                }
-                catch (...)
-                {
-                    LogError(L"An exception was thrown while attempting to inject into a module.");
-                    return E_FAIL;
-                }
-
-                LogTrace("Module Injection Finished. ", moduleId, " : ", module->GetModuleName());
-#endif
                 return S_OK;
             }
-        }
 
+            LogTrace("Module Injection Started. ", moduleId);
+
+            ModuleInjector::IModulePtr module;
+            try
+            {
+                module = std::make_shared<Module>(_corProfilerInfo4, moduleId, _isCoreClr);
+            }
+            catch (const NewRelic::Profiler::MessageException&)
+            {
+                return S_OK;
+            }
+            catch (...)
+            {
+                LogError(L"An exception was thrown while getting details about a module.");
+                return E_FAIL;
+            }
+
+            try
+            {
+                ModuleInjector::ModuleInjector::InjectIntoModule(*module, _isCoreClr);
+            }
+            catch (...)
+            {
+                LogError(L"An exception was thrown while attempting to inject into a module.");
+                return E_FAIL;
+            }
+
+            // (F) safety net: after injecting into the core library, confirm the helper type actually
+            // took. If not, downgrade the whole process to Reflection (the corelib is the first module
+            // loaded, so this precedes essentially every app-method JIT). Runtime-agnostic seam decides.
+            if (module->GetIsThisTheCoreLibAssembly())
+            {
+                const bool injected = module->VerifyNRHelperTypeInjected();
+                const auto effective = MethodRewriter::AgentCallStyle::ResolveEffectiveStrategy(_agentCallStrategy, injected);
+                if (effective != _agentCallStrategy)
+                {
+                    ++_injectionDowngradeCount;
+                    LogError(L"__NRInitializer__ helper type was not defined into the core library; "
+                             L"downgrading the managed-agent calling strategy to Reflection for this process. "
+                             L"injection_downgrades=", _injectionDowngradeCount.load());
+                }
+                _agentCallStrategy = effective;
+            }
+
+            LogTrace("Module Injection Finished. ", moduleId, " : ", module->GetModuleName());
+            return S_OK;
+        }
 
         virtual DWORD OverrideEventMask(DWORD eventMask)
         {
-#ifndef PAL_STDCPP_COMPAT
-            if (!_isCoreClr)
-            {
-                _moduleInjector.reset(new ModuleInjector::ModuleInjector());
-            }
-#endif
             return eventMask;
         }
 

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -1195,7 +1195,7 @@ namespace NewRelic { namespace Profiler {
 
         void LogMessageAboutConfiguredAgentCallStyle()
         {
-            LogInfo(_X("Calls to the managed agent will use the calling strategy - "), MethodRewriter::AgentCallStyle::ToString(_agentCallStrategy));
+            LogInfo(L"Calls to the managed agent will use the calling strategy - ", MethodRewriter::AgentCallStyle::ToString(_agentCallStrategy));
         }
 
         std::unique_ptr<xstring_t> GetAgentCoreDllPath()

--- a/src/Agent/NewRelic/Profiler/Profiler/Module.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Module.h
@@ -137,6 +137,13 @@ namespace NewRelic { namespace Profiler
             //ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_isInitialized"), dataFieldAttributes, intFieldSignature.data(), (uint32_t)intFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
         }
 
+        virtual bool VerifyNRHelperTypeInjected() override
+        {
+            mdTypeDef typeToken = mdTypeDefNil;
+            HRESULT hr = _metaDataImport->FindTypeDefByName(_X("__NRInitializer__"), mdTypeDefNil, &typeToken);
+            return SUCCEEDED(hr) && typeToken != mdTypeDefNil;
+        }
+
         virtual void InjectCoreLibSecuritySafeMethodReference(const xstring_t& methodName, const xstring_t& className, const ByteVector& signature) override
         {
             auto typeReferenceOrDefinitionToken = GetOrCreateTypeReferenceToken(_coreLibAssemblyRefToken, className);

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -39,6 +39,31 @@ build.ps1 -Platform linux                       # Linux (requires Docker)
 
 Profiler GUIDs are documented in the [root claude.md](../CLAUDE.md).
 
+**Injected CoreLib helper methods must stay "tiny" (hard, unguarded
+constraint).** The cache getter/store helpers the profiler injects into
+CoreLib/mscorlib (`MethodRewriter/HelperFunctionManipulator.h`, the `Build*`
+methods) are emitted via `HelperFunctionManipulator::InstrumentHelper` ->
+`FunctionManipulator::InstrumentTiny`, which ALWAYS writes an ECMA-335 tiny
+method header. This path is tiny-only: no size check, no fat-header fallback
+(the fat-upgrade path `FunctionManipulator::ExtractHeaderBodyAndExtra` exists
+but is not on the helper call path). A tiny method is limited to: IL code
+size < 64 bytes (6-bit field), maxstack <= 8 (fixed, never written), no
+locals, no exception-handling clauses (see
+`externals/coreclr-headers/src/inc/corhdr.h` and `corhlpr.h`). Exceeding any
+limit does NOT fail loudly: `InstrumentTiny` sets
+`Flags_CodeSize = (uint8_t)((codeSize << 2) | 0x2)` and silently truncates to
+one byte, so a >= 64-byte body encodes a wrong (smaller) size and the CLR
+then reads a malformed method (InvalidProgramException / JIT failure /
+crash). Nothing asserts or tests this (the tiny/fat boundary tests in
+`MethodRewriterTest/FunctionManipulatorTest.cpp` are disabled) -- it is
+enforced by convention only. Rule: keep every injected helper minimal; when
+adding IL to a `Build*` helper, budget the bytes (single-byte opcodes 1 B;
+short-form branch 2 B; `call`/`callvirt`/`ldsfld`/`stsfld`/`castclass`/
+`ldstr`/`newobj` with a 4-byte token 5 B), keep live stack <= 8, add no
+locals. Verify empirically in a debug build by logging
+`_instructions->GetBytes().size()` before `InstrumentTiny()`; do not trust it
+to fail safely.
+
 ## Agent Core (`Agent/NewRelic/Agent/Core/`)
 
 ```

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-appdomaincaching.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-appdomaincaching.yml
@@ -1,0 +1,25 @@
+# The following must be set either in environment variables or via a .env file in the same folder as this file:
+#
+# See docker-compose-base.yml for common required variables.
+# CONTAINER_NAME  The name for the container
+# NEW_RELIC_DISABLE_APPDOMAIN_CACHING  Opt-out flag for the unified method cache, forwarded into the container
+#
+# To build and run, execute `docker compose -f <path to docker-compose.yml> up`
+# Alternatively, set COMPOSE_FILE environment variable to the path and omit the -f parameter
+
+services:
+    LinuxSmokeTestApp:
+        extends:
+            file: docker-compose-base.yml
+            service: base-app
+        container_name: ${CONTAINER_NAME}
+        image: ${CONTAINER_NAME}
+        platform: ${PLATFORM}
+        environment:
+            - NEW_RELIC_DISABLE_APPDOMAIN_CACHING=${NEW_RELIC_DISABLE_APPDOMAIN_CACHING:-}
+
+networks:
+    default:
+        driver: bridge
+        driver_opts:
+          com.docker.network.bridge.enable_icc: "true"

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AppDomainCachingContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AppDomainCachingContainerTestFixtures.cs
@@ -1,0 +1,32 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.ContainerIntegrationTests.Applications;
+
+namespace NewRelic.Agent.ContainerIntegrationTests.Fixtures;
+
+public class AppDomainCachingEnabledContainerTestFixture : ContainerTestFixtureBase
+{
+    private const string Dockerfile = "SmokeTestApp/Dockerfile";
+    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
+    private const string DistroTag = "noble";
+
+    public AppDomainCachingEnabledContainerTestFixture() : base(DistroTag, Architecture, Dockerfile)
+    {
+        ProfilerLogExpected = true;
+    }
+}
+
+public class AppDomainCachingDisabledContainerTestFixture : ContainerTestFixtureBase
+{
+    private const string Dockerfile = "SmokeTestApp/Dockerfile";
+    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
+    private const string DistroTag = "noble";
+    private const string DockerComposeFile = "docker-compose-appdomaincaching.yml";
+
+    public AppDomainCachingDisabledContainerTestFixture() : base(DistroTag, Architecture, Dockerfile, DockerComposeFile)
+    {
+        ProfilerLogExpected = true;
+        SetAdditionalEnvironmentVariable("NEW_RELIC_DISABLE_APPDOMAIN_CACHING", "true");
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
@@ -14,8 +14,9 @@ public abstract class ContainerTestFixtureBase : RemoteApplicationFixture
 
     protected override int MaxTries => 1;
 
-    protected ContainerTestFixtureBase(string distroTag, ContainerApplication.Architecture containerArchitecture, string dockerfile) :
-        base(new ContainerApplication(distroTag, containerArchitecture, DotnetVersion, dockerfile))
+    protected ContainerTestFixtureBase(string distroTag, ContainerApplication.Architecture containerArchitecture, string dockerfile,
+        string dockerComposeFile = "docker-compose.yml") :
+        base(new ContainerApplication(distroTag, containerArchitecture, DotnetVersion, dockerfile, dockerComposeFile))
     {
     }
 

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AppDomainCachingContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AppDomainCachingContainerTests.cs
@@ -1,0 +1,87 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.ContainerIntegrationTests.Fixtures;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+
+namespace NewRelic.Agent.ContainerIntegrationTests.Tests;
+
+public abstract class AppDomainCachingContainerTest<T> : NewRelicIntegrationTest<T> where T : ContainerTestFixtureBase
+{
+    private readonly T _fixture;
+    private readonly string _expectedStrategy;
+    private readonly bool _cachingDisabled;
+
+    protected AppDomainCachingContainerTest(T fixture, ITestOutputHelper output, string expectedStrategy, bool cachingDisabled) : base(fixture)
+    {
+        _fixture = fixture;
+        _expectedStrategy = expectedStrategy;
+        _cachingDisabled = cachingDisabled;
+        _fixture.TestLogger = output;
+
+        _fixture.Actions(setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.ExerciseApplication();
+
+                // On loaded CI runners container startup can exceed 10s, causing the first
+                // harvest to fire before the HTTP request completes. Wait for the transaction
+                // to be confirmed processed, then wait for a second metric harvest so we are
+                // guaranteed at least one harvest that includes the AppDomainCaching supportability metric.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+
+                // shut down the container and wait for the agent log to see it
+                _fixture.ShutdownRemoteApplication();
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromSeconds(10));
+            });
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void ProfilerLogsExpectedCallingStrategy()
+    {
+        Assert.Contains($"Calls to the managed agent will use the calling strategy - {_expectedStrategy}", _fixture.ProfilerLog.GetFullLogAsString());
+    }
+
+    [Fact]
+    public void SupportabilityMetricReported()
+    {
+        var actualMetrics = _fixture.AgentLog.GetMetrics();
+        if (_cachingDisabled)
+        {
+            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/DotNET/AppDomainCaching/Disabled");
+        }
+        else
+        {
+            Assert.DoesNotContain(actualMetrics, x => x.MetricSpec.Name == "Supportability/DotNET/AppDomainCaching/Disabled");
+        }
+    }
+}
+
+[Trait("Architecture", "amd64")]
+[Trait("Distro", "Ubuntu")]
+public class AppDomainCachingEnabledContainerTest : AppDomainCachingContainerTest<AppDomainCachingEnabledContainerTestFixture>
+{
+    public AppDomainCachingEnabledContainerTest(AppDomainCachingEnabledContainerTestFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, "AppDomain Fallback Cache", cachingDisabled: false)
+    {
+    }
+}
+
+[Trait("Architecture", "amd64")]
+[Trait("Distro", "Ubuntu")]
+public class AppDomainCachingDisabledContainerTest : AppDomainCachingContainerTest<AppDomainCachingDisabledContainerTestFixture>
+{
+    public AppDomainCachingDisabledContainerTest(AppDomainCachingDisabledContainerTestFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, "Reflection", cachingDisabled: true)
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
@@ -54,13 +54,9 @@ public abstract class AppDomainCachingTestsBase<TFixture> : NewRelicIntegrationT
     [Fact]
     public void ProfilerObservesEnvironmentVariable()
     {
-        // The profiler logs the resolved managed-agent calling strategy at startup.
-        // NOTE: Today the profiler forces the Reflection strategy on CoreCLR regardless of
-        // NEW_RELIC_DISABLE_APPDOMAIN_CACHING, because ModuleLoadFinished does not inject the
-        // AppDomain-cache helper stubs into System.Private.CoreLib. That is why the .NET (Core)
-        // "enabled" variant below expects "Reflection" rather than "AppDomain Fallback Cache".
-        // FUTURE: when Core gains AppDomain-fallback support (NR-184027 Milestone B), update the
-        // expected strategy for the Core "enabled" case to "AppDomain Fallback Cache".
+        // The profiler logs the resolved managed-agent calling strategy at startup. Core now honors
+        // NEW_RELIC_DISABLE_APPDOMAIN_CACHING like .NET Framework: default (unset) => AppDomain Fallback Cache,
+        // opt-out (true) => Reflection.
         Assert.Contains($"Calls to the managed agent will use the calling strategy - {_expectedCallingStrategy}", _fixture.ProfilerLog.GetFullLogAsString());
     }
 
@@ -91,7 +87,7 @@ public class AppDomainCachingEnabledTestsFWLatestTests : AppDomainCachingTestsBa
 public class AppDomainCachingEnabledTestsNetCoreLatestTests : AppDomainCachingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
 {
     public AppDomainCachingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-        : base(fixture, output, false, "Reflection")
+        : base(fixture, output, false, "AppDomain Fallback Cache")
     {
     }
 }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -111,6 +111,48 @@ Staging's connect response sets `event_harvest_config.report_period_ms=5000`, so
 
 The repo-root `test.runsettings` holds only NUnit naming settings and is auto-applied to **unit-test** projects via `RunSettingsFilePath` in their csproj (don't pass `--settings` by hand). It is **not** wired into integration projects, and CI runs those via the built exe (`NewRelic.Agent.IntegrationTests.exe -namespace ...`), so no run-settings file applies there.
 
+### Container test mechanics (ContainerIntegrationTests)
+
+How the Linux-agent container tests actually wire up (rediscovered often -- captured here):
+
+- **Harness chain:** `ContainerTestFixtureBase : RemoteApplicationFixture` wraps
+  `ContainerApplication : RemoteApplication`. `ContainerApplication` runs
+  `docker compose -f <composeFile> -p <name> up --build --abort-on-container-exit ...`
+  against service `LinuxSmokeTestApp`. Ctor:
+  `ContainerApplication(distroTag, arch, dotnetVersion, dockerfile, dockerComposeFile = "docker-compose.yml", serviceName = "LinuxSmokeTestApp")`.
+- **Compose files** live in `tests/Agent/IntegrationTests/ContainerApplications/`. `docker-compose.yml`
+  extends `docker-compose-base.yml`'s `base-app`, which declares build `args:` (DISTRO_TAG, TARGET_ARCH,
+  BUILD_ARCH, NEW_RELIC_LICENSE_KEY/APP_NAME/HOST, DOTNET_VERSION, ...), `ports: ${PORT}:80`, and two bind
+  mounts: `${AGENT_PATH}:/usr/local/newrelic-dotnet-agent` (the agent home) and `${LOG_PATH}:/app/logs` (logs).
+  The base has **no `environment:` block**.
+- **Which Dockerfile:** the fixture picks it via the `dockerfile` field (e.g. `SmokeTestApp/Dockerfile`,
+  `.centos`, `.amazon`, `.fedora`), passed to compose as `TEST_DOCKERFILE`. `SmokeTestApp` is a plain ASP.NET
+  Core app exposing `GET /weatherforecast`; its Dockerfile bakes in `CORECLR_ENABLE_PROFILING`,
+  `CORECLR_PROFILER`, `CORECLR_NEW_RELIC_HOME=/usr/local/newrelic-dotnet-agent`, `CORECLR_PROFILER_PATH`, and
+  `NEW_RELIC_LOG_DIRECTORY=/app/logs`. The agent attaches on boot and logs its startup lines with no app code.
+- **Passing a per-test container env var** (e.g. `NEW_RELIC_DISABLE_APPDOMAIN_CACHING`): `RemoteApplicationFixture
+  .SetAdditionalEnvironmentVariable(k,v)` lands the var in the `docker compose up` **host process** env only --
+  compose forwards it into the container **only if** a compose file references it via `${VAR}` in an
+  `environment:` entry. The base compose has none, so add a small compose override file that `extends` `base-app`
+  and adds `environment: - VAR=${VAR:-}` (pattern: `docker-compose-awssdk.yml` uses `- DEBUG=${DEBUG:-0}`), then
+  point the fixture's `dockerComposeFile` at it. Fixtures that need a custom compose file extend
+  `RemoteApplicationFixture` directly and thread `dockerComposeFile` through the `ContainerApplication` ctor
+  (pattern: `KafkaTestFixtureBase`) -- `ContainerTestFixtureBase` hardcodes the default `docker-compose.yml`.
+- **Reading logs / assertions:** `LOG_PATH` = `RemoteApplication.DefaultLogFileDirectoryPath` (host), bind-mounted
+  to `/app/logs`, so `_fixture.AgentLog` (`AgentLogFile`) and `_fixture.ProfilerLog` (`ProfilerLogFile`,
+  `GetFullLogAsString()`) read the container's logs on the host with no container/host distinction. Set
+  `ProfilerLogExpected = true` in the fixture ctor when asserting on the profiler log. The profiler startup line
+  `Calls to the managed agent will use the calling strategy - <X>` is visible here, same as the host tests.
+- **Templates:** simplest fixture+test pair to copy = `Fixtures/LinuxUnicodeLogFileTestFixture.cs` +
+  `Tests/LinuxUnicodeLogFileTest.cs` (asserts on `ProfilerLog`). `Tests/LinuxContainerTests.cs` shows the
+  per-distro `[Trait("Architecture",...)] [Trait("Distro",...)]` class fan-out and the
+  `Actions(setupConfiguration, exerciseApplication)` -> `Initialize()` flow.
+- **glibc vs musl:** `build.ps1 -Platform linux` and the `homefolders` CI artifact only carry the **glibc**
+  `.so` (`newrelichome_{x64,arm64}_coreclr_linux`); `CopyNewRelicHomeCoreClrLinuxDirectoryToRemote` copies that
+  same glibc home for **every** distro fixture including Alpine (the separate musl profiler artifacts from
+  `build_profiler.yml` are not wired into `homefolders`). Target **glibc distros (Ubuntu "noble")** for new
+  functional tests; avoid Alpine unless specifically validating musl.
+
 ## Performance tests
 
 Agent-overhead harness under `tests/Agent/PerformanceTests/` -- Python-orchestrated, not `dotnet test`. Components: `PerformanceTestApp/` (ASP.NET Core workload), `TrafficDriver/` (Locust, enforces <1% error rate), `ReportGenerator/` (ScottPlot charts + `summary.md`), `run-perf-test.py` (single run), `run-perf-comparison.py` (multiple configs from `compare.yml`). The runner bind-mounts an agent-home dir into the container at `/usr/local/newrelic-dotnet-agent` and sets `CORECLR_ENABLE_PROFILING` (0 for the no-agent baseline); `agent-home/` is repopulated and cleared between runs. Needs Docker Desktop (Linux containers), Python 3, `pip install pyyaml`. Full reference: [PerformanceTests/README.md](Agent/PerformanceTests/README.md).


### PR DESCRIPTION
Milestone B of NR-184027: enable the unified injected-bytecode method cache (the `AppDomain Fallback Cache` fast-path) for .NET Core / CoreCLR, removing Core's per-call reflection ceiling on the same mechanism Milestone A de-risked on .NET Framework.

- Unifies `ModuleLoadFinished` so the profiler injects the `__NRInitializer__` helper stubs into `System.Private.CoreLib` on both runtimes; Core now honors the configured calling strategy instead of being forced to Reflection.
- Adds `System.Private.CoreLib` to the instrumentation-target skip guard.
- Adds a graceful-degradation safety net: if the corelib helper type does not take, the process downgrades to Reflection (unit-tested decision seam + native counter).
- Default flips to `AppDomain Fallback Cache`; `NEW_RELIC_DISABLE_APPDOMAIN_CACHING=true` still opts out to Reflection.
- Builds and runs under PAL/Linux.

Validated behind two gates before the flip: Windows-Core perf (fast-path breaks the reflection serialization ceiling and scales; no regression at realistic load) and Linux-Core injection engagement (SPC helper injection honored under PAL, no downgrade).

Stacks on `feature/unified-method-cache` (not `main`).
