### PR TITLE
chore: distinct Dependabot group name for build-tools nuget updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,8 +63,11 @@ updates:
       interval: monthly
     commit-message:
       prefix: "chore(deps):"
-    groups: 
-      nuget-agent:
+    groups:
+      # Distinct group name so the generated PR title ("Bump the
+      # nuget-build-tools group ...") is distinguishable from the core-agent
+      # nuget-agent PRs, which scan a different directory set.
+      nuget-build-tools:
         patterns:
           - "*"
 


### PR DESCRIPTION
The build-tools nuget block reused the same group name (`nuget-agent`) as the core-agent block, so both produced PRs titled "Bump the nuget-agent group with N updates" and were indistinguishable. Renamed the build-tools group to `nuget-build-tools` so future PR titles clearly indicate what they update.