### PR TITLE
chore: Add explicit StyleCop package references to non-SDK test projects

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicAspWebService/BasicAspWebService.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicAspWebService/BasicAspWebService.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -92,6 +92,9 @@
     </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api">
       <Version>8.41.1</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -132,6 +132,9 @@
     </PackageReference>
     <PackageReference Include="ServiceStack.Text">
       <Version>4.0.40</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/tests/Agent/IntegrationTests/Applications/BasicWebApplication/BasicWebApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicWebApplication/BasicWebApplication.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -113,6 +113,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/BasicWebFormsApplication/BasicWebFormsApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicWebFormsApplication/BasicWebFormsApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -104,6 +104,9 @@
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/tests/Agent/IntegrationTests/Applications/BasicWebService/BasicWebService.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicWebService/BasicWebService.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -92,6 +92,9 @@
       <Version>17.14.15</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/tests/Agent/IntegrationTests/Applications/ConsoleAsyncApplication/ConsoleAsyncApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleAsyncApplication/ConsoleAsyncApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -40,6 +40,9 @@
     </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api">
       <Version>8.41.1</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoader/ConsoleInstrumentationLoader.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoader/ConsoleInstrumentationLoader.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -59,6 +59,9 @@
     </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/ConsoleOtherTransactionWrapperApplication/ConsoleOtherTransactionWrapperApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleOtherTransactionWrapperApplication/ConsoleOtherTransactionWrapperApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,6 +43,9 @@
     </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api">
       <Version>8.41.1</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/Agent/IntegrationTests/Applications/MvcAsyncApplication/MvcAsyncApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/MvcAsyncApplication/MvcAsyncApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -112,6 +112,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/OpenRastaWebApplication/OpenRastaWebApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/OpenRastaWebApplication/OpenRastaWebApplication.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -110,6 +110,9 @@
     </PackageReference>
     <PackageReference Include="openrasta-razor">
       <Version>2.5.16</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/OwinRemotingClient.csproj
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/OwinRemotingClient.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -72,6 +72,9 @@
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/OwinRemotingServer.csproj
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/OwinRemotingServer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -79,6 +79,9 @@
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/RejitMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/RejitMvcApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -88,6 +88,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -88,6 +88,9 @@
     </PackageReference>
     <PackageReference Include="ServiceStack.Text">
       <Version>5.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/ThreadProfileStressTest/ThreadProfileStressTest.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ThreadProfileStressTest/ThreadProfileStressTest.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -59,6 +59,9 @@
     </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api">
       <Version>8.41.1</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -110,6 +110,9 @@
     </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource">
       <Version>4.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -107,6 +107,9 @@
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes a problem with the new central package management handling of StyleCop that broke how Visual Studio NuGet restore works, allowing us to build the integration test solutions in Visual Studio again.

