### PR TITLE
chore: Add StyleCop copyright header enforcement to BuildTools solution

### DIFF
--- a/build/ArtifactBuilder/AgentComponents.cs
+++ b/build/ArtifactBuilder/AgentComponents.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/AgentInfo.cs
+++ b/build/ArtifactBuilder/AgentInfo.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO;
 using Newtonsoft.Json;
 

--- a/build/ArtifactBuilder/AgentType.cs
+++ b/build/ArtifactBuilder/AgentType.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 namespace ArtifactBuilder;
 
 public enum AgentType

--- a/build/ArtifactBuilder/Artifacts/Artifact.cs
+++ b/build/ArtifactBuilder/Artifacts/Artifact.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace ArtifactBuilder.Artifacts;

--- a/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
+++ b/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/Artifacts/DownloadSiteArtifact.cs
+++ b/build/ArtifactBuilder/Artifacts/DownloadSiteArtifact.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
+++ b/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
+++ b/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/Artifacts/ZipArchive.cs
+++ b/build/ArtifactBuilder/Artifacts/ZipArchive.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/build/ArtifactBuilder/FileHelpers.cs
+++ b/build/ArtifactBuilder/FileHelpers.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/ArtifactBuilder/FrameworkAgentComponents.cs
+++ b/build/ArtifactBuilder/FrameworkAgentComponents.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/build/ArtifactBuilder/NuGetHelpers.cs
+++ b/build/ArtifactBuilder/NuGetHelpers.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/build/ArtifactBuilder/NugetPackage.cs
+++ b/build/ArtifactBuilder/NugetPackage.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/build/ArtifactBuilder/PackagingException.cs
+++ b/build/ArtifactBuilder/PackagingException.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace ArtifactBuilder;

--- a/build/ArtifactBuilder/ParsedProductWxsTypes.cs
+++ b/build/ArtifactBuilder/ParsedProductWxsTypes.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/build/ArtifactBuilder/Program.cs
+++ b/build/ArtifactBuilder/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using ArtifactBuilder.Artifacts;
 

--- a/build/ArtifactBuilder/SecurityHelpers.cs
+++ b/build/ArtifactBuilder/SecurityHelpers.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/build/ArtifactBuilder/ValidationHelpers.cs
+++ b/build/ArtifactBuilder/ValidationHelpers.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/CompatibilityDocs.Tests/CompatibilityYamlTests.cs
+++ b/build/CompatibilityDocs.Tests/CompatibilityYamlTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.IO;
 using CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs.Tests/MarkdownRendererTests.cs
+++ b/build/CompatibilityDocs.Tests/MarkdownRendererTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using CompatibilityDocs.Rendering;

--- a/build/CompatibilityDocs.Tests/NoteRendererTests.cs
+++ b/build/CompatibilityDocs.Tests/NoteRendererTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using CompatibilityDocs.Rendering;
 using CompatibilityDocs.Schema;
 using NUnit.Framework;

--- a/build/CompatibilityDocs.Tests/PackageReferenceScannerTests.cs
+++ b/build/CompatibilityDocs.Tests/PackageReferenceScannerTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO;
 using System.Linq;
 using CompatibilityDocs.Derivation;

--- a/build/CompatibilityDocs.Tests/PlatformParserTests.cs
+++ b/build/CompatibilityDocs.Tests/PlatformParserTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using NUnit.Framework;
 
 namespace CompatibilityDocs.Tests;

--- a/build/CompatibilityDocs.Tests/ProjectListLoaderTests.cs
+++ b/build/CompatibilityDocs.Tests/ProjectListLoaderTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO;
 using System.Linq;
 using CompatibilityDocs.Derivation;

--- a/build/CompatibilityDocs.Tests/SchemaLoaderTests.cs
+++ b/build/CompatibilityDocs.Tests/SchemaLoaderTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Linq;
 using CompatibilityDocs.Schema;
 using NUnit.Framework;

--- a/build/CompatibilityDocs.Tests/SchemaValidatorTests.cs
+++ b/build/CompatibilityDocs.Tests/SchemaValidatorTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using CompatibilityDocs.Schema;
 using NUnit.Framework;

--- a/build/CompatibilityDocs.Tests/SmokeTests.cs
+++ b/build/CompatibilityDocs.Tests/SmokeTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using NUnit.Framework;
 
 namespace CompatibilityDocs.Tests;

--- a/build/CompatibilityDocs.Tests/VersionResolverTests.cs
+++ b/build/CompatibilityDocs.Tests/VersionResolverTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using CompatibilityDocs.Derivation;
 using NUnit.Framework;

--- a/build/CompatibilityDocs.Tests/VersionSpecTests.cs
+++ b/build/CompatibilityDocs.Tests/VersionSpecTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using CompatibilityDocs.Schema;
 using NUnit.Framework;

--- a/build/CompatibilityDocs.Tests/VersionSpecYamlConverterTests.cs
+++ b/build/CompatibilityDocs.Tests/VersionSpecYamlConverterTests.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using CompatibilityDocs.Schema;
 using NUnit.Framework;
 using YamlDotNet.Serialization;

--- a/build/CompatibilityDocs/Derivation/PackageRef.cs
+++ b/build/CompatibilityDocs/Derivation/PackageRef.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 namespace CompatibilityDocs.Derivation;
 
 public record PackageRef(string PackageId, string Version, string? Tfm);

--- a/build/CompatibilityDocs/Derivation/PackageReferenceScanner.cs
+++ b/build/CompatibilityDocs/Derivation/PackageReferenceScanner.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Construction;

--- a/build/CompatibilityDocs/Derivation/ProjectListLoader.cs
+++ b/build/CompatibilityDocs/Derivation/ProjectListLoader.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/build/CompatibilityDocs/Derivation/VersionResolver.cs
+++ b/build/CompatibilityDocs/Derivation/VersionResolver.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using NuGet.Versioning;
 

--- a/build/CompatibilityDocs/Platform.cs
+++ b/build/CompatibilityDocs/Platform.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 namespace CompatibilityDocs;
 
 public enum Platform

--- a/build/CompatibilityDocs/PlatformParser.cs
+++ b/build/CompatibilityDocs/PlatformParser.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Text.RegularExpressions;
 

--- a/build/CompatibilityDocs/Program.cs
+++ b/build/CompatibilityDocs/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.IO;
 using System.Linq;

--- a/build/CompatibilityDocs/Rendering/MarkdownRenderer.cs
+++ b/build/CompatibilityDocs/Rendering/MarkdownRenderer.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/build/CompatibilityDocs/Rendering/NoteRenderer.cs
+++ b/build/CompatibilityDocs/Rendering/NoteRenderer.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using CompatibilityDocs.Schema;
 

--- a/build/CompatibilityDocs/RepoRootLocator.cs
+++ b/build/CompatibilityDocs/RepoRootLocator.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.IO;
 

--- a/build/CompatibilityDocs/Schema/Category.cs
+++ b/build/CompatibilityDocs/Schema/Category.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/CompatibilityModel.cs
+++ b/build/CompatibilityDocs/Schema/CompatibilityModel.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/Library.cs
+++ b/build/CompatibilityDocs/Schema/Library.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/Note.cs
+++ b/build/CompatibilityDocs/Schema/Note.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/Package.cs
+++ b/build/CompatibilityDocs/Schema/Package.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/SchemaLoader.cs
+++ b/build/CompatibilityDocs/Schema/SchemaLoader.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;

--- a/build/CompatibilityDocs/Schema/SchemaValidationException.cs
+++ b/build/CompatibilityDocs/Schema/SchemaValidationException.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/SchemaValidator.cs
+++ b/build/CompatibilityDocs/Schema/SchemaValidator.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 
 namespace CompatibilityDocs.Schema;

--- a/build/CompatibilityDocs/Schema/VersionSpec.cs
+++ b/build/CompatibilityDocs/Schema/VersionSpec.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/build/CompatibilityDocs/Schema/VersionSpecYamlConverter.cs
+++ b/build/CompatibilityDocs/Schema/VersionSpecYamlConverter.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using YamlDotNet.Core;

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+  <!-- Enforce the New Relic copyright header (SA1633 et al. via Common.ruleset) on the build-tools
+       projects, matching src/ and tests/. StyleCop.props sets the _UsesStyleCop marker that the root
+       Directory.Build.targets keys off to add the StyleCop.Analyzers reference. -->
+  <Import Project="$(MSBuildThisFileDirectory)StyleCop.props" />
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>

--- a/build/Dotty/CsprojHandler.cs
+++ b/build/Dotty/CsprojHandler.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/build/Dotty/NugetVersionData.cs
+++ b/build/Dotty/NugetVersionData.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 

--- a/build/Dotty/PackageInfo.cs
+++ b/build/Dotty/PackageInfo.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/build/Dotty/PackageReference.cs
+++ b/build/Dotty/PackageReference.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;

--- a/build/Dotty/Program.cs
+++ b/build/Dotty/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/build/Dotty/ProjectInfo.cs
+++ b/build/Dotty/ProjectInfo.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Text.Json.Serialization;
 
 namespace Dotty;

--- a/build/Dotty/ProjectPackageInfo.cs
+++ b/build/Dotty/ProjectPackageInfo.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace Dotty;

--- a/build/Linux/test/applications/custom_attributes/Program.cs
+++ b/build/Linux/test/applications/custom_attributes/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace custom_attributes

--- a/build/Linux/test/applications/custom_xml/Program.cs
+++ b/build/Linux/test/applications/custom_xml/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace custom_xml

--- a/build/Linux/test/applications/http_client_test/Program.cs
+++ b/build/Linux/test/applications/http_client_test/Program.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace http_client_test

--- a/build/NewRelic.NuGetHelper/Utils.cs
+++ b/build/NewRelic.NuGetHelper/Utils.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using NuGet;
 
 namespace NewRelic.NuGetHelper;

--- a/build/NugetValidator/Configuration.cs
+++ b/build/NugetValidator/Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace NugetValidator;

--- a/build/NugetValidator/ConsoleNugetLogger.cs
+++ b/build/NugetValidator/ConsoleNugetLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using NuGet.Common;

--- a/build/NugetValidator/ExitCode.cs
+++ b/build/NugetValidator/ExitCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace NugetValidator;

--- a/build/NugetValidator/Options.cs
+++ b/build/NugetValidator/Options.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using CommandLine;

--- a/build/NugetValidator/Program.cs
+++ b/build/NugetValidator/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using CommandLine;

--- a/build/NugetVersionDeprecator/AgentRelease.cs
+++ b/build/NugetVersionDeprecator/AgentRelease.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using Newtonsoft.Json;

--- a/build/NugetVersionDeprecator/Configuration.cs
+++ b/build/NugetVersionDeprecator/Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace NugetVersionDeprecator;

--- a/build/NugetVersionDeprecator/ExitCode.cs
+++ b/build/NugetVersionDeprecator/ExitCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace NugetVersionDeprecator;

--- a/build/NugetVersionDeprecator/Options.cs
+++ b/build/NugetVersionDeprecator/Options.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using CommandLine;

--- a/build/NugetVersionDeprecator/PackageDeprecationInfo.cs
+++ b/build/NugetVersionDeprecator/PackageDeprecationInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 public class PackageDeprecationInfo

--- a/build/NugetVersionDeprecator/Program.cs
+++ b/build/NugetVersionDeprecator/Program.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text;


### PR DESCRIPTION
The BuildTools solution has been missing the reference to `StyleCop.props` that the other solutions have, and therefore most of the source files in it are missing our copyright header.  (Some did have it, but with the wrong date.)  This PR fixes both issues.