### PR TITLE
ci: run full CI suite on Dependabot nuget pull requests

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -38,6 +38,15 @@ env:
   tools_path: ${{ github.workspace }}\build\Tools
   DOTNET_NOLOGO: true
 
+  # Dependabot Full CI Dispatch relaunches this workflow via workflow_dispatch against a
+  # dependabot/* branch. Those runs need the build and the test suites, not a signed MSI or
+  # signed Linux packages, so everything that touches signing material is skipped for them --
+  # keeping the signing cert and GPG key off a runner that just executed build logic from a
+  # package version nobody has reviewed. Steps gate on `env.skip_signing != 'true'`; the
+  # packaging jobs gate on build-fullagent-msi's skipSigning output, since job-level `if`
+  # cannot see `env`. Never true for a pull_request run: ref_name is <pr>/merge there.
+  skip_signing: ${{ github.event_name == 'workflow_dispatch' && startsWith(github.ref_name, 'dependabot/') }}
+
 jobs:
   check-modified-files:
     name: Check if source files were modified, skip remaining jobs if not
@@ -86,6 +95,8 @@ jobs:
 
     outputs:
       agentVersion: ${{ steps.agentVersion.outputs.version }}
+      # Re-exported so the packaging jobs can gate on it: job-level `if` cannot read `env`.
+      skipSigning: ${{ env.skip_signing }}
 
     steps:
       - name: Checkout
@@ -133,8 +144,11 @@ jobs:
             ${{ github.workspace }}\src\Agent\newrelichome_x86_coreclr
           if-no-files-found: error
 
+      # Signing and MSI build are skipped for the Dependabot dispatch (see note above the jobs).
+      # The build and homefolders artifact above are all the test suites need.
       - name: Convert Code Signing Certificate Into File
         id: write_cert
+        if: env.skip_signing != 'true'
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
           $bytes = [Convert]::FromBase64String('${{ secrets.SIGNING_CERT }}')
@@ -143,6 +157,7 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
+        if: env.skip_signing != 'true'
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
@@ -150,21 +165,25 @@ jobs:
 
 
       - name: Add msbuild to PATH (required for MsiInstaller build)
+        if: env.skip_signing != 'true'
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: Build MsiInstaller.sln x86
+        if: env.skip_signing != 'true'
         run: |
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}
         shell: powershell
 
       - name: Build MsiInstaller.sln x64
+        if: env.skip_signing != 'true'
         run: |
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}
         shell: powershell
 
       - name: Archive msi _build Artifacts
+        if: env.skip_signing != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: msi-build-folder-artifacts
@@ -1032,6 +1051,10 @@ jobs:
     needs: build-fullagent-msi
     name: Create RPM Package
     runs-on: ubuntu-22.04
+    # Skipped for the Dependabot dispatch: signs with NEW_GPG_KEY, and needs an MSI artifact
+    # that run does not produce. Compared against 'false' so an unresolved output skips this
+    # job rather than running it with the signing key.
+    if: needs.build-fullagent-msi.outputs.skipSigning == 'false'
 
     steps:
       - name: Harden Runner
@@ -1097,6 +1120,10 @@ jobs:
     needs: build-fullagent-msi
     name: Create Debian package
     runs-on: ubuntu-22.04
+    # Skipped for the Dependabot dispatch: signs with NEW_GPG_KEY, and needs an MSI artifact
+    # that run does not produce. Compared against 'false' so an unresolved output skips this
+    # job rather than running it with the signing key.
+    if: needs.build-fullagent-msi.outputs.skipSigning == 'false'
 
     steps:
       - name: Harden Runner
@@ -1148,6 +1175,8 @@ jobs:
     needs: [create-package-rpm, create-package-deb]
     name: Run ArtifactBuilder
     runs-on: windows-2022
+    # No explicit gate needed: both packaging jobs it needs are skipped for the Dependabot
+    # dispatch, which skips this job with them.
 
     steps:
       - name: Install latest .NET 10 SDK

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -73,9 +73,12 @@ jobs:
     needs:
       - check-modified-files
       - shellcheck
-    # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well
+    # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well.
+    # workflow_dispatch is exempt from the Dependabot exclusion: Dependabot Full CI Dispatch
+    # relaunches this workflow via workflow_dispatch against a Dependabot branch, and that run is
+    # not a Dependabot event, so it has full access to secrets and must not be skipped.
     # run this job if source files were modified, or if triggered by a release, a manual execution or schedule
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    if: (github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]') && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
 
     env:
       fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln
@@ -190,7 +193,7 @@ jobs:
   get-test-namespaces:
     name: Get Test Namespaces
     needs: check-modified-files
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    if: (github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]') && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     outputs:
       integration-namespaces: ${{ steps.compute.outputs.integration }}

--- a/.github/workflows/dependabot_ci_dispatch.yml
+++ b/.github/workflows/dependabot_ci_dispatch.yml
@@ -17,10 +17,11 @@
 #     `gh workflow run --ref <branch>` reads workflow definitions from that
 #     branch, and the github-actions ecosystem is the one group that modifies
 #     files under .github/workflows. Review those by hand.
-#   - The dispatched build does execute MSBuild targets, analyzers and source
-#     generators shipped inside the updated packages, with secrets present.
-#     That is the same code the scheduled All Solutions Build already runs
-#     against the same packages after the PR merges; this only runs it sooner.
+#   - The dispatched build executes MSBuild targets, analyzers and build tasks
+#     from a package version nobody has reviewed yet, so All Solutions Build
+#     skips its signing steps and the RPM/DEB/ArtifactBuilder jobs for
+#     dependabot/* branches. TEST_SECRETS is still present on the test runners:
+#     accepted, since those are test-account credentials, not signing material.
 
 name: Dependabot Full CI Dispatch
 

--- a/.github/workflows/dependabot_ci_dispatch.yml
+++ b/.github/workflows/dependabot_ci_dispatch.yml
@@ -1,0 +1,61 @@
+# Runs the full CI suite for Dependabot pull requests.
+#
+# Dependabot-triggered `pull_request` runs get a read-only GITHUB_TOKEN and no
+# Actions secrets, so All Solutions Build (which needs signing and test
+# secrets) skips itself for Dependabot. `workflow_run` is not subject to those
+# restrictions: it executes the workflow definition from the default branch
+# with normal Actions secrets, so it can relaunch the suite via
+# workflow_dispatch against the Dependabot branch.
+#
+# Security notes:
+#   - This workflow never checks out the pull request branch. It reads event
+#     metadata only, so no pull request content executes in this run.
+#   - The `if` below requires the head repository to be this repository, which
+#     structurally excludes every fork (and therefore every community) pull
+#     request: Dependabot branches live in this repo, fork PRs never do.
+#   - `dependabot/github_actions/*` branches are deliberately excluded.
+#     `gh workflow run --ref <branch>` reads workflow definitions from that
+#     branch, and the github-actions ecosystem is the one group that modifies
+#     files under .github/workflows. Review those by hand.
+#   - The dispatched build does execute MSBuild targets, analyzers and source
+#     generators shipped inside the updated packages, with secrets present.
+#     That is the same code the scheduled All Solutions Build already runs
+#     against the same packages after the PR merges; this only runs it sooner.
+
+name: Dependabot Full CI Dispatch
+
+on:
+  workflow_run:
+    workflows: ["Dependabot Full CI Trigger"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    name: Dispatch All Solutions Build for the Dependabot branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/nuget/')
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Dispatch All Solutions Build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed through the environment rather than interpolated into the
+          # script body, so a branch name can never be treated as shell syntax.
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Dispatching All Solutions Build against $BRANCH"
+          gh workflow run all_solutions.yml --repo "$REPO" --ref "$BRANCH"

--- a/.github/workflows/dependabot_ci_dispatch.yml
+++ b/.github/workflows/dependabot_ci_dispatch.yml
@@ -1,11 +1,11 @@
 # Runs the full CI suite for Dependabot pull requests.
 #
 # Dependabot-triggered `pull_request` runs get a read-only GITHUB_TOKEN and no
-# Actions secrets, so All Solutions Build (which needs signing and test
-# secrets) skips itself for Dependabot. `workflow_run` is not subject to those
-# restrictions: it executes the workflow definition from the default branch
-# with normal Actions secrets, so it can relaunch the suite via
-# workflow_dispatch against the Dependabot branch.
+# Actions secrets, so both All Solutions Build (which needs signing and test
+# secrets) and Unit Tests and Code Coverage skip themselves for Dependabot.
+# `workflow_run` is not subject to those restrictions: it executes the workflow
+# definition from the default branch with normal Actions secrets, so it can
+# relaunch both workflows via workflow_dispatch against the Dependabot branch.
 #
 # Security notes:
 #   - This workflow never checks out the pull request branch. It reads event
@@ -49,7 +49,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
-      - name: Dispatch All Solutions Build
+      - name: Dispatch CI workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Passed through the environment rather than interpolated into the
@@ -57,5 +57,19 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           REPO: ${{ github.repository }}
         run: |
-          echo "Dispatching All Solutions Build against $BRANCH"
-          gh workflow run all_solutions.yml --repo "$REPO" --ref "$BRANCH"
+          # Attempt every dispatch even if an earlier one fails, so a transient
+          # API error on one workflow does not silently skip the others, then
+          # fail the step if any of them did not launch.
+          failed=""
+          for wf in all_solutions.yml unit_tests.yml; do
+            echo "Dispatching $wf against $BRANCH"
+            if ! gh workflow run "$wf" --repo "$REPO" --ref "$BRANCH"; then
+              echo "::error::Failed to dispatch $wf against $BRANCH"
+              failed="$failed $wf"
+            fi
+          done
+
+          if [ -n "$failed" ]; then
+            echo "Dispatch failed for:$failed"
+            exit 1
+          fi

--- a/.github/workflows/dependabot_ci_status.yml
+++ b/.github/workflows/dependabot_ci_status.yml
@@ -1,0 +1,71 @@
+# Reports the result of a Dependabot Full CI Dispatch run back onto the
+# Dependabot pull request as a commit status.
+#
+# Runs dispatched via workflow_dispatch are not attached to a pull request, so
+# their result is otherwise invisible from the PR. This posts a commit status
+# on the branch head SHA (which for a dispatched run is the PR head) so
+# reviewers can see, and click through to, the full CI result.
+#
+# This status is informational and must NOT be added to branch protection as a
+# required check: required contexts apply to every pull request, and pull
+# requests from actors other than Dependabot never receive this status, so
+# requiring it would block them indefinitely.
+
+name: Dependabot Full CI Status
+
+on:
+  workflow_run:
+    workflows: ["All Solutions Build"]
+    types: [completed]
+
+permissions:
+  statuses: write
+
+jobs:
+  report:
+    name: Report full CI result on the Dependabot pull request
+    runs-on: ubuntu-latest
+    # Only report for the dispatched runs this feature creates: a
+    # workflow_dispatch run on a dependabot/nuget/* branch.
+    if: >-
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/nuget/')
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Post commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          # A cancelled run is usually a superseded run: Dependabot force-pushes
+          # to rebase its branches, and All Solutions Build cancels in-progress
+          # runs for the same ref. Reporting failure for those would be wrong,
+          # and a replacement run is already on its way.
+          case "$CONCLUSION" in
+            success)
+              state=success
+              ;;
+            cancelled|skipped)
+              echo "Conclusion '$CONCLUSION' is not a result worth reporting; skipping."
+              exit 0
+              ;;
+            *)
+              state=failure
+              ;;
+          esac
+
+          echo "Reporting '$state' for $HEAD_SHA"
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context="full-ci (dependabot)" \
+            -f target_url="$RUN_URL" \
+            -f description="All Solutions Build: $CONCLUSION"

--- a/.github/workflows/dependabot_ci_status.yml
+++ b/.github/workflows/dependabot_ci_status.yml
@@ -4,18 +4,19 @@
 # Runs dispatched via workflow_dispatch are not attached to a pull request, so
 # their result is otherwise invisible from the PR. This posts a commit status
 # on the branch head SHA (which for a dispatched run is the PR head) so
-# reviewers can see, and click through to, the full CI result.
+# reviewers can see, and click through to, the full CI result. One status is
+# posted per dispatched workflow, distinguished by the workflow name.
 #
-# This status is informational and must NOT be added to branch protection as a
-# required check: required contexts apply to every pull request, and pull
-# requests from actors other than Dependabot never receive this status, so
-# requiring it would block them indefinitely.
+# These statuses are informational and must NOT be added to branch protection
+# as required checks: required contexts apply to every pull request, and pull
+# requests from actors other than Dependabot never receive them, so requiring
+# them would block those pull requests indefinitely.
 
 name: Dependabot Full CI Status
 
 on:
   workflow_run:
-    workflows: ["All Solutions Build"]
+    workflows: ["All Solutions Build", "Unit Tests and Code Coverage"]
     types: [completed]
 
 permissions:
@@ -45,11 +46,12 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           # A cancelled run is usually a superseded run: Dependabot force-pushes
-          # to rebase its branches, and All Solutions Build cancels in-progress
-          # runs for the same ref. Reporting failure for those would be wrong,
-          # and a replacement run is already on its way.
+          # to rebase its branches, and both dispatched workflows cancel
+          # in-progress runs for the same ref. Reporting failure for those would
+          # be wrong, and a replacement run is already on its way.
           case "$CONCLUSION" in
             success)
               state=success
@@ -63,9 +65,11 @@ jobs:
               ;;
           esac
 
-          echo "Reporting '$state' for $HEAD_SHA"
+          # One context per dispatched workflow, so All Solutions Build and Unit
+          # Tests report independently instead of overwriting each other.
+          echo "Reporting '$state' for $HEAD_SHA ($WORKFLOW_NAME)"
           gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$state" \
-            -f context="full-ci (dependabot)" \
+            -f context="full-ci (dependabot) / $WORKFLOW_NAME" \
             -f target_url="$RUN_URL" \
-            -f description="All Solutions Build: $CONCLUSION"
+            -f description="$WORKFLOW_NAME: $CONCLUSION"

--- a/.github/workflows/dependabot_ci_status.yml
+++ b/.github/workflows/dependabot_ci_status.yml
@@ -26,11 +26,17 @@ jobs:
   report:
     name: Report full CI result on the Dependabot pull request
     runs-on: ubuntu-latest
-    # Only report for the dispatched runs this feature creates: a
-    # workflow_dispatch run on a dependabot/nuget/* branch.
+    # Mirror the Dependabot Full CI Dispatch gate, so only a run that dispatcher
+    # created can produce a "full-ci (dependabot)" status. The actor check is
+    # what stops someone pushing a dependabot/nuget/* branch, dispatching it by
+    # hand, and posting a status to a SHA of their choosing. Fail-closed: if a
+    # Dependabot PR gets no status, check the run's actor fields first.
     if: >-
       github.event.workflow_run.event == 'workflow_dispatch' &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/nuget/')
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/nuget/') &&
+      (github.event.workflow_run.actor.login == 'dependabot[bot]' ||
+       github.event.workflow_run.triggering_actor.login == 'dependabot[bot]')
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/dependabot_ci_trigger.yml
+++ b/.github/workflows/dependabot_ci_trigger.yml
@@ -34,4 +34,4 @@ jobs:
           echo "Dependabot pull request #${{ github.event.pull_request.number }}"
           echo "Head branch: ${{ github.event.pull_request.head.ref }}"
           echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-          echo "Dependabot Full CI Dispatch will launch All Solutions Build for this branch."
+          echo "Dependabot Full CI Dispatch will launch All Solutions Build and Unit Tests for this branch."

--- a/.github/workflows/dependabot_ci_trigger.yml
+++ b/.github/workflows/dependabot_ci_trigger.yml
@@ -1,0 +1,37 @@
+# Workflows triggered by Dependabot from a `pull_request` event receive a
+# read-only GITHUB_TOKEN and no access to GitHub Actions secrets (only
+# Dependabot secrets), so they cannot run the full CI suite. This workflow
+# exists solely so that its completion emits a `workflow_run` event, which
+# Dependabot Full CI Dispatch listens for. That dispatcher runs in the context
+# of the default branch, where normal Actions secrets are available.
+#
+# This workflow intentionally does no work and requires no permissions.
+
+name: Dependabot Full CI Trigger
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "feature/**"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  signal:
+    name: Signal that a Dependabot pull request needs the full CI suite
+    # Only Dependabot pull requests need this hop. For any other actor the
+    # normal PR workflows already run with full secrets.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record pull request details
+        run: |
+          echo "Dependabot pull request #${{ github.event.pull_request.number }}"
+          echo "Head branch: ${{ github.event.pull_request.head.ref }}"
+          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "Dependabot Full CI Dispatch will launch All Solutions Build for this branch."

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,9 +40,12 @@ jobs:
     needs: check-modified-files
     runs-on: windows-latest
 
-    # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well
+    # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well.
+    # workflow_dispatch is exempt from the Dependabot exclusion: Dependabot Full CI Dispatch
+    # relaunches this workflow via workflow_dispatch against a Dependabot branch, and that run is
+    # not a Dependabot event, so it has full access to secrets and must not be skipped.
     # run this job if source files were modified, or if triggered by a manual execution or by a push (not a PR)
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' ||  github.event_name == 'workflow_dispatch' || github.event_name == 'push')
+    if: (github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]') && (needs.check-modified-files.outputs.source-files-changed == 'true' ||  github.event_name == 'workflow_dispatch' || github.event_name == 'push')
 
     env:
       test_results_path: tests\TestResults


### PR DESCRIPTION
Dependabot PRs get a read-only token and no Actions secrets, so All Solutions Build and Unit Tests both skip themselves -- which is how the OTel 1.17 transitive-dependency break (#3710) reached main and was only caught by integration tests days later. This adds a `workflow_run` hop that relaunches both workflows for `dependabot/nuget/*` branches without needing a duplicate set of Dependabot secrets.

- `dependabot_ci_trigger.yml` -- no-op workflow on the Dependabot PR; exists only so its completion emits `workflow_run`. No permissions.
- `dependabot_ci_dispatch.yml` -- runs on the default branch (so it has secrets), never checks out PR content, and dispatches `all_solutions.yml` and `unit_tests.yml` against the Dependabot branch. Gated on actor `dependabot[bot]` + `head_repository == this repo` (structurally excludes all fork/community PRs) + `dependabot/nuget/*` (excludes `github_actions` branches, since `--ref` reads workflow definitions from the branch). Attempts every dispatch even if one fails, then fails the step.
- `dependabot_ci_status.yml` -- posts one `full-ci (dependabot) / <workflow name>` commit status per dispatched workflow on the PR head. Skips `cancelled`/`skipped` so force-push rebases do not report false failures. Gate mirrors the dispatcher, including the actor check, so only a dispatcher-created run can post one of these. Informational only; these must not become required checks, since non-Dependabot PRs never receive them.
- `all_solutions.yml`, `unit_tests.yml` -- `workflow_dispatch` is now exempt from the Dependabot actor exclusion, so the dispatched runs are not skipped. Without this the dispatch would silently no-op if `github.actor` inherits `dependabot[bot]`.
- `all_solutions.yml` -- `env.skip_signing` (true only for `workflow_dispatch` against a `dependabot/*` ref) skips cert import, the MsiInstaller build, and the GPG-signing RPM/DEB jobs; ArtifactBuilder skips with them. Build, `homefolders`, and all test suites still run in full.

Notes for review:
- `workflow_run` only fires when the workflow file is on the default branch, so this cannot be exercised until it merges -- not by this PR's CI either, since only `.github/` files changed. The first Dependabot nuget PR after merge is the real test.
- The dispatcher run is created for every PR and skips instantly for non-Dependabot ones (there is no actor filter on `on:`).
- The dispatched unit-test run will upload coverage to Codecov for the Dependabot PR head, which does not happen today.
- Residual risk: the dispatched build runs package-supplied MSBuild targets and analyzers pre-review, with `TEST_SECRETS` present. Accepted -- test credentials, not release-signing material, which is why the signing cert and GPG key are excluded.
