### PR TITLE
fix: Prevent double RUM script injection in ASP.NET Core 6+ responses

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -315,7 +315,7 @@ public class Agent : IAgent // any changes to api, update the interface in exten
         return script == null ? null : new BrowserMonitoringStreamInjector(() => script, stream, encoding);
     }
 
-    public async Task TryInjectBrowserScriptAsync(string contentType, string requestPath, byte[] buffer, Stream baseStream)
+    public async Task<bool> TryInjectBrowserScriptAsync(string contentType, string requestPath, byte[] buffer, Stream baseStream)
     {
         var transaction = _transactionService.GetCurrentInternalTransaction();
 
@@ -333,9 +333,11 @@ public class Agent : IAgent // any changes to api, update the interface in exten
             {
                 transaction?.LogFinest("Skipping RUM Injection: Base stream was disposed.");
             }
+
+            return false;
         }
-        else
-            await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, rumBytes, transaction);
+
+        return await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, rumBytes, transaction);
     }
 
     private string TryGetRUMScriptInternal(string contentType, string requestPath)

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
@@ -17,8 +17,8 @@ public static class BrowserScriptInjectionHelper
     /// <param name="baseStream"></param>
     /// <param name="rumBytes"></param>
     /// <param name="transaction"></param>
-    /// <returns></returns>
-    public static async Task InjectBrowserScriptAsync(byte[] buffer, Stream baseStream, byte[] rumBytes, ITransaction transaction)
+    /// <returns>True if the RUM script was actually written into the stream; false if the buffer was written through unmodified.</returns>
+    public static async Task<bool> InjectBrowserScriptAsync(byte[] buffer, Stream baseStream, byte[] rumBytes, ITransaction transaction)
     {
         var index = BrowserScriptInjectionIndexHelper.TryFindInjectionIndex(buffer);
         if (index == -1)
@@ -26,33 +26,36 @@ public static class BrowserScriptInjectionHelper
             // not found, can't inject anything
             transaction?.LogFinest("Skipping RUM Injection: No suitable location found to inject script.");
             await TryWriteStreamAsync(baseStream, buffer, 0, buffer.Length, transaction);
-            return;
+            return false;
         }
 
         transaction?.LogFinest($"Injecting RUM script at byte index {index}.");
 
-        if (index < buffer.Length) // validate index is less than buffer length
-        {
-            // Write everything up to the insertion index
-            await TryWriteStreamAsync(baseStream, buffer, 0, index, transaction);
-            // Write the RUM script
-            await TryWriteStreamAsync(baseStream, rumBytes, 0, rumBytes.Length, transaction);
-            // Write the rest of the doc, starting after the insertion index
-            await TryWriteStreamAsync(baseStream, buffer, index, buffer.Length - index, transaction);
-        }
-        else
-            transaction?.LogFinest($"Skipping RUM Injection: Insertion index was invalid.");
+        // TryFindInjectionIndex returns an index within the buffer, or an index equal to the
+        // buffer length when the matched tag ends exactly at the end of this buffer - in which
+        // case the script is appended and the trailing write covers zero bytes.
+
+        // Write everything up to the insertion index
+        await TryWriteStreamAsync(baseStream, buffer, 0, index, transaction);
+        // Write the RUM script
+        var scriptWritten = await TryWriteStreamAsync(baseStream, rumBytes, 0, rumBytes.Length, transaction);
+        // Write the rest of the doc, starting after the insertion index
+        await TryWriteStreamAsync(baseStream, buffer, index, buffer.Length - index, transaction);
+
+        return scriptWritten;
     }
 
-    private static async Task TryWriteStreamAsync(Stream stream, byte[] buffer, int offset, int count, ITransaction transaction)
+    private static async Task<bool> TryWriteStreamAsync(Stream stream, byte[] buffer, int offset, int count, ITransaction transaction)
     {
         try
         {
             await stream.WriteAsync(buffer, offset, count);
+            return true;
         }
         catch (ObjectDisposedException)
         {
             transaction?.LogFinest("RUM Injection aborted: Stream was disposed.");
+            return false;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgent.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgent.cs
@@ -103,8 +103,8 @@ public interface IAgent : IAgentExperimental
     /// <param name="requestPath">The path of the request</param>
     /// <param name="buffer">A UTF-8 encoded buffer of the content for this request</param>
     /// <param name="baseStream">The stream into which the script (and buffer) should be injected</param>
-    /// <returns></returns>
-    Task TryInjectBrowserScriptAsync(string contentType, string requestPath, byte[] buffer, Stream baseStream);
+    /// <returns>True if the browser script was injected into the stream; false if it was not (e.g. no script was available, or no suitable injection location was found).</returns>
+    Task<bool> TryInjectBrowserScriptAsync(string contentType, string requestPath, byte[] buffer, Stream baseStream);
 
     /// <summary>
     /// Returns the Trace Metadata of the currently executing transaction.

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
@@ -136,15 +136,18 @@ public class BrowserInjectingStreamWrapper : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         // pass through without modification if we're already in the middle of injecting
+        // don't inject if the script has already been injected into this response
         // don't inject if the response isn't an HTML response
-        if (_context != null && !Disabled && !CurrentlyInjecting() && IsHtmlResponse())
+        if (_context != null && !Disabled && !CurrentlyInjecting() && IsHtmlResponse() && !WasScriptInjected())
         {
             try
             {
                 // Set a flag on the context to indicate we're in the middle of injecting - prevents multiple recursions when response compression is in use
                 StartInjecting();
-                _agent.TryInjectBrowserScriptAsync(_context.Response?.ContentType, _context.Request?.Path, buffer, _baseStream)
+                var injected = _agent.TryInjectBrowserScriptAsync(_context.Response?.ContentType, _context.Request?.Path, buffer, _baseStream)
                     .GetAwaiter().GetResult();
+                if (injected)
+                    MarkScriptInjected();
             }
             finally
             {
@@ -169,14 +172,17 @@ public class BrowserInjectingStreamWrapper : Stream
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
         // pass through without modification if we're already in the middle of injecting
+        // don't inject if the script has already been injected into this response
         // don't inject if the response isn't an HTML response
-        if (_context != null & !Disabled && !CurrentlyInjecting() && IsHtmlResponse())
+        if (_context != null && !Disabled && !CurrentlyInjecting() && IsHtmlResponse() && !WasScriptInjected())
         {
             try
             {
                 // Set a flag on the context to indicate we're in the middle of injecting - prevents multiple recursions when response compression is in use
                 StartInjecting();
-                await _agent.TryInjectBrowserScriptAsync(_context.Response?.ContentType, _context.Request?.Path, buffer.ToArray(), _baseStream);
+                var injected = await _agent.TryInjectBrowserScriptAsync(_context.Response?.ContentType, _context.Request?.Path, buffer.ToArray(), _baseStream);
+                if (injected)
+                    MarkScriptInjected();
             }
             finally
             {
@@ -200,6 +206,39 @@ public class BrowserInjectingStreamWrapper : Stream
     }
 
     private const string InjectingRUM = "InjectingRUM";
+
+    // Latches the first successful injection so later writes in the same response pass through.
+    // Stored on the shared HttpContext.Items rather than in an instance field because response
+    // compression puts a second, independent BrowserInjectingStreamWrapper on the same response
+    // (ResponseCompressionBodyOnWriteWrapper wraps the compression stream), and an instance field
+    // would only latch whichever instance performed the injection.
+    private const string RumScriptInjected = "RumScriptInjected";
+
+    private bool WasScriptInjected()
+    {
+        try
+        {
+            return _context?.Items.ContainsKey(RumScriptInjected) ?? false;
+        }
+        catch (ObjectDisposedException)
+        {
+            _agent.Logger.Log(Level.Finest, "BrowserInjectingStreamWrapper: Unable to check for RUM script injected flag, _context.Items was disposed.");
+            return false;
+        }
+    }
+
+    private void MarkScriptInjected()
+    {
+        try
+        {
+            if (_context != null)
+                _context.Items[RumScriptInjected] = null;
+        }
+        catch (ObjectDisposedException)
+        {
+            _agent.Logger.Log(Level.Finest, "BrowserInjectingStreamWrapper: Unable to insert RUM script injected flag, _context.Items was disposed.");
+        }
+    }
 
     private void FinishInjecting()
     {

--- a/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Pages/LargeHead.cshtml
+++ b/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Pages/LargeHead.cshtml
@@ -1,0 +1,27 @@
+@page
+@{
+    Layout = null;
+}
+@*
+    Page for BrowserAgentAutoInjectionLargeHead (GitHub issue #3725). The oversized
+    <head> is the point: it must exceed the response writer's buffer so that <body>
+    lands in a later write to the response body than <head>, which is what used to
+    make the agent inject the RUM script twice. Do not shrink the filler loop or use
+    a shared layout - either change makes the test pass for the wrong reason.
+
+    The injection anchor here is the charset <meta> tag (the agent prefers the last
+    charset / x-ua-compatible meta tag in the head over the opening <head> tag), so
+    keep that tag ahead of the filler.
+*@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="utf-8" />
+<title>Large Head</title>
+<style>
+@for (var i = 0; i < 8000; i++)
+{
+    @Html.Raw($".filler-{i} {{ color: #abcdef; content: \"padding padding padding padding padding\"; }}\n")
+}
+</style>
+</head><body>
+Large head page
+</body></html>

--- a/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Program.cs
@@ -61,6 +61,16 @@ public class Program
                 }));
         });
 
+        // Writes an HTML document in two explicit writes, split exactly on the closing '>'
+        // of the opening <head> tag. That puts the RUM injection index exactly at the end of
+        // the first write's buffer - see BrowserAgentAutoInjectionSplitHead.
+        app.MapGet("/splithead", async context =>
+        {
+            context.Response.ContentType = "text/html; charset=utf-8";
+            await context.Response.WriteAsync("<html><head>");
+            await context.Response.WriteAsync("</head><body>split head page</body></html>");
+        });
+
         app.Urls.Add($"http://127.0.0.1:{_port}");
 
         var task = app.RunAsync(ct.Token);

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/JavaScriptAgent.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/JavaScriptAgent.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -30,5 +31,29 @@ public static class JavaScriptAgent
         var match = matches[1]; //specifically look for the 2nd match. The first match contains settings. The 2nd match contains the actual browser agent.
         Assert.True(match.Success, "Did not find a match for the JavaScript agent config in the provided page.");
         return match.Groups[1].Value;
+    }
+
+    /// <summary>
+    /// Returns the offset of every non-overlapping NREUM.info block in the source. Exactly one
+    /// offset means the browser agent script was injected exactly once; more than one means the
+    /// agent injected it multiple times into a single response.
+    /// </summary>
+    public static List<int> FindInfoBlockOffsets(string source)
+    {
+        const string marker = "NREUM.info";
+
+        var offsets = new List<int>();
+        var searchStart = 0;
+        while (true)
+        {
+            var index = source.IndexOf(marker, searchStart, StringComparison.Ordinal);
+            if (index < 0)
+                break;
+
+            offsets.Add(index);
+            searchStart = index + marker.Length;
+        }
+
+        return offsets;
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjectionLargeHead.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjectionLargeHead.cs
@@ -1,0 +1,150 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Text;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures;
+
+// Regression test for double RUM injection in the ASP.NET Core 6+ browser injector
+// (GitHub issue #3725).
+//
+// When the <head> section of an HTML response is larger than the response writer's internal
+// buffer, the response body reaches the wrapped stream across more than one Write/WriteAsync
+// call. BrowserInjectingStreamWrapper evaluates each write independently, so without a
+// once-per-response latch the script is injected twice: the first write contains the <head>
+// anchor, and a later write contains "<body" but no "<head", so the FindIndexBeforeBodyTag
+// fallback fires and injects again. Writes containing neither anchor are passed through
+// untouched, so the count tops out at two. The .NET Framework path was never affected -
+// BrowserMonitoringStreamInjector switches to PassThroughStreamWriter after the first
+// successful injection.
+//
+// Run both with and without response compression. With compression enabled there are TWO
+// BrowserInjectingStreamWrapper instances for one response - the middleware wraps the response
+// body, and ResponseCompressionBodyOnWriteWrapper separately wraps the compression stream - so
+// the compressed variant covers the multi-write path through that second instance, which no
+// existing test did. The latch lives in HttpContext.Items so both instances observe it.
+public abstract class BrowserAgentAutoInjectionLargeHeadBase : NewRelicIntegrationTest<BasicAspNetCoreRazorApplicationFixture>
+{
+    private readonly BasicAspNetCoreRazorApplicationFixture _fixture;
+    private string _htmlContent;
+
+    protected BrowserAgentAutoInjectionLargeHeadBase(BasicAspNetCoreRazorApplicationFixture fixture, ITestOutputHelper output, bool enableResponseCompression)
+        : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.AutoInstrumentBrowserMonitoring(true);
+                configModifier.BrowserMonitoringEnableAttributes(true);
+                configModifier.EnableAspNetCore6PlusBrowserInjection(true);
+                configModifier.BrowserMonitoringLoader("rum");
+            },
+            exerciseApplication: () =>
+            {
+                _htmlContent = _fixture.Get("LargeHead");
+            }
+        );
+
+        _fixture.SetResponseCompression(enableResponseCompression);
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void RumScriptIsInjectedOnlyOnce()
+    {
+        // This test project is xUnit, so NrAssert.Multiple (which delegates to NUnit's
+        // Assert.Multiple) cannot aggregate these failures - the first failing assert throws.
+        // They are ordered so an infrastructure problem surfaces as its own distinct failure
+        // before the interesting count assertion.
+        Assert.NotNull(_htmlContent);
+
+        var connectResponseData = _fixture.AgentLog.GetConnectResponseData();
+        var jsAgentFromConnectResponse = connectResponseData.JsAgentLoader;
+        var jsAgentFromHtmlContent = JavaScriptAgent.GetJavaScriptAgentScriptFromSource(_htmlContent);
+
+        // confirm injection happened at all
+        Assert.Equal(jsAgentFromConnectResponse, jsAgentFromHtmlContent);
+
+        // verify that the browser injecting stream wrapper didn't catch an exception and disable itself
+        var agentDisabledLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Unexpected exception. Browser injection will be disabled. *?");
+        Assert.Null(agentDisabledLogLine);
+
+        // the interesting assertion: the RUM loader marker should appear exactly once.
+        // More than one occurrence means the agent injected the browser script multiple
+        // times into a single response. The failure message reports every occurrence's
+        // offset and which region of the document it falls in, so a regression tells us
+        // where the extra injection landed instead of only that it happened.
+        var markerOffsets = JavaScriptAgent.FindInfoBlockOffsets(_htmlContent);
+
+        var openHeadIndex = _htmlContent.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
+        var openHeadEndIndex = openHeadIndex >= 0 ? _htmlContent.IndexOf('>', openHeadIndex) : -1;
+        var closeHeadIndex = _htmlContent.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
+        var bodyOpenIndex = _htmlContent.IndexOf("<body", StringComparison.OrdinalIgnoreCase);
+
+        var detail = new StringBuilder();
+        for (var i = 0; i < markerOffsets.Count; i++)
+        {
+            if (i > 0)
+            {
+                detail.Append(", ");
+            }
+
+            var offset = markerOffsets[i];
+            detail.Append(offset).Append(" (").Append(ClassifyRegion(offset, openHeadEndIndex, closeHeadIndex, bodyOpenIndex)).Append(')');
+        }
+
+        var message = $"Expected the RUM script to be injected exactly once; found {markerOffsets.Count} " +
+            $"NREUM.info occurrence(s). Offsets/regions: {detail}. Anchors: openHeadEnd={openHeadEndIndex}, " +
+            $"closeHead={closeHeadIndex}, bodyOpen={bodyOpenIndex}, contentLength={_htmlContent.Length}.";
+
+        Assert.True(markerOffsets.Count == 1, message);
+    }
+
+    // Classifies an offset relative to the document's <head>/<body> anchors. Anchors
+    // that were not found (-1) are handled defensively so this never throws while
+    // building an assertion failure message.
+    private static string ClassifyRegion(int offset, int openHeadEndIndex, int closeHeadIndex, int bodyOpenIndex)
+    {
+        if (openHeadEndIndex >= 0 && offset > openHeadEndIndex && (closeHeadIndex < 0 || offset < closeHeadIndex))
+        {
+            return "in-head";
+        }
+
+        if (closeHeadIndex >= 0 && offset > closeHeadIndex && (bodyOpenIndex < 0 || offset < bodyOpenIndex))
+        {
+            return "between-head-and-body";
+        }
+
+        if (bodyOpenIndex >= 0 && offset >= bodyOpenIndex)
+        {
+            return "in-body";
+        }
+
+        return "other/before-head";
+    }
+}
+
+public class BrowserAgentAutoInjectionLargeHeadUnCompressed : BrowserAgentAutoInjectionLargeHeadBase
+{
+    public BrowserAgentAutoInjectionLargeHeadUnCompressed(BasicAspNetCoreRazorApplicationFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, false)
+    {
+    }
+}
+
+public class BrowserAgentAutoInjectionLargeHeadCompressed : BrowserAgentAutoInjectionLargeHeadBase
+{
+    public BrowserAgentAutoInjectionLargeHeadCompressed(BasicAspNetCoreRazorApplicationFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, true)
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjectionSplitHead.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjectionSplitHead.cs
@@ -1,0 +1,100 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures;
+
+// Regression test for silent response-content loss in the ASP.NET Core 6+ browser injector.
+//
+// BrowserScriptInjectionHelper.InjectBrowserScriptAsync used to reject an injection index
+// equal to the buffer length as invalid: it logged "Skipping RUM Injection: Insertion index
+// was invalid." and returned WITHOUT writing the buffer at all. BrowserInjectingStreamWrapper
+// returns immediately after calling into the agent and never writes the buffer itself, so
+// that write's bytes never reached the client - the response was silently truncated. An index
+// equal to the buffer length is now handled as a valid split point: the script is appended and
+// the trailing write covers zero bytes.
+//
+// That index arises when a single Write/WriteAsync call's buffer ends exactly on the closing
+// '>' of the opening <head> tag. Forcing an ASP.NET Core response writer's internal buffer
+// boundary to land there is not reliably controllable, so the test app's "/splithead" endpoint
+// writes the response in two explicit WriteAsync calls split at exactly that byte.
+//
+// This is a separate defect from the double injection covered by
+// BrowserAgentAutoInjectionLargeHead: that one is about the script being inserted twice, this
+// one about response bytes being dropped. Before the fix the response came back starting with
+// "</head><script ...NREUM.info..." - the first write's bytes were gone and the script had
+// been injected against the second write's <body> anchor instead.
+public class BrowserAgentAutoInjectionSplitHead : NewRelicIntegrationTest<BasicAspNetCoreRazorApplicationFixture>
+{
+    private const string FirstWriteContent = "<html><head>";
+
+    private readonly BasicAspNetCoreRazorApplicationFixture _fixture;
+    private string _htmlContent;
+
+    public BrowserAgentAutoInjectionSplitHead(BasicAspNetCoreRazorApplicationFixture fixture, ITestOutputHelper output)
+        : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.AutoInstrumentBrowserMonitoring(true);
+                configModifier.BrowserMonitoringEnableAttributes(true);
+                configModifier.EnableAspNetCore6PlusBrowserInjection(true);
+                configModifier.BrowserMonitoringLoader("rum");
+            },
+            exerciseApplication: () =>
+            {
+                _htmlContent = _fixture.Get("splithead");
+            }
+        );
+
+        _fixture.SetResponseCompression(false);
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void ResponseIsNotTruncatedAndScriptIsInjectedOnce()
+    {
+        // This test project is xUnit, so NrAssert.Multiple (which delegates to NUnit's
+        // Assert.Multiple) cannot aggregate these failures - the first failing assert throws.
+        // They are ordered so an infrastructure problem surfaces as its own distinct failure
+        // before the interesting assertions.
+        Assert.NotNull(_htmlContent);
+
+        // THE KEY ASSERTION - no content loss.
+        // Using StartsWith (not Contains) because the first write's bytes, if present at all,
+        // must be at the very start of the response - nothing could legitimately precede them.
+        // If the first write is dropped, the response instead starts with the second write's
+        // content ("</head><body>...") or with the RUM script.
+        var preview = _htmlContent.Length > 120 ? _htmlContent.Substring(0, 120) : _htmlContent;
+        Assert.True(_htmlContent.StartsWith(FirstWriteContent, StringComparison.Ordinal),
+            $"Expected the response to start with the first write's content (\"{FirstWriteContent}\") but the " +
+            $"first write's bytes appear to have been dropped. First 120 characters of actual response: " +
+            $"\"{preview}\"");
+
+        // confirm injection happened at all, and that the injected script is the one the
+        // collector handed us
+        var jsAgentFromConnectResponse = _fixture.AgentLog.GetConnectResponseData().JsAgentLoader;
+        var jsAgentFromHtmlContent = JavaScriptAgent.GetJavaScriptAgentScriptFromSource(_htmlContent);
+        Assert.Equal(jsAgentFromConnectResponse, jsAgentFromHtmlContent);
+
+        // The RUM script should still be injected exactly once.
+        var markerOffsets = JavaScriptAgent.FindInfoBlockOffsets(_htmlContent);
+        Assert.True(markerOffsets.Count == 1,
+            $"Expected the RUM script to be injected exactly once; found {markerOffsets.Count} " +
+            $"NREUM.info occurrence(s) at offset(s) {string.Join(", ", markerOffsets)} in the response.");
+
+        // Verify that the browser injecting stream wrapper didn't catch an exception and disable itself.
+        var agentDisabledLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Unexpected exception. Browser injection will be disabled. *?");
+        Assert.Null(agentDisabledLogLine);
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserScriptInjectionHelperTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserScriptInjectionHelperTests.cs
@@ -1,0 +1,150 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NewRelic.Agent.Api;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+[TestFixture]
+public class BrowserScriptInjectionHelperTests
+{
+    private static readonly byte[] RumBytes = Encoding.UTF8.GetBytes("<script>RUM</script>");
+
+    private const string HtmlContent = "<html><head></head><body></body></html>";
+
+    // The agent injects immediately after the opening head tag when the head has no
+    // charset / x-ua-compatible meta tag, so the expected index is just past its '>'.
+    private static readonly int ExpectedHeadIndex = HtmlContent.IndexOf('>', HtmlContent.IndexOf("<head", StringComparison.Ordinal)) + 1;
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_ReturnsTrue_AndWritesScriptAtHeadTag_WhenLocationFound()
+    {
+        var buffer = Encoding.UTF8.GetBytes(HtmlContent);
+        var expectedIndex = ExpectedHeadIndex;
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, null);
+
+        var expectedBytes = new byte[buffer.Length + RumBytes.Length];
+        Buffer.BlockCopy(buffer, 0, expectedBytes, 0, expectedIndex);
+        Buffer.BlockCopy(RumBytes, 0, expectedBytes, expectedIndex, RumBytes.Length);
+        Buffer.BlockCopy(buffer, expectedIndex, expectedBytes, expectedIndex + RumBytes.Length, buffer.Length - expectedIndex);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(baseStream.ToArray(), Is.EqualTo(expectedBytes));
+        });
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_ReturnsFalse_AndWritesBufferUnchanged_WhenNoLocationFound()
+    {
+        var content = "<html><p>Hello</p></html>"; // no <head> and no <body>
+        var buffer = Encoding.UTF8.GetBytes(content);
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(baseStream.ToArray(), Is.EqualTo(buffer));
+        });
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_ReturnsTrue_AndAppendsScript_WhenInsertionIndexIsAtEndOfBuffer()
+    {
+        // The opening head tag ends exactly at the end of the buffer, so the insertion index
+        // equals the buffer length. That is a valid split point - the script is appended and
+        // the trailing write covers zero bytes. This case used to be treated as an invalid
+        // index, which returned without writing the buffer at all and silently dropped this
+        // write's content from the response.
+        var buffer = Encoding.UTF8.GetBytes("<html><head>");
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, null);
+
+        var expectedBytes = new byte[buffer.Length + RumBytes.Length];
+        Buffer.BlockCopy(buffer, 0, expectedBytes, 0, buffer.Length);
+        Buffer.BlockCopy(RumBytes, 0, expectedBytes, buffer.Length, RumBytes.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(baseStream.ToArray(), Is.EqualTo(expectedBytes));
+        });
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_ReturnsFalse_WhenBaseStreamIsDisposed()
+    {
+        var buffer = Encoding.UTF8.GetBytes(HtmlContent); // a valid injection location exists
+        var transaction = Mock.Create<ITransaction>();
+
+        var baseStream = new MemoryStream();
+        baseStream.Dispose();
+
+        // the disposed stream must be swallowed rather than surfaced to the response writer
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, transaction);
+
+        Assert.That(result, Is.False);
+        Mock.Assert(() => transaction.LogFinest("RUM Injection aborted: Stream was disposed."), Occurs.AtLeastOnce());
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_LogsInjectionIndex_WhenTransactionIsSupplied()
+    {
+        // every other test passes a null transaction, which exercises the null-conditional
+        // side of the transaction?.LogFinest(...) calls; this covers the non-null side
+        var transaction = Mock.Create<ITransaction>();
+        var buffer = Encoding.UTF8.GetBytes(HtmlContent);
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, transaction);
+
+        Assert.That(result, Is.True);
+        Mock.Assert(() => transaction.LogFinest($"Injecting RUM script at byte index {ExpectedHeadIndex}."), Occurs.Once());
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_LogsSkipReason_WhenNoLocationFound()
+    {
+        var transaction = Mock.Create<ITransaction>();
+        var buffer = Encoding.UTF8.GetBytes("<html><p>Hello</p></html>");
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, transaction);
+
+        Assert.That(result, Is.False);
+        Mock.Assert(() => transaction.LogFinest("Skipping RUM Injection: No suitable location found to inject script."), Occurs.Once());
+    }
+
+    [Test]
+    public async Task InjectBrowserScriptAsync_ReturnsFalse_AndWritesNothing_WhenBufferIsEmpty()
+    {
+        var buffer = Array.Empty<byte>();
+
+        using var baseStream = new MemoryStream();
+
+        var result = await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, RumBytes, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(baseStream.ToArray(), Is.Empty);
+        });
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Configuration;
@@ -2305,6 +2308,55 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             // Assert
             Assert.That(actualAttributes.ContainsKey(attributeName), Is.False);
         }
+        #endregion
+
+        #region TryInjectBrowserScriptAsync
+
+        [Test]
+        public async Task TryInjectBrowserScriptAsync_ReturnsFalse_AndWritesBufferUnchanged_WhenNoScriptIsAvailable()
+        {
+            // with the prereq checker declining, no script is produced, so there is
+            // nothing to inject; the buffer must still be written through untouched
+            Mock.Arrange(() => _browserMonitoringPrereqChecker.ShouldAutomaticallyInject(Arg.IsAny<IInternalTransaction>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns(false);
+
+            var buffer = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+            using var baseStream = new MemoryStream();
+
+            var result = await _agent.TryInjectBrowserScriptAsync("text/html", "/some/path", buffer, baseStream);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.False);
+                Assert.That(baseStream.ToArray(), Is.EqualTo(buffer));
+            });
+        }
+
+        [Test]
+        public async Task TryInjectBrowserScriptAsync_ReturnsTrue_AndWritesScriptIntoBuffer_WhenScriptIsAvailable()
+        {
+            const string script = "<script>RUM</script>";
+
+            SetupTransaction();
+            Mock.Arrange(() => _browserMonitoringPrereqChecker.ShouldAutomaticallyInject(Arg.IsAny<IInternalTransaction>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns(true);
+            Mock.Arrange(() => _browserMonitoringScriptMaker.GetScript(Arg.IsAny<IInternalTransaction>(), Arg.IsAny<string>()))
+                .Returns(script);
+
+            var buffer = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+            using var baseStream = new MemoryStream();
+
+            var result = await _agent.TryInjectBrowserScriptAsync("text/html", "/some/path", buffer, baseStream);
+
+            var written = Encoding.UTF8.GetString(baseStream.ToArray());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(written, Is.EqualTo("<html><head>" + script + "</head><body></body></html>"));
+            });
+        }
+
         #endregion
 
         private void SetupTransaction()

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Layout, conventions, and the non-obvious facts for **writing** tests.
 - **Running** integration tests -> `run-integration-tests` skill (build-first, layer pick, CLI, env gotchas, troubleshooting). Don't duplicate it here.
-- **Building** first -> `build-dotnet-agent` skill. CLI build workarounds (`Core.UnitTest` `SolutionDir`, Extensions DLL-direct) and the no-unit-tests-for-wrappers rule -> [root claude.md](../CLAUDE.md).
+- **Building** first -> `build-dotnet-agent` skill. CLI build workarounds (`Core.UnitTest` `SolutionDir`, Extensions DLL-direct) and the no-unit-tests-for-wrappers rule -> [root claude.md](../CLAUDE.md). Building the **integration test solutions** themselves needs VS MSBuild + three specific flags -> [Building the solution](#building-the-solution) below.
 
 Five layers, all integration layers read the built `src/Agent/newrelichome_*` dirs (build `FullAgent.sln` first):
 
@@ -48,6 +48,26 @@ tests/Agent/
 - **Never `InternalsVisibleTo`** -- refactor the production type instead (root claude.md).
 
 ## Integration tests
+
+### Building the solution
+
+`IntegrationTests.sln` / `UnboundedIntegrationTests.sln` need **VS MSBuild** with all three of these flags -- use the CI invocation verbatim (`all_solutions.yml`):
+
+```
+"C:\Program Files\Microsoft Visual Studio\<ver>\Enterprise\MSBuild\Current\Bin\MSBuild.exe" \
+  tests/Agent/IntegrationTests/IntegrationTests.sln \
+  -restore -m -p:Configuration=Debug -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy
+```
+
+Each omission produces a different misleading error in the legacy ASP.NET FW web apps -- none of them a real code break:
+
+| Wrong invocation | Error |
+|---|---|
+| `dotnet build` (any flags) | `MSB4019: Microsoft.WebApplication.targets was not found` -- `VSToolsPath` resolves under the dotnet SDK |
+| missing `-restore` | `error: Your project file doesn't list 'win' as a "RuntimeIdentifier"` (packages.config projects) |
+| missing `DeployOnBuild`/`PublishProfile` | `MSB4006: circular dependency ... involving target "Deploy"` (~11 projects) |
+
+`MSB3027/MSB3021: cannot copy netstandard.dll ... locked by ".NET Host (<pid>)"` is a persistent MSBuild worker node left over from an earlier `dotnet build` -- clear it with `dotnet build-server shutdown`, not by killing PIDs.
 
 Pattern: start a test app with the agent attached, exercise it, wait for a harvest, assert on the parsed agent log.
 


### PR DESCRIPTION
Fixes #3725.

When an HTML response's `<head>` exceeds the response writer's buffer, the body reaches
`BrowserInjectingStreamWrapper` across multiple writes. Each write was evaluated
independently, so the script was injected once after `<head>` and again before `<body>` via
the fallback anchor. `TryInjectBrowserScriptAsync` now reports whether it injected, and the
wrapper latches that on `HttpContext.Items` so later writes pass through. The latch is on the
context rather than the instance because response compression puts a second wrapper on the
same response.

Also fixes a latent defect found in the same code path: an injection index equal to the buffer
length was rejected as invalid, and that write's bytes were dropped entirely rather than
written through - silently truncating the response.

Covered by new unit tests plus two integration tests (`BrowserAgentAutoInjectionLargeHead`,
compressed and uncompressed, and `BrowserAgentAutoInjectionSplitHead`).
