### PR TITLE
fix: Add on-insert check to SimpleCache to prevent runaway growth.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/ICacheStats.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/ICacheStats.cs
@@ -10,5 +10,6 @@ public interface ICacheStats
     int CountHits { get; }
     int CountMisses { get; }
     int CountEjections { get; }
+    int CountDropped { get; }
     void ResetStats();
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
@@ -91,52 +91,41 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     /// </summary>
     public TValue Peek(TKey key)
     {
-        var node = PeekInternal(key);
-        return node;
+        _cacheMap.TryGetValue(key, out var value);
+        return value;
     }
 
     /// <summary>
-    /// Checks whether the specified key exists in the cache without updating stats.
+    /// Checks whether the specified key exists in the cache without updating stats. Unlike <see cref="Peek"/>,
+    /// this is correct for a key whose cached value is itself null.
     /// </summary>
-    public bool Contains(TKey key) => PeekInternal(key) != null;
+    public bool Contains(TKey key) => _cacheMap.ContainsKey(key);
 
     /// <summary>
-    /// Allows searching of the cache.  If found, returns the existing item and updates the statistics.
-    /// If not found, returns NULL.
+    /// Allows searching of the cache. If found, returns the existing item (which may itself be null) and
+    /// records a hit. If not found, records a miss and returns null.
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
     public TValue Get(TKey key)
     {
-
-        var node = PeekInternal(key);
-
-        if (node != null)
-        {
-            Interlocked.Increment(ref _countHits);
-        }
-        else
-        {
-            Interlocked.Increment(ref _countMisses);
-        }
-
-        return node;
+        TryGetTrackingStats(key, out var value);
+        return value;
     }
 
     /// <summary>
-    /// Attempts to find an item in the cache.  If found, returns the existing item and updates the statistics.
-    /// If not found, will add the item to the cache, unless the cache is at capacity, in which case the item
-    /// is dropped (not cached) but is still computed and returned.
+    /// Attempts to find an item in the cache.  If found (a cached null value counts as found), returns the
+    /// existing item and updates the statistics. If not found, will add the item to the cache, unless the
+    /// cache is at capacity, in which case the item is dropped (not cached) but is still computed and returned.
     /// </summary>
     /// <param name="key"></param>
     /// <param name="valueFx">Function to call to obtain the value if the key is not present in the cache.</param>
     /// <returns></returns>
     public TValue GetOrAdd(TKey key, Func<TValue> valueFx)
     {
-        var result = Get(key);
-        if (result != null)
+        if (TryGetTrackingStats(key, out var existing))
         {
-            return result;
+            return existing;
         }
 
         if (_count >= _capacity)
@@ -158,8 +147,8 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
             return newValue;
         }
 
-        // Another thread won the race for this key; return the value that is actually cached. If the
-        // cache was cleared in between, fall back to the value just computed.
+        // Another thread won the race for this key; return the value that is actually cached, which may
+        // legitimately be null. If the cache was cleared in between, fall back to the value just computed.
         return _cacheMap.TryGetValue(key, out var raceWinner) ? raceWinner : newValue;
     }
 
@@ -226,15 +215,20 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     /// </summary>
     public int Size => _count;
 
-    private TValue PeekInternal(TKey key)
+    /// <summary>
+    /// Looks up <paramref name="key"/> and records a hit or miss based on whether it is actually present -
+    /// not on whether <paramref name="value"/> is null, since a cached null value is a valid hit.
+    /// </summary>
+    private bool TryGetTrackingStats(TKey key, out TValue value)
     {
-        TValue node;
-        if (!_cacheMap.TryGetValue(key, out node))
+        if (_cacheMap.TryGetValue(key, out value))
         {
-            return null;
+            Interlocked.Increment(ref _countHits);
+            return true;
         }
 
-        return node;
+        Interlocked.Increment(ref _countMisses);
+        return false;
     }
 
     /// <summary>
@@ -246,11 +240,14 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     {
         if (_droppedSinceLastMaintenance > 0 || _count > _capacity)
         {
-            // Zero the tracked count before clearing the map: an insert that lands between the two
-            // would otherwise be counted (Interlocked.Increment already ran) but then wiped by Clear,
-            // permanently under-counting. Doing it in this order instead risks the opposite, harmless
-            // direction: an insert landing here is wiped by Clear but not counted, so _count briefly
-            // under-reports until that thread's next successful insert - it never drifts high.
+            // Zero the tracked count before clearing the map, not after: once both halves of every
+            // in-flight insert have completed, this guarantees map.Count <= _count - drift is over-report
+            // only, so the capacity guard can never be silently defeated and the map can't grow past
+            // capacity indefinitely. (Transiently, e.g. mid-Clear, the map can briefly hold more real
+            // entries than _count reports - that's expected and resolves once Clear finishes.) The
+            // opposite order (Clear then Exchange) permits an insert to durably survive the Clear while
+            // its Increment is wiped by the Exchange, permanently under-counting and letting the map
+            // creep past capacity forever.
             var count = Interlocked.Exchange(ref _count, 0);
             _cacheMap.Clear();
             Interlocked.Add(ref _countEjections, count);

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
@@ -9,8 +9,10 @@ using System.Threading;
 namespace NewRelic.Agent.Extensions.Caching;
 
 /// <summary>
-/// Simple cache maintains a collection. Periodically, the cache is maintained on a seperate thread.
-/// When it is full, the cache is cleared.
+/// Simple cache maintains a collection. New items are dropped instead of added once the cache is at
+/// (approximately) capacity. Periodically, the cache is maintained on a separate thread: if any items
+/// were dropped, or the tracked size is over capacity (e.g. after <see cref="Capacity"/> is lowered),
+/// the cache is cleared.
 /// </summary>
 /// <typeparam name="TKey"></typeparam>
 /// <typeparam name="TValue"></typeparam>
@@ -21,14 +23,28 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     private readonly Timer _maintainCacheTimer;
 
     /// <summary>
-    /// Time in milliseconds. How often the Agent will check cache size and clears off the cache
-    /// if its size is greater than its capacity.
+    /// Default time in milliseconds between <see cref="MaintainCache"/> checks.
     /// </summary>
     public const int CleanUpTimePeriod = 500;
 
     private int _countHits;
     private int _countMisses;
     private int _countEjections;
+    private int _countDropped;
+
+    /// <summary>
+    /// Set when an item is dropped and cleared back to 0 by <see cref="MaintainCache"/>. Separate from
+    /// <see cref="_countDropped"/> (which is cumulative and only reset via <see cref="ResetStats"/>) so that
+    /// a single drop doesn't cause every future maintenance tick to clear the cache forever.
+    /// </summary>
+    private int _droppedSinceLastMaintenance;
+
+    /// <summary>
+    /// The number of items currently in <see cref="_cacheMap"/>. Tracked separately because
+    /// ConcurrentDictionary.Count acquires every one of the dictionary's internal locks, which
+    /// blocks all concurrent writers, and the count is consulted on every insert attempt.
+    /// </summary>
+    private int _count;
 
     private int _capacity;
 
@@ -37,7 +53,6 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
         get => _capacity;
         set => SetCapacity(value);
     }
-
 
     ///// <summary>
     ///// Metric for counting the number of items a Get function hits an existing item in the cache
@@ -54,14 +69,25 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     ///// </summary>
     public int CountEjections => _countEjections;
 
-    public SimpleCache(int capacity)
+    ///// <summary>
+    ///// Metric for counting the number of items that were not added to the cache because it was at capacity
+    ///// </summary>
+    public int CountDropped => _countDropped;
+
+    /// <param name="capacity"></param>
+    /// <param name="maintainCacheIntervalMs">
+    /// How often <see cref="MaintainCache"/> runs on its own timer. Exposed (instead of hard-coding
+    /// <see cref="CleanUpTimePeriod"/>) so tests can pass <see cref="Timeout.Infinite"/> to disable the
+    /// timer and drive maintenance deterministically via explicit <see cref="MaintainCache"/> calls.
+    /// </param>
+    public SimpleCache(int capacity, int maintainCacheIntervalMs = CleanUpTimePeriod)
     {
         Capacity = capacity;
-        _maintainCacheTimer = new Timer(o => MaintainCache(), null, CleanUpTimePeriod, CleanUpTimePeriod);
+        _maintainCacheTimer = new Timer(o => MaintainCache(), null, maintainCacheIntervalMs, maintainCacheIntervalMs);
     }
 
     /// <summary>
-    /// Allows searching of the cache without updating stats or affecting the priority of items in the cache.
+    /// Allows searching of the cache without updating stats.
     /// </summary>
     public TValue Peek(TKey key)
     {
@@ -70,7 +96,7 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     }
 
     /// <summary>
-    /// Checks whether the specified key exists in the cache without updating stats or affecting the priority of items in the cache.
+    /// Checks whether the specified key exists in the cache without updating stats.
     /// </summary>
     public bool Contains(TKey key) => PeekInternal(key) != null;
 
@@ -99,7 +125,8 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
 
     /// <summary>
     /// Attempts to find an item in the cache.  If found, returns the existing item and updates the statistics.
-    /// If not found, will add the item to the cache.
+    /// If not found, will add the item to the cache, unless the cache is at capacity, in which case the item
+    /// is dropped (not cached) but is still computed and returned.
     /// </summary>
     /// <param name="key"></param>
     /// <param name="valueFx">Function to call to obtain the value if the key is not present in the cache.</param>
@@ -107,23 +134,70 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     public TValue GetOrAdd(TKey key, Func<TValue> valueFx)
     {
         var result = Get(key);
+        if (result != null)
+        {
+            return result;
+        }
 
-        return result ?? _cacheMap.GetOrAdd(key, x => valueFx());
+        if (_count >= _capacity)
+        {
+            Interlocked.Increment(ref _countDropped);
+            Interlocked.Increment(ref _droppedSinceLastMaintenance);
+            return valueFx();
+        }
+
+        var newValue = valueFx();
+
+        // TryAdd, not GetOrAdd: it returns true on exactly one thread - the one that actually
+        // inserted - so it is a safe trigger for incrementing the tracked count. A factory delegate
+        // passed to GetOrAdd can run on more than one thread when they race for the same new key,
+        // which would over-count.
+        if (_cacheMap.TryAdd(key, newValue))
+        {
+            Interlocked.Increment(ref _count);
+            return newValue;
+        }
+
+        // Another thread won the race for this key; return the value that is actually cached. If the
+        // cache was cleared in between, fall back to the value just computed.
+        return _cacheMap.TryGetValue(key, out var raceWinner) ? raceWinner : newValue;
     }
 
     /// <summary>
     /// Attempts to add an item to the cache.  If the item already exists, returns false. Otherwise, returns true.
+    /// If the cache is at capacity, the item is dropped and not added.
     /// </summary>
     /// <param name="key"></param>
     /// <param name="valueFunc">Function to call to obtain the value if the key is not present in the cache.</param>
     /// <returns></returns>
     public bool TryAdd(TKey key, Func<TValue> valueFunc)
     {
-        return _cacheMap.TryAdd(key, valueFunc());
+        // Fast exit for a key that is already cached: it is not a capacity drop, and there is no
+        // need to build a value for it.
+        if (_cacheMap.ContainsKey(key))
+        {
+            return false;
+        }
+
+        if (_count >= _capacity)
+        {
+            Interlocked.Increment(ref _countDropped);
+            Interlocked.Increment(ref _droppedSinceLastMaintenance);
+            return false;
+        }
+
+        if (!_cacheMap.TryAdd(key, valueFunc()))
+        {
+            // Another thread added this key between the ContainsKey check and here.
+            return false;
+        }
+
+        Interlocked.Increment(ref _count);
+        return true;
     }
 
     /// <summary>
-    /// Allows resetting of the Hit, Miss, and Ejection counters
+    /// Allows resetting of the Hit, Miss, Ejection, and Dropped counters
     /// </summary>
     [MethodImpl(MethodImplOptions.Synchronized)]
     public void ResetStats()
@@ -131,6 +205,7 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
         _countHits = 0;
         _countMisses = 0;
         _countEjections = 0;
+        _countDropped = 0;
     }
 
     [MethodImpl(MethodImplOptions.Synchronized)]
@@ -145,9 +220,11 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     }
 
     /// <summary>
-    /// The number of items stored in the cache
+    /// The approximate number of items stored in the cache. Concurrent writers racing the capacity
+    /// check can transiently push this a little past <see cref="Capacity"/>; it self-corrects at the
+    /// next <see cref="MaintainCache"/> tick.
     /// </summary>
-    public int Size => _cacheMap.Count;
+    public int Size => _count;
 
     private TValue PeekInternal(TKey key)
     {
@@ -161,27 +238,38 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     }
 
     /// <summary>
-    /// public only for unit tests. Don't call this method directly!
-    /// </summary>        
+    /// Clears the cache if anything was dropped since the last check, or if the tracked size is over
+    /// capacity (e.g. <see cref="Capacity"/> was just lowered below the current size). Public only for
+    /// unit tests. Don't call this method directly!
+    /// </summary>
     public void MaintainCache()
     {
-        var count = _cacheMap.Count;
-        if (count > _capacity)
+        if (_droppedSinceLastMaintenance > 0 || _count > _capacity)
         {
+            // Zero the tracked count before clearing the map: an insert that lands between the two
+            // would otherwise be counted (Interlocked.Increment already ran) but then wiped by Clear,
+            // permanently under-counting. Doing it in this order instead risks the opposite, harmless
+            // direction: an insert landing here is wiped by Clear but not counted, so _count briefly
+            // under-reports until that thread's next successful insert - it never drifts high.
+            var count = Interlocked.Exchange(ref _count, 0);
             _cacheMap.Clear();
             Interlocked.Add(ref _countEjections, count);
+            Interlocked.Exchange(ref _droppedSinceLastMaintenance, 0);
         }
     }
 
     public void Dispose()
     {
+        Interlocked.Exchange(ref _count, 0);
         _cacheMap.Clear();
         _maintainCacheTimer?.Dispose();
     }
 
     public void Reset()
     {
+        Interlocked.Exchange(ref _count, 0);
         _cacheMap.Clear();
+        Interlocked.Exchange(ref _droppedSinceLastMaintenance, 0);
         ResetStats();
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Caching/SimpleCache.cs
@@ -109,7 +109,7 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     /// <returns></returns>
     public TValue Get(TKey key)
     {
-        TryGetTrackingStats(key, out var value);
+        TryGetInternal(key, out var value);
         return value;
     }
 
@@ -123,7 +123,7 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     /// <returns></returns>
     public TValue GetOrAdd(TKey key, Func<TValue> valueFx)
     {
-        if (TryGetTrackingStats(key, out var existing))
+        if (TryGetInternal(key, out var existing))
         {
             return existing;
         }
@@ -219,7 +219,7 @@ public class SimpleCache<TKey, TValue> : ICacheStats, IDisposable where TValue :
     /// Looks up <paramref name="key"/> and records a hit or miss based on whether it is actually present -
     /// not on whether <paramref name="value"/> is null, since a cached null value is a valid hit.
     /// </summary>
-    private bool TryGetTrackingStats(TKey key, out TValue value)
+    private bool TryGetInternal(TKey key, out TValue value)
     {
         if (_cacheMap.TryGetValue(key, out value))
         {

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
@@ -135,6 +135,29 @@ public class SimpleCacheTests
     }
 
     [Test]
+    public void Contains_ReturnsFalse_ForAbsentKey()
+    {
+        var cache = new SimpleCache<string, string>(5);
+
+        Assert.That(cache.Contains("key1"), Is.False);
+    }
+
+    [Test]
+    public void Get_RecordsAMiss_ForAbsentKey()
+    {
+        var cache = new SimpleCache<string, string>(5);
+
+        var result = cache.Get("key1");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Null);
+            Assert.That(cache.CountHits, Is.EqualTo(0));
+            Assert.That(cache.CountMisses, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public void Get_RecordsAHit_ForKeyWithACachedNullValue()
     {
         var cache = new SimpleCache<string, string>(5);

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
@@ -100,6 +100,67 @@ public class SimpleCacheTests
     }
 
     [Test]
+    public void GetOrAdd_TreatsACachedNullValueAsAHit_NotAMiss()
+    {
+        int capacity = 5;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        var firstFactoryInvocations = 0;
+        var result1 = cache.GetOrAdd("key1", () => { firstFactoryInvocations++; return null; });
+
+        var secondFactoryInvocations = 0;
+        var result2 = cache.GetOrAdd("key1", () => { secondFactoryInvocations++; return "value2"; });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result1, Is.Null);
+            //key1 is cached (with a null value), so this must be a hit: the cached null is returned
+            //as-is and the second factory must never run.
+            Assert.That(result2, Is.Null);
+            Assert.That(firstFactoryInvocations, Is.EqualTo(1));
+            Assert.That(secondFactoryInvocations, Is.EqualTo(0));
+            Assert.That(cache.CountHits, Is.EqualTo(1));
+            Assert.That(cache.CountMisses, Is.EqualTo(1));
+            Assert.That(cache.Size, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Contains_ReturnsTrue_ForKeyWithACachedNullValue()
+    {
+        var cache = new SimpleCache<string, string>(5);
+        cache.GetOrAdd("key1", () => null);
+
+        Assert.That(cache.Contains("key1"), Is.True);
+    }
+
+    [Test]
+    public void Get_RecordsAHit_ForKeyWithACachedNullValue()
+    {
+        var cache = new SimpleCache<string, string>(5);
+        cache.GetOrAdd("key1", () => null); //1 miss (insert)
+
+        var result = cache.Get("key1"); //should be a hit, not another miss
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Null);
+            Assert.That(cache.CountHits, Is.EqualTo(1));
+            Assert.That(cache.CountMisses, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Peek_ReturnsNull_ForKeyWithACachedNullValue()
+    {
+        var cache = new SimpleCache<string, string>(5);
+        cache.GetOrAdd("key1", () => null);
+
+        //Peek can't distinguish a cached null from an absent key - Contains is the correct check for that.
+        Assert.That(cache.Peek("key1"), Is.Null);
+    }
+
+    [Test]
     public void TryAdd_DropsNewItem_WhenCacheAtCapacity()
     {
         int capacity = 2;

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Cache/SimpleCacheTests.cs
@@ -35,9 +35,10 @@ public class SimpleCacheTests
         var expectedHits = 0;
         var expectedMisses = 3;
         var expectedEjections = 0;
+        var expectedDropped = 0;
         var expectedSize = 3;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
     }
 
     [Test]
@@ -53,7 +54,7 @@ public class SimpleCacheTests
         cache.GetOrAdd("key2", () => val2);
         cache.GetOrAdd("key3", () => val3);
 
-        //This should not modify the value of key2 
+        //This should not modify the value of key2
         var shouldbeVal2 = cache.GetOrAdd("key2", () => "xyz");
 
         Assert.Multiple(() =>
@@ -69,13 +70,120 @@ public class SimpleCacheTests
         var expectedHits = 1;
         var expectedMisses = 3;
         var expectedEjections = 0;
+        var expectedDropped = 0;
         var expectedSize = 3;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
     }
 
     [Test]
-    public void CacheGetsClearedIfItGoesAboveCapacity()
+    public void GetOrAdd_DropsNewItem_ButStillReturnsIt_WhenCacheAtCapacity()
+    {
+        int capacity = 2;
+        // Disable the internal timer: the assertion below expects the drop to NOT have been cleared
+        // yet, which a live 500ms timer could race.
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+
+        //Cache is now at capacity; a new key should be dropped, not cached, but the computed value is still returned.
+        var val3 = cache.GetOrAdd("key3", () => "value3");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(val3, Is.EqualTo("value3"));
+            Assert.That(cache.Peek("key3"), Is.Null);
+            Assert.That(cache.Size, Is.EqualTo(capacity));
+            Assert.That(cache.CountDropped, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TryAdd_DropsNewItem_WhenCacheAtCapacity()
+    {
+        int capacity = 2;
+        // Disable the internal timer: see comment in GetOrAdd_DropsNewItem_ButStillReturnsIt_WhenCacheAtCapacity.
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
+
+        cache.TryAdd("key1", () => "value1");
+        cache.TryAdd("key2", () => "value2");
+
+        var result = cache.TryAdd("key3", () => "value3");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(cache.Peek("key3"), Is.Null);
+            Assert.That(cache.Size, Is.EqualTo(capacity));
+            Assert.That(cache.CountDropped, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TryAdd_ReturnsFalse_WhenKeyAlreadyExists_EvenAtCapacity()
+    {
+        int capacity = 2;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        var val1 = "value1";
+        cache.TryAdd("key1", () => val1);
+        cache.TryAdd("key2", () => "value2");
+
+        //key1 already exists; this is not a capacity drop.
+        var result = cache.TryAdd("key1", () => "somethingElse");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(cache.Peek("key1"), Is.SameAs(val1));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void MaintainCache_PersistsCache_WhenAtCapacityButNothingWasDropped()
+    {
+        int capacity = 2;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+
+        cache.MaintainCache(); // force cache to maintain, normally done on a timer.
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Size, Is.EqualTo(capacity));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+            Assert.That(cache.CountEjections, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void MaintainCache_ClearsCache_WhenItemsWereDropped()
+    {
+        int capacity = 2;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+
+        //Overflow the cache so an item gets dropped.
+        cache.GetOrAdd("key3", () => "value3");
+
+        cache.MaintainCache(); // force cache to maintain, normally done on a timer.
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Size, Is.EqualTo(0));
+            Assert.That(cache.CountEjections, Is.EqualTo(capacity));
+            Assert.That(cache.CountDropped, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CacheGetsClearedOnlyAfterAnItemIsDropped()
     {
         var val1 = "value1";
         var val2 = "value2";
@@ -85,7 +193,8 @@ public class SimpleCacheTests
         var val6 = "value6";
 
         int capacity = 5;
-        var cache = new SimpleCache<string, string>(capacity);
+        // Disable the internal timer: see comment in GetOrAdd_DropsNewItem_ButStillReturnsIt_WhenCacheAtCapacity.
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
 
         cache.GetOrAdd("key1", () => val1);
         cache.GetOrAdd("key2", () => val2);
@@ -95,23 +204,27 @@ public class SimpleCacheTests
 
         cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
-        //This checks that the clearing didn't happen.
+        //This checks that filling the cache exactly to capacity did not drop anything, so nothing was cleared.
         Assert.That(cache.Size, Is.EqualTo(capacity));
 
-        //Overflow the cache
+        //Overflow the cache; the new key is dropped rather than added.
         cache.GetOrAdd("key6", () => val6);
+
+        Assert.That(cache.Peek("key6"), Is.Null);
+        Assert.That(cache.Size, Is.EqualTo(capacity));
 
         cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
-        //Checks the clearing happened.
+        //Checks the clearing happened because an item was dropped.
         Assert.That(cache.Size, Is.EqualTo(0));
 
         var expectedHits = 0;
         var expectedMisses = 6;
-        var expectedEjections = 6;
+        var expectedEjections = 5;
+        var expectedDropped = 1;
         var expectedSize = 0;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
     }
 
     [Test]
@@ -176,23 +289,25 @@ public class SimpleCacheTests
         cache.MaintainCache(); // force cache to maintain, normally done on a timer.
         Assert.That(cache.Size, Is.EqualTo(newCapacity));
 
-        //This should overflowt the cache
+        //This should overflow the cache; key8 is dropped rather than added.
         cache.GetOrAdd("key8", () => val8);
+
+        Assert.That(cache.Peek("key8"), Is.Null);
 
         cache.MaintainCache(); // force cache to maintain, normally done on a timer.
         Assert.That(cache.Size, Is.EqualTo(0));
 
-
         var expectedHits = 0;
         var expectedMisses = 8;
-        var expectedEjections = 8;
+        var expectedEjections = 7;
+        var expectedDropped = 1;
         var expectedSize = 0;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
     }
 
     [Test]
-    public void Capacity_Decrease_CapacityIsActuallyDecrease()
+    public void Capacity_Decrease_ClearsCacheOnNextMaintenance_EvenWithoutADrop()
     {
         var val1 = "value1";
         var val2 = "value2";
@@ -201,7 +316,8 @@ public class SimpleCacheTests
         var val5 = "value5";
 
         int capacity = 5;
-        var cache = new SimpleCache<string, string>(capacity);
+        // Disable the internal timer: see comment in GetOrAdd_DropsNewItem_ButStillReturnsIt_WhenCacheAtCapacity.
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
 
         cache.GetOrAdd("key1", () => val1);
         cache.GetOrAdd("key2", () => val2);
@@ -217,17 +333,17 @@ public class SimpleCacheTests
         int newCapacity = 3;
         cache.Capacity = newCapacity;
 
-        cache.MaintainCache(); // force cache to maintain, normally done on a timer.
+        //Lowering capacity below the current size is picked up on the very next maintenance tick even
+        //though nothing was dropped - a capacity reduction (e.g. for memory pressure) must not wait on
+        //a new distinct key showing up to reclaim the over-capacity entries.
+        cache.MaintainCache();
 
-        //This checks that the clearing happened and setting new capacity works.
-        Assert.That(cache.Size, Is.EqualTo(0));
-
-        var expectedHits = 0;
-        var expectedMisses = 5;
-        var expectedEjections = 5;
-        var expectedSize = 0;
-
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Size, Is.EqualTo(0));
+            Assert.That(cache.CountEjections, Is.EqualTo(capacity));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -247,18 +363,36 @@ public class SimpleCacheTests
         var expectedHits = 2;
         var expectedMisses = 2;
         var expectedEjections = 0;
+        var expectedDropped = 0;
         var expectedSize = 2;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
 
         cache.ResetStats();
 
         expectedHits = 0;
         expectedMisses = 0;
         expectedEjections = 0;
+        expectedDropped = 0;
         expectedSize = 2;
 
-        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
+        EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedDropped, expectedSize);
+    }
+
+    [Test]
+    public void ResetStats_ResetsDroppedCounter()
+    {
+        int capacity = 1;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2"); // dropped, cache is at capacity
+
+        Assert.That(cache.CountDropped, Is.EqualTo(1));
+
+        cache.ResetStats();
+
+        Assert.That(cache.CountDropped, Is.EqualTo(0));
     }
 
     [Test]
@@ -266,11 +400,11 @@ public class SimpleCacheTests
     {
         var cache = new SimpleCache<string, string>(1);
         cache.GetOrAdd("key1", () => "value1");
-        cache.GetOrAdd("key2", () => "value2");
+        cache.GetOrAdd("key2", () => "value2"); // dropped, cache is at capacity
 
         Thread.Sleep(2500); // unnecessarily long, but should eliminate test flickers
 
-        EvaluateCacheMetrics(cache, 0, 2, 2, 0);
+        EvaluateCacheMetrics(cache, 0, 2, 1, 1, 0);
     }
 
     [Test]
@@ -302,6 +436,53 @@ public class SimpleCacheTests
     }
 
     [Test]
+    public void TryAdd_DoesNotInvokeValueFunc_WhenKeyAlreadyExists()
+    {
+        int capacity = 5;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.TryAdd("key1", () => "value1");
+
+        var valueFuncInvocations = 0;
+        var result = cache.TryAdd("key1", () =>
+        {
+            valueFuncInvocations++;
+            return "value2";
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            //The key is already cached, so there is no reason to build a value for it.
+            Assert.That(valueFuncInvocations, Is.EqualTo(0));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void TryAdd_DoesNotInvokeValueFunc_WhenCacheAtCapacity()
+    {
+        int capacity = 1;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.TryAdd("key1", () => "value1");
+
+        var valueFuncInvocations = 0;
+        var result = cache.TryAdd("key2", () =>
+        {
+            valueFuncInvocations++;
+            return "value2";
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(valueFuncInvocations, Is.EqualTo(0));
+            Assert.That(cache.CountDropped, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public void Dispose_ClearsCache()
     {
         var val1 = "value1";
@@ -315,15 +496,154 @@ public class SimpleCacheTests
         Assert.That(cache.Peek("key1"), Is.Null);
     }
 
+    [Test]
+    public void Reset_ClearsCacheAndStats()
+    {
+        int capacity = 2;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key1", () => "value1"); // hit
+        cache.GetOrAdd("key2", () => "value2");
+        cache.GetOrAdd("key3", () => "value3"); // dropped, cache is at capacity
+
+        cache.Reset();
+
+        EvaluateCacheMetrics(cache, 0, 0, 0, 0, 0);
+        Assert.That(cache.Peek("key1"), Is.Null);
+    }
+
+    [Test]
+    public void Size_CountsOnlyActualInsertions()
+    {
+        int capacity = 10;
+        var cache = new SimpleCache<string, string>(capacity);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+        cache.GetOrAdd("key2", () => "value2"); // already cached, not a new entry
+        cache.TryAdd("key3", () => "value3");
+        cache.TryAdd("key3", () => "value3"); // already cached, not a new entry
+        cache.TryAdd("key1", () => "value1"); // already cached by GetOrAdd, not a new entry
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Size, Is.EqualTo(3));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+            Assert.That(cache.CountEjections, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void MaintainCache_ResetsSize_SoTheClearedCacheAcceptsNewItemsAgain()
+    {
+        int capacity = 2;
+        // Disable the internal timer: see comment in GetOrAdd_DropsNewItem_ButStillReturnsIt_WhenCacheAtCapacity.
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+        cache.GetOrAdd("key3", () => "value3"); // dropped, cache is at capacity
+
+        cache.MaintainCache(); // force cache to maintain, normally done on a timer.
+        Assert.That(cache.Size, Is.EqualTo(0));
+
+        //The cache is empty, so this must be cached rather than dropped.
+        cache.GetOrAdd("key4", () => "value4");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Peek("key4"), Is.EqualTo("value4"));
+            Assert.That(cache.Size, Is.EqualTo(1));
+            Assert.That(cache.CountDropped, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void MaintainCache_DoesNotKeepClearing_OnLaterTicksAfterASingleDropIsResolved()
+    {
+        // Regression test: _countDropped (cumulative, only reset via ResetStats) used to be the
+        // maintenance trigger, so a single drop caused every future tick to clear the cache forever,
+        // permanently degrading it to a 500ms-lifetime cache. _droppedSinceLastMaintenance fixes this
+        // by being reset every tick.
+        int capacity = 2;
+        var cache = new SimpleCache<string, string>(capacity, Timeout.Infinite);
+
+        cache.GetOrAdd("key1", () => "value1");
+        cache.GetOrAdd("key2", () => "value2");
+        cache.GetOrAdd("key3", () => "value3"); // dropped, cache is at capacity
+
+        cache.MaintainCache(); // clears because of the drop
+        Assert.That(cache.Size, Is.EqualTo(0));
+
+        cache.GetOrAdd("key4", () => "value4"); // cache is empty, so this is cached, not dropped
+
+        //Nothing new was dropped and the cache is within capacity, so repeated ticks must not clear it.
+        cache.MaintainCache();
+        cache.MaintainCache();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Peek("key4"), Is.EqualTo("value4"));
+            Assert.That(cache.Size, Is.EqualTo(1));
+            Assert.That(cache.CountEjections, Is.EqualTo(capacity));
+        });
+    }
+
+    [Test]
+    public void GetOrAdd_ConcurrentCallsForSameNewKey_CountTheInsertOnlyOnce()
+    {
+        const int threadCount = 16;
+        int capacity = 10;
+        var cache = new SimpleCache<string, object>(capacity);
+
+        var results = new object[threadCount];
+        var startGate = new ManualResetEventSlim(false);
+        var threads = new Thread[threadCount];
+
+        for (var i = 0; i < threadCount; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() =>
+            {
+                startGate.Wait();
+                //Each thread offers a distinct instance, so the winner of the race is identifiable.
+                results[index] = cache.GetOrAdd("sameKey", () => new object());
+            });
+            threads[i].Start();
+        }
+
+        startGate.Set();
+
+        foreach (var thread in threads)
+        {
+            Assert.That(thread.Join(TimeSpan.FromSeconds(30)), Is.True, "Cache access thread did not complete.");
+        }
+
+        Assert.Multiple(() =>
+        {
+            //Only one entry was actually inserted no matter how many threads raced for the key, so
+            //the tracked size must be exactly 1. Counting inside a factory delegate handed to
+            //ConcurrentDictionary.GetOrAdd would inflate this, because that delegate can run on more
+            //than one thread even though only one of its results is stored.
+            Assert.That(cache.Size, Is.EqualTo(1));
+            Assert.That(cache.CountDropped, Is.EqualTo(0));
+
+            //Threads that lost the race must return the value that is actually cached.
+            Assert.That(results, Is.All.SameAs(cache.Peek("sameKey")));
+        });
+    }
+
 
     private void EvaluateCacheMetrics<T, V>(SimpleCache<T, V> cache, int expectedHits, int expectedMisses,
-        int expectedEjections, int expectedSize) where V : class
+        int expectedEjections, int expectedDropped, int expectedSize) where V : class
     {
         Assert.Multiple(() =>
         {
             Assert.That(cache.CountHits, Is.EqualTo(expectedHits));
             Assert.That(cache.CountMisses, Is.EqualTo(expectedMisses));
             Assert.That(cache.CountEjections, Is.EqualTo(expectedEjections));
+            Assert.That(cache.CountDropped, Is.EqualTo(expectedDropped));
             Assert.That(cache.Size, Is.EqualTo(expectedSize));
         });
     }


### PR DESCRIPTION
## Description

`SimpleCache` cleared its entire contents whenever it grew past capacity, so a busy cache (e.g. SQL parse cache) thrashed constantly and `ConcurrentDictionary.Count` locked every internal bucket on every check/clear, blocking all writers ~2x/sec per cache instance across ~15+ live instances.

- Drop new inserts on the floor once at capacity; add a `Dropped` metric (`CountDropped`) alongside the existing Hits/Misses/Ejections, plumbed through `ResetStats` the same way.
- `MaintainCache` (500ms timer) now clears only when something was actually dropped, or when tracked size is over capacity (handles `Capacity` being lowered) — otherwise persists the cache even sitting at capacity.
- Replaced `ConcurrentDictionary.Count` with a self-tracked `Interlocked` counter for size/capacity checks — removes the full-lock-acquisition cost from every insert and from `Size`.
- Fixed root cause of a null-value bug: a cached `null` was indistinguishable from an absent key, causing `GetOrAdd` to re-run the factory on every call and `Contains`/`TryAdd` to disagree about whether the key existed. `Contains`/`Get`/`GetOrAdd` now key off `ConcurrentDictionary`'s own presence signal, not `value != null`.
- Added a constructor overload (`maintainCacheIntervalMs`, default unchanged) so tests can disable the internal timer for determinism instead of racing it.

## Test plan
- [x] Unit tests added/updated in `SimpleCacheTests.cs` for drop-on-insert, capacity increase/decrease, maintenance persist-vs-clear, null-value handling, and lock-free size tracking (32 tests, all passing on net10.0/net481)
- [x] `Core.UnitTest` regression check on all real `SimpleCache` consumers (`DatabaseStatementParser`, `CacheByDatastoreVendor`, `DatastoreSegmentData`, `DatabaseService`, `JsonArrayConverter`) — all passing

## Performance

**Scenario 1** — below capacity (1000 keys, capacity 2000, 3s, 20 threads):
Old: 17.2M ops/sec   New: 22.9M ops/sec   (+33%)
Even under light load with zero clears either side, New wins — Old's 500ms timer still calls _cacheMap.Count every tick, which locks every internal dictionary segment (ConcurrentDictionary's default concurrency level scales with core count — 80 locks on this box) and briefly stalls all 20 writer threads each time. New reads a plain int.

**Scenario 2** — well above capacity (capacity 500, every key unique, 3s, 20 threads):
Old: peak size 2,047,235 entries (!) — grows unbounded for up to 500ms between clears
New: peak size       518 entries    — bounded at ~capacity + in-flight writers, always
Old: 3.5M ops/sec        New: 8.8M ops/sec   (2.5x)
This is the actual bug: Old lets the dictionary grow completely unchecked between ticks, then eats a full-lock Clear() on a multi-million-entry table. New drops on insert, so it never has more than ~capacity to hold or clear.

**Scenario 3** — null-value "negative cache" pattern (if (!Contains(k)) TryAdd(k, factory), factory returns null, 5 keys, 2s):
Old: 32,846,943 factory calls (every single op re-runs it — the poison-slot bug)
New:          5 factory calls (once per key, ever — correct)
Old: 16.3M ops/sec       New: 456.4M ops/sec   (28x)
Old's Contains treats a cached null as absent forever, so every call re-triggers TryAdd, and TryAdd's factory argument evaluates before its own internal existence check — so the "wasted" work runs unconditionally, every time, forever. New's fix eliminates it entirely after the first insert.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
