### PR TITLE
fix: Aggregate metrics post rename instead of using old names.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollection.cs
@@ -67,27 +67,55 @@ public class MetricStatsCollection
         }
     }
 
-    public IEnumerable<MetricWireModel> ConvertToJsonForSending(IMetricNameService nameService)
+    /// <summary>
+    /// Applies the metric rename rules to every metric in this collection and returns the results, ready
+    /// to be serialized and sent.
+    ///
+    /// Everything up to this point aggregates on pre-rename metric names, so two distinct names can collapse
+    /// onto a single name once the rules are applied. Renamed metrics are therefore re-keyed and re-merged
+    /// here; without that, colliding metrics would be sent as separate metrics that happen to share a name,
+    /// each carrying only its own portion of the data, instead of as one aggregate.
+    /// </summary>
+    public IList<MetricWireModel> ConvertToJsonForSending(IMetricNameService nameService)
     {
-        foreach (KeyValuePair<string, MetricDataWireModel> current in _unscopedStats)
+        var metrics = new List<MetricWireModel>();
+
+        foreach (KeyValuePair<string, MetricDataWireModel> current in RenameAndMerge(_unscopedStats, nameService))
         {
-            var metric = MetricWireModel.BuildMetric(nameService, current.Key, null, current.Value);
-            if (metric != null)
-            {
-                yield return metric;
-            }
+            metrics.Add(MetricWireModel.BuildMetric(current.Key, null, current.Value));
         }
 
         foreach (KeyValuePair<string, MetricStatsDictionary<string, MetricDataWireModel>> currentScope in _scopedStats)
         {
-            foreach (KeyValuePair<string, MetricDataWireModel> currentMetric in currentScope.Value)
+            foreach (KeyValuePair<string, MetricDataWireModel> currentMetric in RenameAndMerge(currentScope.Value, nameService))
             {
-                var metric = MetricWireModel.BuildMetric(nameService, currentMetric.Key, currentScope.Key, currentMetric.Value);
-                if (metric != null)
-                {
-                    yield return metric;
-                }
+                metrics.Add(MetricWireModel.BuildMetric(currentMetric.Key, currentScope.Key, currentMetric.Value));
             }
         }
+
+        return metrics;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="stats"/> keyed on post-rename metric names, merging the data of any
+    /// metrics whose names collide once renamed. Metrics that the rename rules mark as ignored are dropped.
+    /// </summary>
+    private MetricStatsDictionary<string, MetricDataWireModel> RenameAndMerge(IEnumerable<KeyValuePair<string, MetricDataWireModel>> stats, IMetricNameService nameService)
+    {
+        var renamedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
+
+        foreach (KeyValuePair<string, MetricDataWireModel> current in stats)
+        {
+            // MetricNameService returns null if the metric needs to be ignored
+            var newName = nameService.RenameMetric(current.Key);
+            if (newName == null)
+            {
+                continue;
+            }
+
+            renamedStats.Merge(newName, current.Value, _mergeFunction);
+        }
+
+        return renamedStats;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -65,16 +65,21 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         return new MetricWireModel(metricName, mergedData);
     }
 
-    public static MetricWireModel BuildMetric(IMetricNameService metricNameService, string proposedName, string scope, MetricDataWireModel metricData)
+    /// <summary>
+    /// Builds a metric using <paramref name="name"/> as-is. Metric rename rules are deliberately NOT
+    /// applied here: metrics aggregate under this name and the rules are applied once at harvest time,
+    /// in <see cref="Aggregators.MetricStatsCollection.ConvertToJsonForSending"/>. Renaming here as well
+    /// would apply the rules twice to any metric that is built before it is aggregated.
+    /// </summary>
+    /// <returns>The metric, or null if <paramref name="name"/> is null.</returns>
+    public static MetricWireModel BuildMetric(string name, string scope, MetricDataWireModel metricData)
     {
-        // MetricNameService will return null if the metric needs to be ignored
-        var newName = metricNameService.RenameMetric(proposedName);
-        if (newName == null)
+        if (name == null)
         {
             return null;
         }
 
-        var metricName = new MetricNameWireModel(newName, scope);
+        var metricName = new MetricNameWireModel(name, scope);
         return new MetricWireModel(metricName, metricData);
     }
 
@@ -120,13 +125,6 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
 
     public class MetricBuilder : IMetricBuilder
     {
-        private readonly IMetricNameService _metricNameService;
-
-        public MetricBuilder(IMetricNameService metricNameService)
-        {
-            _metricNameService = metricNameService;
-        }
-
         #region Transaction builders
 
         public static void TryBuildTransactionMetrics(bool isWebTransaction, TimeSpan responseTimeOrDuration,
@@ -161,37 +159,37 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         public MetricWireModel TryBuildMemoryPhysicalMetric(long memoryPhysical)
         {
             var data = MetricDataWireModel.BuildByteData(memoryPhysical);
-            return BuildMetric(_metricNameService, MetricNames.MemoryPhysical, null, data);
+            return BuildMetric(MetricNames.MemoryPhysical, null, data);
         }
 
         public MetricWireModel TryBuildMemoryWorkingSetMetric(long memoryWorkingSet)
         {
             var data = MetricDataWireModel.BuildByteData(memoryWorkingSet);
-            return BuildMetric(_metricNameService, MetricNames.MemoryWorkingSet, null, data);
+            return BuildMetric(MetricNames.MemoryWorkingSet, null, data);
         }
 
         public MetricWireModel TryBuildThreadpoolUsageStatsMetric(ThreadType type, ThreadStatus status, int countThreadpoolThreads)
         {
             var data = MetricDataWireModel.BuildGaugeValue(countThreadpoolThreads);
-            return BuildMetric(_metricNameService, MetricNames.GetThreadpoolUsageStatsName(type, status), null, data);
+            return BuildMetric(MetricNames.GetThreadpoolUsageStatsName(type, status), null, data);
         }
 
         public MetricWireModel TryBuildThreadpoolThroughputStatsMetric(ThreadpoolThroughputStatsType type, int statsVal)
         {
             var data = MetricDataWireModel.BuildGaugeValue(statsVal);
-            return BuildMetric(_metricNameService, MetricNames.GetThreadpoolThroughputStatsName(type), null, data);
+            return BuildMetric(MetricNames.GetThreadpoolThroughputStatsName(type), null, data);
         }
 
         public MetricWireModel TryBuildCpuUserTimeMetric(TimeSpan cpuTime)
         {
             var data = MetricDataWireModel.BuildTimingData(cpuTime, cpuTime);
-            return BuildMetric(_metricNameService, MetricNames.CpuUserTime, null, data);
+            return BuildMetric(MetricNames.CpuUserTime, null, data);
         }
 
         public MetricWireModel TryBuildCpuUserUtilizationMetric(float cpuUtilization)
         {
             var data = MetricDataWireModel.BuildPercentageData(cpuUtilization);
-            return BuildMetric(_metricNameService, MetricNames.CpuUserUtilization, null, data);
+            return BuildMetric(MetricNames.CpuUserUtilization, null, data);
         }
 
         public MetricWireModel TryBuildCpuTimeRollupMetric(bool isWebTransaction, TimeSpan cpuTime)
@@ -200,14 +198,14 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
                 ? MetricNames.WebTransactionCpuTimeAll
                 : MetricNames.OtherTransactionCpuTimeAll;
             var data = MetricDataWireModel.BuildTimingData(cpuTime, TimeSpan.Zero);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCpuTimeMetric(TransactionMetricName transactionMetricName, TimeSpan cpuTime)
         {
             var proposedName = MetricNames.TransactionCpuTime(transactionMetricName);
             var data = MetricDataWireModel.BuildTimingData(cpuTime, TimeSpan.Zero);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public static void TryBuildQueueTimeMetric(TimeSpan queueTime, TransactionMetricStatsCollection txStats)
@@ -219,25 +217,25 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         public MetricWireModel TryBuildGCBytesMetric(GCSampleType sampleType, long value)
         {
             var data = MetricDataWireModel.BuildByteData(value);
-            return BuildMetric(_metricNameService, MetricNames.GetGCMetricName(sampleType), null, data);
+            return BuildMetric(MetricNames.GetGCMetricName(sampleType), null, data);
         }
 
         public MetricWireModel TryBuildGCCountMetric(GCSampleType sampleType, int value)
         {
             var data = MetricDataWireModel.BuildCountData(value);
-            return BuildMetric(_metricNameService, MetricNames.GetGCMetricName(sampleType), null, data);
+            return BuildMetric(MetricNames.GetGCMetricName(sampleType), null, data);
         }
 
         public MetricWireModel TryBuildGCPercentMetric(GCSampleType sampleType, float value)
         {
             var data = MetricDataWireModel.BuildPercentageData(value);
-            return BuildMetric(_metricNameService, MetricNames.GetGCMetricName(sampleType), null, data);
+            return BuildMetric(MetricNames.GetGCMetricName(sampleType), null, data);
         }
 
         public MetricWireModel TryBuildGCGaugeMetric(GCSampleType sampleType, float value)
         {
             var data = MetricDataWireModel.BuildGaugeValue(value);
-            return BuildMetric(_metricNameService, MetricNames.GetGCMetricName(sampleType), null, data);
+            return BuildMetric(MetricNames.GetGCMetricName(sampleType), null, data);
         }
 
         #region Transaction apdex builders
@@ -512,87 +510,87 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             var proposedName = MetricNames.GetSupportabilityName(metricName);
             var data = MetricDataWireModel.BuildCountData(count);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityDataUsageMetric(string metricName, long callCount, float dataSent, float dataReceived)
         {
             var data = MetricDataWireModel.BuildDataUsageValue(callCount, dataSent, dataReceived);
-            return BuildMetric(_metricNameService, metricName, null, data);
+            return BuildMetric(metricName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilitySummaryMetric(string metricName, float totalValue, int countSamples, float minValue, float maxValue)
         {
             var proposedName = MetricNames.GetSupportabilityName(metricName);
             var data = MetricDataWireModel.BuildSummaryValue(countSamples, totalValue, minValue, maxValue);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityGaugeMetric(string metricName, float value)
         {
             var proposedName = MetricNames.GetSupportabilityName(metricName);
             var data = MetricDataWireModel.BuildGaugeValue(value);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildDotnetFrameworkVersionMetric(DotnetFrameworkVersion version)
         {
             var proposedName = MetricNames.GetSupportabilityDotnetFrameworkVersion(version);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildDotnetCoreVersionMetric(DotnetCoreVersion version)
         {
             var proposedName = MetricNames.GetSupportabilityDotnetCoreVersion(version);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCATSupportabilityCountMetric(CATSupportabilityCondition conditionType, int count)
         {
             var proposedName = MetricNames.GetSupportabilityCATConditionMetricName(conditionType);
             var data = MetricDataWireModel.BuildCountData(count);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAgentVersionMetric(string agentVersion)
         {
             var proposedName = MetricNames.GetSupportabilityAgentVersion(agentVersion);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAgentVersionByHostMetric(string hostName, string agentVersion)
         {
             var proposedName = MetricNames.GetSupportabilityAgentVersionByHost(hostName, agentVersion);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
         public MetricWireModel TryBuildLibraryVersionMetric(string assemblyName, string assemblyVersion)
         {
             var proposedName = MetricNames.GetSupportabilityLibraryVersion(assemblyName, assemblyVersion);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
         public MetricWireModel TryBuildCustomInstrumentationMetric(string assemblyName, string className, string method)
         {
             var proposedName = MetricNames.GetSupportabilityCustomInstrumentation(assemblyName, className, method);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
         public MetricWireModel TryBuildMetricHarvestAttemptMetric()
         {
             const string proposedName = MetricNames.SupportabilityMetricHarvestTransmit;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildInstallTypeMetric(string installType)
         {
             var proposedName = MetricNames.GetSupportabilityInstallType(installType);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #region TransactionEvents
@@ -601,21 +599,21 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             const string proposedName = MetricNames.SupportabilityTransactionEventsReservoirResize;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildTransactionEventsCollectedMetric()
         {
             const string proposedName = MetricNames.SupportabilityTransactionEventsCollected;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildTransactionEventsRecollectedMetric(int eventsRecollected)
         {
             const string proposedName = MetricNames.SupportabilityTransactionEventsRecollected;
             var data = MetricDataWireModel.BuildCountData(eventsRecollected);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildTransactionEventsSentMetric(int eventCount)
@@ -623,7 +621,7 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
             // Note: this metric is REQUIRED by APM (see https://source.datanerd.us/agents/agent-specs/pull/84)
             const string proposedName = MetricNames.SupportabilityTransactionEventsSent;
             var data = MetricDataWireModel.BuildCountData(eventCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildTransactionEventsSeenMetric()
@@ -631,7 +629,7 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
             // Note: this metric is REQUIRED by APM (see https://source.datanerd.us/agents/agent-specs/pull/84)
             const string proposedName = MetricNames.SupportabilityTransactionEventsSeen;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #endregion TransactionEvents
@@ -642,35 +640,35 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             const string proposedName = MetricNames.SupportabilityCustomEventsReservoirResize;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCustomEventsCollectedMetric()
         {
             const string proposedName = MetricNames.SupportabilityCustomEventsCollected;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCustomEventsRecollectedMetric(int eventsRecollected)
         {
             const string proposedName = MetricNames.SupportabilityCustomEventsRecollected;
             var data = MetricDataWireModel.BuildCountData(eventsRecollected);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCustomEventsSentMetric(int eventCount)
         {
             const string proposedName = MetricNames.SupportabilityCustomEventsSent;
             var data = MetricDataWireModel.BuildCountData(eventCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCustomEventsSeenMetric()
         {
             const string proposedName = MetricNames.SupportabilityCustomEventsSeen;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #endregion CustomEvents
@@ -681,21 +679,21 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             const string proposedName = MetricNames.SupportabilityErrorTracesCollected;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildErrorTracesRecollectedMetric(int errorTracesRecollected)
         {
             const string proposedName = MetricNames.SupportabilityErrorTracesRecollected;
             var data = MetricDataWireModel.BuildCountData(errorTracesRecollected);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildErrorTracesSentMetric(int errorTraceCount)
         {
             const string proposedName = MetricNames.SupportabilityErrorTracesSent;
             var data = MetricDataWireModel.BuildCountData(errorTraceCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #endregion ErrorTraces
@@ -706,14 +704,14 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             const string proposedName = MetricNames.SupportabilityErrorEventsSent;
             var data = MetricDataWireModel.BuildCountData(eventCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildErrorEventsSeenMetric()
         {
             const string proposedName = MetricNames.SupportabilityErrorEventsSeen;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #endregion ErrorEvents
@@ -730,14 +728,14 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             const string proposedName = MetricNames.SupportabilitySqlTracesRecollected;
             var data = MetricDataWireModel.BuildCountData(sqlTracesRecollected);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSqlTracesSentMetric(int sqlTraceCount)
         {
             const string proposedName = MetricNames.SupportabilitySqlTracesSent;
             var data = MetricDataWireModel.BuildCountData(sqlTraceCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         #endregion SqlTraces
@@ -747,7 +745,7 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             var proposedName = MetricNames.GetSupportabilityAgentHealthEvent(agentHealthEvent, additionalData);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAgentHealthEventMetric(AgentHealthEvent agentHealthEvent, string wrapperName,
@@ -756,14 +754,14 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
             var proposedName =
                 MetricNames.GetSupportabilityAgentHealthEvent(agentHealthEvent, $"{wrapperName}/{typeName}.{methodName}");
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildFeatureEnabledMetric(string featureName)
         {
             var proposedName = MetricNames.GetSupportabilityFeatureEnabled(featureName);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
 
@@ -771,14 +769,14 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             var proposedName = MetricNames.GetSupportabilityAgentApi(methodName);
             var data = MetricDataWireModel.BuildCountData(count);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCustomTimingMetric(string suffix, TimeSpan time)
         {
             var proposedName = MetricNames.GetCustom(suffix);
             var data = MetricDataWireModel.BuildTimingData(time, time);
-            return BuildMetric(_metricNameService, proposedName.ToString(), null, data);
+            return BuildMetric(proposedName.ToString(), null, data);
         }
 
         public MetricWireModel TryBuildCustomCountMetric(string metricName, int count = 1)
@@ -787,68 +785,68 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
             // This is probably a historical blunder -- it's not a good thing that we allow users to use whatever text they want for the first segment.
             // However, that is what the API currently allows and it would be difficult to take that feature away.
             var data = MetricDataWireModel.BuildCountData(count);
-            return BuildMetric(_metricNameService, metricName, null, data);
+            return BuildMetric(metricName, null, data);
         }
 
         public MetricWireModel TryBuildLinuxOsMetric(bool isLinux)
         {
             var proposedName = MetricNames.GetSupportabilityLinuxOs();
             var data = MetricDataWireModel.BuildIfLinuxData(isLinux);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildBootIdError()
         {
             var proposedName = MetricNames.GetSupportabilityBootIdError();
             var data = MetricDataWireModel.BuildBootIdError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildKubernetesUsabilityError()
         {
             var proposedName = MetricNames.GetSupportabilityKubernetesUsabilityError();
             var data = MetricDataWireModel.BuildKubernetesUsabilityError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAwsUsabilityError()
         {
             var proposedName = MetricNames.GetSupportabilityAwsUsabilityError();
             var data = MetricDataWireModel.BuildAwsUsabilityError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAzureUsabilityError()
         {
             var proposedName = MetricNames.GetSupportabilityAzureUsabilityError();
             var data = MetricDataWireModel.BuildAzureUsabilityError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildPcfUsabilityError()
         {
             var proposedName = MetricNames.GetSupportabilityPcfUsabilityError();
             var data = MetricDataWireModel.BuildPcfUsabilityError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildGcpUsabilityError()
         {
             var proposedName = MetricNames.GetSupportabilityGcpUsabilityError();
             var data = MetricDataWireModel.BuildGcpUsabilityError();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildAgentTimingMetric(string suffix, TimeSpan time)
         {
             var proposedName = MetricNames.GetSupportabilityAgentTimingMetric(suffix);
             var data = MetricDataWireModel.BuildTimingData(time, time);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
 
         private MetricWireModel TryBuildSupportabilityDistributedTraceMetric(string proposedName, int count = 1) =>
-            BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
 
         // New Relic Payload (Legacy DT) sup. metrics: https://source.datanerd.us/agents/agent-specs/blob/master/distributed_tracing/New-Relic-Payload.md
 
@@ -931,25 +929,25 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         {
             var proposedName = MetricNames.GetSupportabilityErrorHttpStatusCodeFromCollector(statusCode);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityEndpointMethodErrorAttempts(string endpointMethod)
         {
             var proposedName = MetricNames.GetSupportabilityEndpointMethodErrorAttempts(endpointMethod);
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityEndpointMethodErrorDuration(string endpointMethod, TimeSpan responseDuration)
         {
             var proposedName = MetricNames.GetSupportabilityEndpointMethodErrorDuration(endpointMethod);
             var data = MetricDataWireModel.BuildTimingData(responseDuration, responseDuration);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         private MetricWireModel TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimitMetric(string proposedName, int count) =>
-            BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
 
         public MetricWireModel TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimit(string endpoint, int count = 1) =>
             TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimitMetric(MetricNames.GetSupportabilityPayloadsDroppedDueToMaxPayloadLimit(endpoint), count);
@@ -1007,64 +1005,64 @@ public class MetricWireModel : IAllMetricStatsCollection, IWireModel
         public MetricWireModel TryBuildLoggingMetricsLinesCountBySeverityMetric(string logLevel, int count)
         {
             var proposedName = MetricNames.GetLoggingMetricsLinesBySeverityName(logLevel);
-            return BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            return BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
         }
 
         public MetricWireModel TryBuildLoggingMetricsLinesCountMetric(int count)
         {
             var proposedName = MetricNames.GetLoggingMetricsLinesName();
-            return BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            return BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
         }
 
         public MetricWireModel TryBuildLoggingMetricsDeniedCountBySeverityMetric(string logLevel, int count)
         {
             var proposedName = MetricNames.GetLoggingMetricsDeniedBySeverityName(logLevel);
-            return BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            return BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
         }
 
         public MetricWireModel TryBuildLoggingMetricsDeniedCountMetric(int count)
         {
             var proposedName = MetricNames.GetLoggingMetricsDeniedName();
-            return BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
+            return BuildMetric(proposedName, null, MetricDataWireModel.BuildCountData(count));
         }
 
         public MetricWireModel TryBuildSupportabilityLoggingEventsCollectedMetric()
         {
             const string proposedName = MetricNames.SupportabilityLoggingEventsCollected;
             var data = MetricDataWireModel.BuildCountData();
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityLoggingEventsSentMetric(int loggingEventCount)
         {
             const string proposedName = MetricNames.SupportabilityLoggingEventsSent;
             var data = MetricDataWireModel.BuildCountData(loggingEventCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildSupportabilityLoggingEventsDroppedMetric(int droppedCount)
         {
             const string proposedName = MetricNames.SupportabilityLoggingEventsDropped;
             var data = MetricDataWireModel.BuildCountData(droppedCount);
-            return BuildMetric(_metricNameService, proposedName, null, data);
+            return BuildMetric(proposedName, null, data);
         }
 
         public MetricWireModel TryBuildCountMetric(string metricName, long count)
         {
             var data = MetricDataWireModel.BuildCountData(count);
-            return BuildMetric(_metricNameService, metricName, null, data);
+            return BuildMetric(metricName, null, data);
         }
 
         public MetricWireModel TryBuildByteMetric(string metricName, long totalBytes, long? exclusiveBytes)
         {
             var data = MetricDataWireModel.BuildByteData(totalBytes, exclusiveBytes);
-            return BuildMetric(_metricNameService, metricName, null, data);
+            return BuildMetric(metricName, null, data);
         }
 
         public MetricWireModel TryBuildGaugeMetric(string metricName, float value)
         {
             var data = MetricDataWireModel.BuildGaugeValue(value);
-            return BuildMetric(_metricNameService, metricName, null, data);
+            return BuildMetric(metricName, null, data);
         }
 
         #endregion

--- a/tests/Agent/UnitTests/CompositeTests/MetricNameRuleTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/MetricNameRuleTests.cs
@@ -1,0 +1,168 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Core.Configuration;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NUnit.Framework;
+
+namespace CompositeTests;
+
+/// <summary>
+/// End-to-end coverage for server-side metric_name_rules. The agent must apply the rules and then
+/// aggregate the results, so metrics whose names collapse onto one name are sent as a single metric
+/// carrying their combined data rather than as duplicates that merely share a name.
+/// </summary>
+internal class MetricNameRuleTests
+{
+    private static CompositeTestAgent _compositeTestAgent;
+
+    private IAgent _agent;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _compositeTestAgent = new CompositeTestAgent();
+        _agent = _compositeTestAgent.GetAgent();
+    }
+
+    [TearDown]
+    public static void TearDown()
+    {
+        _compositeTestAgent.Dispose();
+    }
+
+    private void PushMetricNameRules(params ServerConfiguration.RegexRule[] rules)
+    {
+        _compositeTestAgent.ServerConfiguration.MetricNameRegexRules = rules;
+        _compositeTestAgent.PushConfiguration();
+    }
+
+    private void RunTransactionWithTwoSegments()
+    {
+        var tx = _agent.CreateTransaction(
+            isWeb: true,
+            category: EnumNameCache<WebTransactionType>.GetName(WebTransactionType.Action),
+            transactionDisplayName: "name",
+            doNotTrackAsUnitOfWork: true);
+        _agent.StartTransactionSegmentOrThrow("segmentA").End();
+        _agent.StartTransactionSegmentOrThrow("segmentB").End();
+        tx.End();
+        _compositeTestAgent.Harvest();
+    }
+
+    [Test]
+    public void MetricsCollapsedOntoOneNameByARule_AreAggregatedIntoASingleMetric()
+    {
+        PushMetricNameRules(new ServerConfiguration.RegexRule
+        {
+            MatchExpression = @"^DotNet/segment[AB]$",
+            Replacement = "DotNet/merged",
+            EvaluationOrder = 0
+        });
+
+        RunTransactionWithTwoSegments();
+
+        // Both segments contribute to one unscoped and one scoped "DotNet/merged" metric, each with a
+        // call count of 2 -- not two separate metrics of call count 1 that happen to share a name.
+        MetricAssertions.MetricsExist(new List<ExpectedMetric>
+        {
+            new ExpectedCountMetric { Name = "DotNet/merged", CallCount = 2 },
+            new ExpectedCountMetric { Name = "DotNet/merged", Scope = "WebTransaction/Action/name", CallCount = 2 }
+        }, _compositeTestAgent.Metrics);
+
+        MetricAssertions.MetricsDoNotExist(new List<ExpectedMetric>
+        {
+            new ExpectedMetric { Name = "DotNet/segmentA" },
+            new ExpectedMetric { Name = "DotNet/segmentB" }
+        }, _compositeTestAgent.Metrics);
+
+        var mergedMetrics = _compositeTestAgent.Metrics
+            .Where(metric => metric.MetricNameModel.Name == "DotNet/merged")
+            .ToList();
+        Assert.That(mergedMetrics, Has.Count.EqualTo(2),
+            "Expected exactly one unscoped and one scoped 'DotNet/merged' metric. More than that means the renamed metrics were emitted separately instead of being merged.");
+    }
+
+    [Test]
+    public void MetricsCollapsedOntoOneNameByARule_HaveTheirTimingDataCombined()
+    {
+        PushMetricNameRules(new ServerConfiguration.RegexRule
+        {
+            MatchExpression = @"^DotNet/segment[AB]$",
+            Replacement = "DotNet/merged",
+            EvaluationOrder = 0
+        });
+
+        RunTransactionWithTwoSegments();
+
+        var unscopedMerged = _compositeTestAgent.Metrics
+            .Single(metric => metric.MetricNameModel.Name == "DotNet/merged" && metric.MetricNameModel.Scope == null);
+        var scopedMerged = _compositeTestAgent.Metrics
+            .Single(metric => metric.MetricNameModel.Name == "DotNet/merged" && metric.MetricNameModel.Scope == "WebTransaction/Action/name");
+
+        // Value1 is total time and Value2 total exclusive time; both segments' time must be present.
+        Assert.Multiple(() =>
+        {
+            Assert.That(unscopedMerged.DataModel.Value0, Is.EqualTo(2));
+            Assert.That(unscopedMerged.DataModel.Value1, Is.GreaterThanOrEqualTo(0));
+            Assert.That(scopedMerged.DataModel.Value0, Is.EqualTo(2));
+            Assert.That(scopedMerged.DataModel.Value1, Is.EqualTo(unscopedMerged.DataModel.Value1));
+            Assert.That(scopedMerged.DataModel.Value2, Is.EqualTo(unscopedMerged.DataModel.Value2));
+        });
+    }
+
+    [Test]
+    public void MetricsMatchingAnIgnoreRule_AreNotSent()
+    {
+        PushMetricNameRules(new ServerConfiguration.RegexRule
+        {
+            MatchExpression = @"^DotNet/segmentA$",
+            Ignore = true,
+            EvaluationOrder = 0
+        });
+
+        RunTransactionWithTwoSegments();
+
+        MetricAssertions.MetricsExist(new List<ExpectedMetric>
+        {
+            new ExpectedCountMetric { Name = "DotNet/segmentB", CallCount = 1 }
+        }, _compositeTestAgent.Metrics);
+
+        MetricAssertions.MetricsDoNotExist(new List<ExpectedMetric>
+        {
+            new ExpectedMetric { Name = "DotNet/segmentA" },
+            new ExpectedMetric { Name = "DotNet/segmentA", Scope = "WebTransaction/Action/name" }
+        }, _compositeTestAgent.Metrics);
+    }
+
+    [Test]
+    public void RenameRulesAreAppliedExactlyOnceToEveryMetric()
+    {
+        // A catch-all, non-idempotent rule: applying it twice to the same name yields a doubled prefix.
+        // Supportability metrics are the ones at risk here, because they are built (and previously
+        // renamed) before they are aggregated, then renamed again at harvest.
+        PushMetricNameRules(new ServerConfiguration.RegexRule
+        {
+            MatchExpression = "^(.*)$",
+            Replacement = "Prefixed/$1",
+            EvaluationOrder = 0
+        });
+
+        RunTransactionWithTwoSegments();
+
+        var doublePrefixed = _compositeTestAgent.Metrics
+            .Where(metric => metric.MetricNameModel.Name.StartsWith("Prefixed/Prefixed/"))
+            .Select(metric => metric.MetricNameModel.Name)
+            .ToList();
+
+        Assert.That(doublePrefixed, Is.Empty,
+            "These metric names were run through the rename rules twice: " + string.Join(", ", doublePrefixed));
+
+        // Sanity check that the rule actually fired, so the assertion above cannot pass vacuously.
+        Assert.That(_compositeTestAgent.Metrics.Select(metric => metric.MetricNameModel.Name),
+            Has.All.StartsWith("Prefixed/"));
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthHeartbeatTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthHeartbeatTests.cs
@@ -43,7 +43,7 @@ internal class AgentHealthHeartbeatTests
     {
         var metricNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-        return new MetricWireModel.MetricBuilder(metricNameService);
+        return new MetricWireModel.MetricBuilder();
     }
 
     [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
@@ -195,8 +195,8 @@ public class MetricAggregatorTests
         Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<IEnumerable<MetricWireModel>>(), Arg.IsAny<string>()))
             .DoInstead<IEnumerable<MetricWireModel>>(metrics => sentMetrics = metrics);
 
-        _metricAggregator.Collect(MetricWireModel.BuildMetric(_metricNameService, "DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
-        _metricAggregator.Collect(MetricWireModel.BuildMetric(_metricNameService, "DotNet/metric2", "scope2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
+        _metricAggregator.Collect(MetricWireModel.BuildMetric("DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
+        _metricAggregator.Collect(MetricWireModel.BuildMetric("DotNet/metric2", "scope2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
 
         _harvestAction();
 
@@ -263,9 +263,9 @@ public class MetricAggregatorTests
         Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<IEnumerable<MetricWireModel>>(), Arg.IsAny<string>()))
             .DoInstead<IEnumerable<MetricWireModel>>(metrics => sentMetrics = metrics);
 
-        _metricAggregator.Collect(MetricWireModel.BuildMetric(_metricNameService, "DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
-        _metricAggregator.Collect(MetricWireModel.BuildMetric(_metricNameService, "DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
-        _metricAggregator.Collect(MetricWireModel.BuildMetric(_metricNameService, "DotNet/metric2", "scope2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
+        _metricAggregator.Collect(MetricWireModel.BuildMetric("DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
+        _metricAggregator.Collect(MetricWireModel.BuildMetric("DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
+        _metricAggregator.Collect(MetricWireModel.BuildMetric("DotNet/metric2", "scope2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5))));
 
         _harvestAction();
 
@@ -345,9 +345,9 @@ public class MetricAggregatorTests
                 return DataTransportResponseStatus.Retain;
             });
 
-        _metricAggregator.Collect(BuildMetric(_metricNameService, "DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
+        _metricAggregator.Collect(BuildMetric("DotNet/metric1", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
         _harvestAction();
-        _metricAggregator.Collect(BuildMetric(_metricNameService, "DotNet/metric2", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
+        _metricAggregator.Collect(BuildMetric("DotNet/metric2", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1))));
         _harvestAction();
 
         Assert.Multiple(() =>

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NewRelic.Agent.Core.Metrics;
 using NewRelic.Agent.Core.WireModels;
 using NUnit.Framework;
@@ -21,7 +22,7 @@ class MetricStatsCollectionTests
     {
         _metricNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => _metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-        _metricBuilder = new MetricWireModel.MetricBuilder(_metricNameService);
+        _metricBuilder = new MetricWireModel.MetricBuilder();
     }
 
     [TearDown]
@@ -37,7 +38,7 @@ class MetricStatsCollectionTests
     {
         IMetricNameService mNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
         IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(mNameService);
@@ -64,7 +65,7 @@ class MetricStatsCollectionTests
 
     private void MergeUnscopedNotCreated_OneStat()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
         IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
@@ -90,7 +91,7 @@ class MetricStatsCollectionTests
     {
         IMetricNameService mNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         var scopedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
         scopedStats[metric1.MetricNameModel.Name] = metric1.DataModel;
@@ -116,7 +117,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeUnscopedNotCreated_OneStatEmptyString()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
         IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
@@ -140,7 +141,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeUnscopedNotCreated_TwoStatsSame()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
@@ -161,7 +162,7 @@ class MetricStatsCollectionTests
         }
         Assert.That(count, Is.EqualTo(1));
 
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
+        var metric2 = MetricWireModel.BuildMetric("name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
         collection.MergeUnscopedStats(metric2.MetricNameModel.Name, metric2.DataModel);
         collection.MergeUnscopedStats(metric2.MetricNameModel.Name, metric2.DataModel);
         stats = collection.ConvertToJsonForSending(_metricNameService);
@@ -186,8 +187,8 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeUnscopeNotCreated_TwoDifferentSame()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
+        var metric2 = MetricWireModel.BuildMetric("DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
         var collection = new MetricStatsCollection();
         collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
@@ -233,7 +234,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_OneStat_StringData()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
         IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
@@ -257,7 +258,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_TwoStatsSame_StringData()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
         collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
@@ -283,8 +284,8 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_TwoDifferentSame_StringData()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
+        var metric2 = MetricWireModel.BuildMetric("DotNet/another", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
         var collection = new MetricStatsCollection();
         collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
@@ -331,7 +332,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_OneStat()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
         txStats.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
@@ -357,7 +358,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_TwoStatsSame()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
         txStats.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
@@ -385,7 +386,7 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_TwoStatsSeparateEngines()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         var collection = new MetricStatsCollection();
         MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
         txStats1.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
@@ -415,8 +416,8 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_TwoDifferentSame()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
+        var metric2 = MetricWireModel.BuildMetric("DotNet/another", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
         var collection = new MetricStatsCollection();
         MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
@@ -462,10 +463,10 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeScopedStats_DifferentScopes()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-        var metric3 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myotherscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-        var metric4 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "myotherscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(6)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
+        var metric2 = MetricWireModel.BuildMetric("DotNet/another", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        var metric3 = MetricWireModel.BuildMetric("DotNet/name", "myotherscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
+        var metric4 = MetricWireModel.BuildMetric("DotNet/another", "myotherscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(6)));
 
 
         var collection = new MetricStatsCollection();
@@ -549,8 +550,8 @@ class MetricStatsCollectionTests
     [Test]
     public void MergeStatsEngine_Mix()
     {
-        var metric5 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4)));
-        var metric6 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(6)));
+        var metric5 = MetricWireModel.BuildMetric("DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4)));
+        var metric6 = MetricWireModel.BuildMetric("DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(6)));
 
         var collection1 = new MetricStatsCollection();
         MetricStatsDictionary<string, MetricDataWireModel> scoped1 = new MetricStatsDictionary<string, MetricDataWireModel>();
@@ -581,5 +582,205 @@ class MetricStatsCollectionTests
     }
 
     #endregion MergeStatsEngine
+
+    #region Rename collisions
+
+    /// <summary>
+    /// Creates a name service that renames each key of <paramref name="renames"/> to its value and leaves
+    /// every other metric name alone. A null value means the rename rules ignore that metric.
+    /// </summary>
+    private static IMetricNameService CreateRenamingMetricNameService(IDictionary<string, string> renames)
+    {
+        var nameService = Mock.Create<IMetricNameService>();
+        Mock.Arrange(() => nameService.RenameMetric(Arg.IsAny<string>()))
+            .Returns<string>(name => renames.TryGetValue(name, out var newName) ? newName : name);
+        return nameService;
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_UnscopedMetricsCollidingAfterRename_AreMergedIntoOneMetric()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", "Custom/Renamed" },
+            { "Custom/B", "Custom/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeUnscopedStats("Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeUnscopedStats("Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("Custom/Renamed"));
+            Assert.That(stats[0].MetricNameModel.Scope, Is.EqualTo(null));
+            Assert.That(stats[0].DataModel.Value0, Is.EqualTo(15));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_UnscopedMetricsCollidingAfterRename_MergeTimingDataAcrossAllValues()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "DotNet/A", "DotNet/Renamed" },
+            { "DotNet/B", "DotNet/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeUnscopedStats("DotNet/A", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+        collection.MergeUnscopedStats("DotNet/B", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("DotNet/Renamed"));
+            Assert.That(stats[0].DataModel.Value0, Is.EqualTo(2));
+            Assert.That(stats[0].DataModel.Value1, Is.EqualTo(8));
+            Assert.That(stats[0].DataModel.Value2, Is.EqualTo(6));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_ScopedMetricsInSameScopeCollidingAfterRename_AreMergedIntoOneMetric()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", "Custom/Renamed" },
+            { "Custom/B", "Custom/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeScopedStats("myScope", "Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeScopedStats("myScope", "Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("Custom/Renamed"));
+            Assert.That(stats[0].MetricNameModel.Scope, Is.EqualTo("myScope"));
+            Assert.That(stats[0].DataModel.Value0, Is.EqualTo(15));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_ScopedMetricsInDifferentScopesCollidingAfterRename_AreNotMerged()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", "Custom/Renamed" },
+            { "Custom/B", "Custom/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeScopedStats("scopeOne", "Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeScopedStats("scopeTwo", "Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats.Select(metric => metric.MetricNameModel.Name), Has.All.EqualTo("Custom/Renamed"));
+            Assert.That(stats.First(metric => metric.MetricNameModel.Scope == "scopeOne").DataModel.Value0, Is.EqualTo(5));
+            Assert.That(stats.First(metric => metric.MetricNameModel.Scope == "scopeTwo").DataModel.Value0, Is.EqualTo(10));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_UnscopedAndScopedMetricsWithTheSameRenamedName_AreNotMerged()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", "Custom/Renamed" },
+            { "Custom/B", "Custom/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeUnscopedStats("Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeScopedStats("myScope", "Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats.First(metric => metric.MetricNameModel.Scope == null).DataModel.Value0, Is.EqualTo(5));
+            Assert.That(stats.First(metric => metric.MetricNameModel.Scope == "myScope").DataModel.Value0, Is.EqualTo(10));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_WhenOneOfTwoCollidingUnscopedMetricsIsIgnored_OnlyTheSurvivorsDataIsSent()
+    {
+        // A null rename means the rename rules say to ignore the metric
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", null },
+            { "Custom/B", "Custom/Renamed" }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeUnscopedStats("Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeUnscopedStats("Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("Custom/Renamed"));
+            Assert.That(stats[0].DataModel.Value0, Is.EqualTo(10));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_WhenAScopedMetricIsIgnored_ItIsNotSent()
+    {
+        var nameService = CreateRenamingMetricNameService(new Dictionary<string, string>
+        {
+            { "Custom/A", null }
+        });
+
+        var collection = new MetricStatsCollection();
+        collection.MergeScopedStats("myScope", "Custom/A", MetricDataWireModel.BuildCountData(5));
+        collection.MergeScopedStats("myScope", "Custom/B", MetricDataWireModel.BuildCountData(10));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("Custom/B"));
+            Assert.That(stats[0].MetricNameModel.Scope, Is.EqualTo("myScope"));
+            Assert.That(stats[0].DataModel.Value0, Is.EqualTo(10));
+        });
+    }
+
+    [Test]
+    public void ConvertToJsonForSending_AppliesRenameRulesExactlyOncePerMetricName()
+    {
+        // Guards against the metric name being run through the rename rules more than once, which
+        // a non-idempotent rule (one that does not anchor on something it removes) would compound.
+        var nameService = Mock.Create<IMetricNameService>();
+        Mock.Arrange(() => nameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "Prefix/" + name);
+
+        var collection = new MetricStatsCollection();
+        collection.MergeUnscopedStats("Custom/A", MetricDataWireModel.BuildCountData(5));
+
+        var stats = collection.ConvertToJsonForSending(nameService);
+
+        Assert.That(stats, Has.Count.EqualTo(1));
+        Assert.That(stats[0].MetricNameModel.Name, Is.EqualTo("Prefix/Custom/A"));
+    }
+
+    #endregion Rename collisions
 
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/TransactionMetricStatsCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/TransactionMetricStatsCollectionTests.cs
@@ -25,7 +25,7 @@ class TransactionMetricStatsCollectionTests
     {
         var metricNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-        return new MetricWireModel.MetricBuilder(metricNameService);
+        return new MetricWireModel.MetricBuilder();
     }
 
     #region MergeUnscopedStats

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/ConvertMetricDataToJsonTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/ConvertMetricDataToJsonTests.cs
@@ -34,10 +34,10 @@ public class ConvertMetricDataToJsonTests
         _connectionHandler = new ConnectionHandler(new JsonSerializer(), Mock.Create<ICollectorWireFactory>(), Mock.Create<IProcessStatic>(), Mock.Create<IDnsStatic>(),
             Mock.Create<ILabelsService>(), Mock.Create<Environment>(), Mock.Create<ISystemInfo>(), Mock.Create<IAgentHealthReporter>(), Mock.Create<IEnvironment>(), fileWrapper);
 
-        var validScopedMetric = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "WebTransaction/DotNet/name",
+        var validScopedMetric = MetricWireModel.BuildMetric("DotNet/name", "WebTransaction/DotNet/name",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3.0), TimeSpan.FromSeconds(2.0)));
 
-        var validUnscopedMetric = MetricWireModel.BuildMetric(_metricNameService, "Custom/name", string.Empty,
+        var validUnscopedMetric = MetricWireModel.BuildMetric("Custom/name", string.Empty,
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4.0), TimeSpan.FromSeconds(3.0)));
 
         var validMetricWireModels = new List<MetricWireModel> { validScopedMetric, validUnscopedMetric };

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCSampleTransformerV2Tests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCSampleTransformerV2Tests.cs
@@ -21,7 +21,7 @@ public class GCSampleTransformerV2Tests
     [SetUp]
     public void SetUp()
     {
-        _metricBuilder = new MetricWireModel.MetricBuilder(new MetricNameService());
+        _metricBuilder = new MetricWireModel.MetricBuilder();
 
         _metricAggregator = Mock.Create<IMetricAggregator>();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
@@ -33,7 +33,7 @@ public class GCStatsSampleTransformerTests
     public void Setup()
     {
         var metricNameService = new MetricNameService();
-        _metricBuilder = new MetricBuilder(metricNameService);
+        _metricBuilder = new MetricBuilder();
         _metricAggregator = Mock.Create<IMetricAggregator>();
 
         _transformer = new GcSampleTransformer(_metricBuilder, _metricAggregator);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/MemorySampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/MemorySampleTransformerTests.cs
@@ -26,7 +26,7 @@ public class MemorySampleTransformerTests
     [SetUp]
     public void SetUp()
     {
-        _metricBuilder = new MetricWireModel.MetricBuilder(new MetricNameService());
+        _metricBuilder = new MetricWireModel.MetricBuilder();
         _metricAggregator = Mock.Create<IMetricAggregator>();
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/ThreadStatsSampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/ThreadStatsSampleTransformerTests.cs
@@ -26,7 +26,7 @@ public class ThreadStatsSampleTransformerTests
     public void SetUp()
     {
         var metricNameService = new MetricNameService();
-        _metricBuilder = new MetricBuilder(metricNameService);
+        _metricBuilder = new MetricBuilder();
         _metricAggregator = Mock.Create<IMetricAggregator>();
 
         _threadStatsTransformer = new ThreadStatsSampleTransformer(_metricBuilder, _metricAggregator);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
@@ -165,7 +165,7 @@ public class TransactionTransformerTests
     {
         _metricNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => _metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-        return new MetricWireModel.MetricBuilder(_metricNameService);
+        return new MetricWireModel.MetricBuilder();
     }
 
     #region Invalid/ignored transactions

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricBuilderTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricBuilderTests.cs
@@ -4,7 +4,6 @@
 using NewRelic.Agent.Core.Metrics;
 using NewRelic.Testing.Assertions;
 using NUnit.Framework;
-using Telerik.JustMock;
 using realWireModels = NewRelic.Agent.Core.WireModels;
 
 namespace NewRelic.Agent.Core.WireModels;
@@ -17,10 +16,7 @@ public class MetricBuilderTests
     [SetUp]
     public void SetUp()
     {
-        var metricNameService = Mock.Create<IMetricNameService>();
-        Mock.Arrange(() => metricNameService.RenameMetric(Arg.IsAny<string>()))
-            .Returns(metricName => metricName);
-        _metricBuilder = new MetricWireModel.MetricBuilder(metricNameService);
+        _metricBuilder = new MetricWireModel.MetricBuilder();
     }
 
     [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
@@ -38,7 +38,7 @@ public class MetricWireModelTests
     public void MetricWireModelStartsWithNameInString()
     {
         var metricData = MetricDataWireModel.BuildGaugeValue(1);
-        var wireModel = MetricWireModel.BuildMetric(_metricNameService, "originalName", null, metricData);
+        var wireModel = MetricWireModel.BuildMetric("originalName", null, metricData);
 
         var wireModelString = wireModel.ToString();
 
@@ -49,7 +49,7 @@ public class MetricWireModelTests
     public void ScopedMetricWireModelStartsWithNameInString()
     {
         var metricData = MetricDataWireModel.BuildGaugeValue(1);
-        var actual = MetricWireModel.BuildMetric(_metricNameService, "originalName", "theScope", metricData);
+        var actual = MetricWireModel.BuildMetric("originalName", "theScope", metricData);
 
         // The code currently uses the type name of the data value and is not worth testing
         Assert.That(actual.ToString(), Does.StartWith("originalName (theScope)"));
@@ -59,7 +59,7 @@ public class MetricWireModelTests
     public void MetricWireModelUsesReferenceEquals()
     {
         var metricData = MetricDataWireModel.BuildGaugeValue(1);
-        var metricWireModel = MetricWireModel.BuildMetric(_metricNameService, "originalName", "theScope", metricData);
+        var metricWireModel = MetricWireModel.BuildMetric("originalName", "theScope", metricData);
 
 #pragma warning disable NUnit2009 // The same value has been provided as both the actual and the expected argument
         Assert.That(metricWireModel, Is.EqualTo(metricWireModel));
@@ -73,8 +73,8 @@ public class MetricWireModelTests
     public bool MetricWireModelComparesItsData(string firstMetricName, string firstMetricScope, float firstMetricValue,
         string secondMetricName, string secondMetricScope, float secondMetricValue)
     {
-        var first = MetricWireModel.BuildMetric(_metricNameService, firstMetricName, firstMetricScope, MetricDataWireModel.BuildGaugeValue(firstMetricValue));
-        var second = MetricWireModel.BuildMetric(_metricNameService, secondMetricName, secondMetricScope, MetricDataWireModel.BuildGaugeValue(secondMetricValue));
+        var first = MetricWireModel.BuildMetric(firstMetricName, firstMetricScope, MetricDataWireModel.BuildGaugeValue(firstMetricValue));
+        var second = MetricWireModel.BuildMetric(secondMetricName, secondMetricScope, MetricDataWireModel.BuildGaugeValue(secondMetricValue));
 
         return first.Equals(second);
     }
@@ -82,7 +82,7 @@ public class MetricWireModelTests
     [Test]
     public void MetricWireModelDoesNotEqualNull()
     {
-        var metricWireModel = MetricWireModel.BuildMetric(_metricNameService, "originalName", null, null);
+        var metricWireModel = MetricWireModel.BuildMetric("originalName", null, null);
 
         Assert.That(metricWireModel, Is.Not.EqualTo(null));
     }
@@ -94,8 +94,8 @@ public class MetricWireModelTests
     public bool MetricWireModelHashCodeUsesNameAndData(string firstMetricName, string firstMetricScope, float firstMetricValue,
         string secondMetricName, string secondMetricScope, float secondMetricValue)
     {
-        var first = MetricWireModel.BuildMetric(_metricNameService, firstMetricName, firstMetricScope, MetricDataWireModel.BuildGaugeValue(firstMetricValue));
-        var second = MetricWireModel.BuildMetric(_metricNameService, secondMetricName, secondMetricScope, MetricDataWireModel.BuildGaugeValue(secondMetricValue));
+        var first = MetricWireModel.BuildMetric(firstMetricName, firstMetricScope, MetricDataWireModel.BuildGaugeValue(firstMetricValue));
+        var second = MetricWireModel.BuildMetric(secondMetricName, secondMetricScope, MetricDataWireModel.BuildGaugeValue(secondMetricValue));
 
         return first.GetHashCode().Equals(second.GetHashCode());
     }
@@ -105,7 +105,7 @@ public class MetricWireModelTests
     [Test]
     public void AddMetricsToEngine_OneScopedMetric()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         Assert.That(metric1, Is.Not.Null);
         var data = metric1.DataModel;
@@ -161,7 +161,7 @@ public class MetricWireModelTests
     [TestCase(null)]
     public void AddMetricsToEngine_OneUnscopedMetricMissingScope(string empty)
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", empty,
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", empty,
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
         Assert.That(metric1, Is.Not.Null);
 
@@ -203,7 +203,7 @@ public class MetricWireModelTests
     [Test]
     public void Merge_MergesOneMetricCorrectly()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
         var mergedMetric = MetricWireModel.Merge(new[] { metric1 });
 
@@ -221,9 +221,9 @@ public class MetricWireModelTests
     [Test]
     public void Merge_MergesTwoMetricsCorrectly()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric2 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
 
         var mergedMetric = MetricWireModel.Merge(metric1, metric2);
@@ -242,11 +242,11 @@ public class MetricWireModelTests
     [Test]
     public void Merge_MergesThreeMetricsCorrectly()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric2 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
-        var metric3 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric3 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(13), TimeSpan.FromSeconds(11)));
 
         var mergedMetric = MetricWireModel.Merge(new[] { metric1, metric2, metric3 });
@@ -265,11 +265,11 @@ public class MetricWireModelTests
     [Test]
     public void Merge_MergesThreeMetricsCorrectly_WhenMergedProgressively()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric2 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
-        var metric3 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric3 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(13), TimeSpan.FromSeconds(11)));
 
         var mergedMetric = MetricWireModel.Merge(new[] { metric1, metric2 });
@@ -289,7 +289,7 @@ public class MetricWireModelTests
     [Test]
     public void Merge_IgnoresNullMetrics()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
 
         var mergedMetric = MetricWireModel.Merge(new[] { null, metric1, null });
@@ -308,11 +308,11 @@ public class MetricWireModelTests
     [Test]
     public void Merge_Throws_IfGivenMetricsWithDifferentNames()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name1", "scope",
+        var metric2 = MetricWireModel.BuildMetric("DotNet/name1", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
-        var metric3 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name2", "scope",
+        var metric3 = MetricWireModel.BuildMetric("DotNet/name2", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(13), TimeSpan.FromSeconds(11)));
 
         NrAssert.Throws<Exception>(() => MetricWireModel.Merge(new[] { metric1, metric2, metric3 }));
@@ -321,11 +321,11 @@ public class MetricWireModelTests
     [Test]
     public void Merge_Throws_IfGivenMetricsWithDifferentScopes()
     {
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-        var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope1",
+        var metric2 = MetricWireModel.BuildMetric("DotNet/name", "scope1",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
-        var metric3 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope2",
+        var metric3 = MetricWireModel.BuildMetric("DotNet/name", "scope2",
             MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(13), TimeSpan.FromSeconds(11)));
 
 
@@ -353,7 +353,7 @@ public class MetricWireModelTests
     {
         const string expectedJson = @"[{""name"":""DotNet/name"",""scope"":""scope1""},[1,3.0,1.0,3.0,3.0,9.0]]";
 
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope1", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", "scope1", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
 
         var serializedMetric = JsonConvert.SerializeObject(metric1);
 
@@ -365,7 +365,7 @@ public class MetricWireModelTests
     {
         const string expectedJson = @"[{""name"":""DotNet/name""},[1,3.0,1.0,3.0,3.0,9.0]]";
 
-        var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
+        var metric1 = MetricWireModel.BuildMetric("DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
 
         var serializedMetric = JsonConvert.SerializeObject(metric1);
 
@@ -379,18 +379,26 @@ public class MetricWireModelTests
     [Test]
     public void BuildMetricWireModelUsesOriginalName()
     {
-        var actual = MetricWireModel.BuildMetric(_metricNameService, "originalName", null, null);
+        var actual = MetricWireModel.BuildMetric("originalName", null, null);
         Assert.That(actual.MetricNameModel.Name, Is.EqualTo("originalName"));
     }
 
     [Test]
     public void BuildMetricWireModelReturnsNullWhenNameIsNull()
     {
-        var mockNameService = Mock.Create<IMetricNameService>();
-        Mock.Arrange(() => mockNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(null);
-
-        var actual = MetricWireModel.BuildMetric(mockNameService, "originalName", null, null);
+        var actual = MetricWireModel.BuildMetric(null, "theScope", MetricDataWireModel.BuildGaugeValue(1));
         Assert.That(actual, Is.Null);
+    }
+
+    [Test]
+    public void BuildMetricWireModelDoesNotApplyRenameRules()
+    {
+        // Rename rules belong to the harvest (MetricStatsCollection.ConvertToJsonForSending). Applying them
+        // here as well would run them twice over any metric that is built before it is aggregated, such as
+        // the supportability metrics from AgentHealthReporter and metrics retained after a failed send.
+        var actual = MetricWireModel.BuildMetric("Supportability/originalName", null, MetricDataWireModel.BuildGaugeValue(1));
+
+        Assert.That(actual.MetricNameModel.Name, Is.EqualTo("Supportability/originalName"));
     }
 
     [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/Utilities.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/Utilities.cs
@@ -12,6 +12,6 @@ public static class Utilities
     {
         var metricNameService = Mock.Create<IMetricNameService>();
         Mock.Arrange(() => metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-        return new MetricWireModel.MetricBuilder(metricNameService);
+        return new MetricWireModel.MetricBuilder();
     }
 }


### PR DESCRIPTION
## Description

Metrics were not aggregated after server-side `metric_name_rules` were applied. Renaming happened as the *last* step before serialization, inside a lazy iterator that emitted one metric per pre-rename dictionary key. Every aggregation layer keys on pre-rename names, so two names collapsing onto one after renaming were sent as two separate metrics sharing a name, each carrying only its own portion of the data — e.g. `metric/A` (count 5) and `metric/B` (count 10) shipped as two `metric/Renamed` metrics of 5 and 10 instead of one of 15.

`MetricWireModel.Merge` — the fold needed to fix this — was registered in DI but had zero consumers.

Two fixes:

**1. Re-merge after renaming** (`MetricStatsCollection.ConvertToJsonForSending`). Renamed names are re-keyed into a fresh `(scope, name)` dictionary and collisions folded with the same `MetricDataWireModel.BuildAggregateData` used by every other merge in the pipeline. Ignored (null-rename) metrics are still dropped. The method is now eager and returns `IList` — a name's merged data isn't known until every input key has been renamed. Its only caller already called `.ToList()`, so nothing relied on the laziness.

**2. Rename exactly once** (`MetricWireModel.BuildMetric`). `BuildMetric` no longer takes an `IMetricNameService` or applies the rules; harvest solely owns renaming. Previously, metrics built *before* aggregation — supportability metrics, the sampler/transformer metrics, and metrics retained after a failed send — were renamed at build time, aggregated under the renamed name, then renamed **again** at harvest. A catch-all rule produced 41 double-prefixed metric names (`Supportability/*`, `GC/*`, `CPU/*`, `Memory/*`, `Threadpool/*`); anchored rules are idempotent on a second pass, which is why this stayed hidden. `MetricWireModel.MetricBuilder` is now stateless.

Renames per harvest are unchanged (once per unique name). Renaming is removed from the metric-builder path, which drops a per-call LINQ `OrderBy` allocation that occurred even with no rules configured. The added re-key dictionary runs on the harvest thread against a collection nothing else references — the replacement stats queue is installed before the old one is drained, so application threads never wait on it.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
