### PR TITLE
fix: Guard null OperationContext in WCF MethodInvokerWrapper

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
@@ -63,6 +63,22 @@ public class MethodInvokerWrapper : IWrapper
     private const string InvokeEndMethodName = "InvokeEnd";
     private const string InvokeAsyncMethodName = "InvokeAsync";
     private const string WrapperName = "MethodInvokerWrapper";
+    private const string NullOperationContextMetricPrefix = "WCFService/NullOperationContext";
+    private const string NullOperationContextMetricNameOther = NullOperationContextMetricPrefix + "/Other";
+
+    // Precomputed per-invoker-method metric names for the null-OperationContext bail-out.
+    // This is the granularity at which the wrapper actually gets disabled (the NoOp swap is
+    // keyed per functionId, i.e. one JIT'd method), so it is deliberately not the invocation
+    // style (Sync/APM/TAP) - InvokeEnd's style is ambiguous and is omitted from
+    // _methodNameInvocationTypesDic below, but InvokeEnd can still reach the bail-out.
+    private static readonly Dictionary<string, string> _nullOperationContextMetricNamesByMethod = new Dictionary<string, string>()
+    {
+        { SyncMethodName, NullOperationContextMetricPrefix + "/" + SyncMethodName },
+        { InvokeBeginMethodName, NullOperationContextMetricPrefix + "/" + InvokeBeginMethodName },
+        { InvokeEndMethodName, NullOperationContextMetricPrefix + "/" + InvokeEndMethodName },
+        { InvokeAsyncMethodName, NullOperationContextMetricPrefix + "/" + InvokeAsyncMethodName }
+    };
+
     /// <summary>
     /// Translates the method name to the type of invocation
     /// </summary>
@@ -88,6 +104,11 @@ public class MethodInvokerWrapper : IWrapper
 
     private static IEnumerable<string> ExtractHeaderValue(OperationContext context, string key)
     {
+        if (context == null)
+        {
+            return null;
+        }
+
         string headerValue = null;
 
         if(context.IncomingMessageProperties != null && context.IncomingMessageProperties.TryGetValue(HttpRequestMessageProperty.Name, out var httpRequestMessageAsObject))
@@ -130,6 +151,26 @@ public class MethodInvokerWrapper : IWrapper
     public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
     {
         var transactionAlreadyExists = transaction.IsValid;
+        var instrumentedMethodName = instrumentedMethodCall.MethodCall.Method.MethodName;
+
+        // OperationContext.Current is null when the operation is dispatched off the
+        // WCF request thread (e.g. a custom IOperationInvoker that hands work to a
+        // thread pool thread). Without it there is no URI, no request method, no
+        // request headers and no inbound DT/CAT headers to read, and the same missing
+        // ambient context is why no transaction was found in context storage. Creating
+        // a transaction here would produce a contentless WebTransaction/WCF entry that
+        // is still stored (in ThreadLocalStorage) and harvested, and would be left
+        // orphaned for the next invocation on this thread to adopt. Bail out instead.
+        var operationContext = OperationContext.Current;
+        if (!transactionAlreadyExists && operationContext == null)
+        {
+            var nullOperationContextMetricName = _nullOperationContextMetricNamesByMethod.TryGetValue(instrumentedMethodName, out var perMethodMetricName)
+                ? perMethodMetricName
+                : NullOperationContextMetricNameOther;
+
+            agent.GetExperimentalApi().RecordSupportabilityMetric(nullOperationContextMetricName);
+            return Delegates.NoOp;
+        }
 
         var methodInfo = TryGetMethodInfo(instrumentedMethodCall);
         if (methodInfo == null)
@@ -137,7 +178,6 @@ public class MethodInvokerWrapper : IWrapper
             throw new NullReferenceException("methodInfo");
         }
 
-        var instrumentedMethodName = instrumentedMethodCall.MethodCall.Method.MethodName;
         var parameters = GetParameters(instrumentedMethodCall.MethodCall, methodInfo, instrumentedMethodCall.MethodCall.MethodArguments, agent);
 
         ReportSupportabilityMetric_InvocationMethod(agent, instrumentedMethodName);
@@ -146,7 +186,7 @@ public class MethodInvokerWrapper : IWrapper
         var shouldTryProcessInboundCatOrDT = _methodNamesStart.Contains(instrumentedMethodName);
         var shouldTryEndTransaction = _methodNamesEndTrx.Contains(instrumentedMethodName);
 
-        var uri = OperationContext.Current?.IncomingMessageHeaders?.To;
+        var uri = operationContext?.IncomingMessageHeaders?.To;
 
         var transactionName = GetTransactionName(agent, uri, methodInfo);
 
@@ -164,7 +204,7 @@ public class MethodInvokerWrapper : IWrapper
 
             transaction.GetExperimentalApi().SetWrapperToken(_wrapperToken);
 
-            CaptureHttpRequestHeadersAndMethod(agent, transaction);
+            CaptureHttpRequestHeadersAndMethod(agent, transaction, operationContext);
         }
 
         var requestPath = uri?.AbsolutePath;
@@ -189,7 +229,7 @@ public class MethodInvokerWrapper : IWrapper
             {
                 var transportType = TransportType.Other;
 
-                var msgProperties = OperationContext.Current?.IncomingMessageProperties;
+                var msgProperties = operationContext?.IncomingMessageProperties;
                 if (msgProperties != null && msgProperties.TryGetValue(HttpRequestMessageProperty.Name, out var httpRequestMessageObject))
                 {
                     if (httpRequestMessageObject is HttpRequestMessageProperty)
@@ -198,7 +238,7 @@ public class MethodInvokerWrapper : IWrapper
                     }
                 }
 
-                transaction.AcceptDistributedTraceHeaders(OperationContext.Current, ExtractHeaderValue, transportType);
+                transaction.AcceptDistributedTraceHeaders(operationContext, ExtractHeaderValue, transportType);
             }
         }
 
@@ -320,9 +360,13 @@ public class MethodInvokerWrapper : IWrapper
             });
     }
 
-    private void CaptureHttpRequestHeadersAndMethod(IAgent agent, ITransaction transaction)
+    private void CaptureHttpRequestHeadersAndMethod(IAgent agent, ITransaction transaction, OperationContext context)
     {
-        var context = OperationContext.Current;
+        if (context == null)
+        {
+            return;
+        }
+
         if (context.IncomingMessageProperties != null
             && context.IncomingMessageProperties.TryGetValue(HttpRequestMessageProperty.Name, out var httpRequestMessageAsObject)
             && httpRequestMessageAsObject is HttpRequestMessageProperty httpRequestMessage)
@@ -377,6 +421,11 @@ public class MethodInvokerWrapper : IWrapper
             return;
         }
 
+        if (context == null)
+        {
+            return;
+        }
+
         var headersToAttach = transaction.GetResponseMetadata();
         foreach (var header in headersToAttach)
         {
@@ -384,7 +433,7 @@ public class MethodInvokerWrapper : IWrapper
             var outgoingMessageHeaders = context.OutgoingMessageHeaders;
             if (outgoingMessageHeaders != null && outgoingMessageHeaders.MessageVersion.Envelope != EnvelopeVersion.None)
             {
-                context.OutgoingMessageHeaders.Add(MessageHeader.CreateHeader(header.Key, "", header.Value));
+                outgoingMessageHeaders.Add(MessageHeader.CreateHeader(header.Key, "", header.Value));
             }
 
             AddHeaderToHttpResponsePropertyForOutgoingMessage(header, context);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
@@ -169,6 +169,9 @@ public class MethodInvokerWrapper : IWrapper
                 : NullOperationContextMetricNameOther;
 
             agent.GetExperimentalApi().RecordSupportabilityMetric(nullOperationContextMetricName);
+
+            agent.Logger.Finest($"{WrapperName}: OperationContext.Current was null in {instrumentedMethodName} (operation likely dispatched off the WCF request thread). Not instrumenting this invocation.");
+
             return Delegates.NoOp;
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -89,6 +89,16 @@ public abstract class AgentLogBase
     public const string WrapperExceptionLogLineRegex = ErrorLogLinePrefixRegex + "An exception occurred in a wrapper";
     public const string ApplicationErrorLogLineRegex = DebugLogLinePrefixRegex + "Noticed application error";
 
+    // A wrapper threw out of BeforeWrappedMethod/AfterWrappedMethod. Distinct
+    // from WrapperExceptionLogLineRegex above, which matches a different message.
+    public const string TracerInvocationErrorLogLineRegex = ErrorLogLinePrefixRegex + "Tracer invocation error";
+
+    // The agent gave up on a wrapper after WrapperExceptionLimit consecutive
+    // failures and swapped in the NoOp wrapper for that functionId. Capture group
+    // 1 is the wrapper type, group 2 is the method it was disabled for.
+    public const string WrapperDisabledLogLineRegex = ErrorLogLinePrefixRegex +
+        @"Wrapper (\S+) is being disabled for (\S+) due to too many consecutive exceptions";
+
     // explain plan failure
     public const string ExplainPlainFailureLogLineRegex = DebugLogLinePrefixRegex + "Unable to execute explain plan for query: (.*)";
 
@@ -663,6 +673,21 @@ public abstract class AgentLogBase
     public int GetApplicationErrorLineCount()
     {
         return TryGetLogLines(ApplicationErrorLogLineRegex).Count();
+    }
+
+    public int GetTracerInvocationErrorLineCount()
+    {
+        return TryGetLogLines(TracerInvocationErrorLogLineRegex).Count();
+    }
+
+    /// <summary>
+    /// Returns the "Wrapper X is being disabled for Y" lines, if any. A non-empty
+    /// result means the agent stopped instrumenting a method for the rest of the
+    /// process lifetime.
+    /// </summary>
+    public IEnumerable<Match> GetWrapperDisabledLines()
+    {
+        return TryGetLogLines(WrapperDisabledLogLineRegex);
     }
 
     #endregion

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFNullOperationContextTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFNullOperationContextTests.cs
@@ -1,0 +1,163 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using NewRelic.Testing.Assertions;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.WCF.Service.Self;
+
+/// <summary>
+/// Regression coverage for the Wcf3 MethodInvokerWrapper null-dereference on
+/// OperationContext.Current.
+///
+/// MethodInvokerWrapper.CaptureHttpRequestHeadersAndMethod reads
+/// OperationContext.Current with no null check. It is reached only when no
+/// transaction is found in context storage - and because WCF transaction storage
+/// is itself backed by OperationContext.Current (OperationContextStorage,
+/// priority 5) and HttpContext.Current (HttpContextStorage, priority 10), a
+/// thread with neither ambient context fails the lookup AND the dereference.
+///
+/// The service here (a minimal Echo contract - see NullOperationContextEcho.cs)
+/// is hosted with an IOperationInvoker that dispatches the instrumented
+/// SyncMethodInvoker.Invoke onto a fresh thread, which strips both.
+///
+/// Without a fix this produces "Tracer invocation error" /
+/// NullReferenceException on every call and, after WrapperExceptionLimit
+/// (default 5) consecutive failures, the agent swaps in the NoOp wrapper for
+/// SyncMethodInvoker.Invoke - permanently losing WebTransaction/WCF naming for
+/// the life of the process.
+/// </summary>
+public class WCFService_Self_NullOperationContext : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFWLatest>
+{
+    // Must exceed WrapperExceptionLimit (default 5) so that an unfixed agent
+    // reaches the disable threshold rather than merely logging a few errors.
+    private const int CallCount = 8;
+
+    private readonly ConsoleDynamicMethodFixtureFWLatest _fixture;
+
+    public WCFService_Self_NullOperationContext(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+
+        const string relativePath = "WCFServiceNullOpContext";
+
+        // NetTcp deliberately, not BasicHttp: self-hosting an http:// endpoint
+        // needs an HTTP.sys URL reservation, which fails with "HTTP could not
+        // register URL ... Access is denied" on an unelevated dev machine.
+        // net.tcp needs no reservation. The binding is irrelevant to the defect -
+        // the null dereference happens before anything HTTP-specific is read.
+        var binding = WCFBindingType.NetTcp;
+        var port = _fixture.RemoteApplication.Port;
+
+        _fixture.AddCommand($"WCFServiceSelfHosted StartServiceWithOffThreadInvoker {binding} {port} {relativePath}");
+        _fixture.AddCommand($"NullOperationContextEchoClient InitializeClient {port} {relativePath}");
+
+        for (var i = 0; i < CallCount; i++)
+        {
+            _fixture.AddCommand($"NullOperationContextEchoClient Echo {i}");
+        }
+
+        _fixture.AddCommand("WCFServiceSelfHosted StopService");
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                _fixture.RemoteApplication.NewRelicConfig.SetLogLevel("finest");
+                _fixture.RemoteApplication.NewRelicConfig.ConfigureFasterMetricsHarvestCycle(10);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void WrapperDoesNotThrowOnNullOperationContext()
+    {
+        var tracerErrors = _fixture.AgentLog.GetTracerInvocationErrorLineCount();
+
+        Assert.True(tracerErrors == 0,
+            $"Expected no tracer invocation errors, but found {tracerErrors}. " +
+            "The Wcf3 MethodInvokerWrapper most likely dereferenced a null OperationContext.Current.");
+    }
+
+    [Fact]
+    public void WrapperIsNotDisabled()
+    {
+        var disabled = _fixture.AgentLog.GetWrapperDisabledLines().ToList();
+
+        Assert.True(disabled.Count == 0,
+            "The agent disabled a wrapper due to consecutive exceptions, which permanently " +
+            "reduces instrumentation for the life of the process. Disabled: " +
+            string.Join("; ", disabled.Select(m => m.Value.Trim())));
+    }
+
+    [Fact]
+    public void NullOperationContextSupportabilityMetric_IsRecordedForEveryCall_AndInvocationStyleIsAbsent()
+    {
+        // The wrapper records the invoked method name as a fourth metric segment
+        // (Invoke, InvokeBegin, InvokeEnd, InvokeAsync, or Other as a fallback for
+        // an unrecognized method). This test drives synchronous Echo calls only,
+        // so the expected variant is Invoke.
+        //
+        // Expected count is CallCount (8): the exercised operation
+        // (NullOperationContextEchoClient/INullOperationContextEchoService.Echo)
+        // has no dependency on OperationContext.Current, incoming headers, or any
+        // external call, so all 8 queued off-thread invocations complete and each
+        // one bails out on the null OperationContext.Current, recording the
+        // metric once per call.
+        var expectedMetrics = new[]
+        {
+            new Assertions.ExpectedMetric { metricName = "Supportability/WCFService/NullOperationContext/Invoke", CallCountAllHarvests = CallCount }
+        };
+
+        // The bail-out returns before ReportSupportabilityMetric_InvocationMethod
+        // runs, so a call that hit the null-OperationContext path should never
+        // also record an invocation style. Confirmed absent from the log.
+        //
+        // The Other variant would only appear if the invoked-method-name lookup
+        // failed to recognize SyncMethodInvoker.Invoke, which would itself be a
+        // real defect in the wrapper. Confirmed absent from the log.
+        var unexpectedMetrics = new[]
+        {
+            new Assertions.ExpectedMetric { metricName = "Supportability/WCFService/InvocationStyle/Sync" },
+            new Assertions.ExpectedMetric { metricName = "Supportability/WCFService/NullOperationContext/Other" }
+        };
+
+        var actualMetrics = _fixture.AgentLog.GetMetrics();
+
+        NrAssert.Multiple(
+            () => Assertions.MetricsExist(expectedMetrics, actualMetrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, actualMetrics)
+        );
+    }
+
+    // Deliberately NOT asserting that WebTransaction/WCF/* metrics are present.
+    //
+    // That would be the most direct expression of customer impact - the disable
+    // makes WCF transactions collapse into the generic host-level name - but it
+    // depends on a full harvest round-tripping through the collector, which is
+    // timing-sensitive and the usual source of flakiness in the WCF metric
+    // assertions. This test is about a deterministic null dereference, so it
+    // should not inherit that timing dependency.
+    //
+    // The two log-based assertions above hold regardless of harvest timing. The
+    // Supportability/WCFService/NullOperationContext/Invoke assertion in
+    // NullOperationContextSupportabilityMetric_IsRecordedOnce_AndInvocationStyleIsAbsent
+    // is a different, safe case even though it does depend on a harvest: the fast
+    // ConfigureFasterMetricsHarvestCycle(10) plus the WaitForLogLine wait on
+    // MetricDataLogLineRegex already gate the whole test on that harvest having
+    // completed before any [Fact] runs, so there is no additional timing
+    // dependency being introduced here.
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/NullOperationContextEcho.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/NullOperationContextEcho.cs
@@ -1,0 +1,76 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.ServiceModel;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using NewRelic.Api.Agent;
+
+namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF;
+
+/// <summary>
+/// Minimal WCF contract used only by StartServiceWithOffThreadInvoker.
+///
+/// The shared IWcfService/WcfService contract (used by StartService and every
+/// other WCF test) is not suitable for a tight loop of CallCount off-thread
+/// invocations: its SyncGetData implementation calls out to
+/// https://www.google.com/ on every invocation (WcfService.DoWork), and
+/// CallCount rapid-fire calls trip Google's rate limiter (HTTP 429) after the
+/// first call. That FaultException is unrelated to the null-OperationContext
+/// defect this test targets, but it kills the MFA host process and truncates
+/// the run to a single invocation.
+///
+/// Echo has no dependency on OperationContext.Current, incoming headers,
+/// session state, or any external call, so it can run all CallCount
+/// invocations from OffThreadOperationInvoker's fresh worker thread with
+/// nothing for the thread hop to break.
+/// </summary>
+[ServiceContract]
+public interface INullOperationContextEchoService
+{
+    [OperationContract]
+    string Echo(int value);
+}
+
+public class NullOperationContextEchoService : INullOperationContextEchoService
+{
+    public string Echo(int value)
+    {
+        return value.ToString();
+    }
+}
+
+/// <summary>
+/// Client exerciser for INullOperationContextEchoService. Mirrors WCFClient's
+/// pattern of building the channel once in an Initialize call and reusing it
+/// across subsequent LibraryMethod calls.
+/// </summary>
+[Library]
+public class NullOperationContextEchoClient
+{
+    private INullOperationContextEchoService _channel;
+
+    [LibraryMethod]
+    public void InitializeClient(int port, string relativePath)
+    {
+        var endpointAddress = WCFLibraryHelpers.GetEndpointAddress(WCFBindingType.NetTcp, port, relativePath);
+        var binding = new NetTcpBinding { ReceiveTimeout = TimeSpan.FromMinutes(2) };
+        var factory = new ChannelFactory<INullOperationContextEchoService>(binding, new EndpointAddress(endpointAddress));
+        _channel = factory.CreateChannel();
+    }
+
+    [LibraryMethod]
+    [Transaction]
+    public void Echo(int value)
+    {
+        if (_channel == null)
+        {
+            throw new InvalidOperationException("NullOperationContextEchoClient not instantiated");
+        }
+
+        var result = _channel.Echo(value);
+        ConsoleMFLogger.Info($"NullOperationContextEchoClient.Echo({value}) returned {result}");
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/OffThreadOperationInvoker.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/OffThreadOperationInvoker.cs
@@ -1,0 +1,165 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.Threading;
+using MultiFunctionApplicationHelpers;
+
+namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF;
+
+/// <summary>
+/// Wraps the real IOperationInvoker that WCF built for an operation - for a
+/// synchronous contract that is
+/// System.ServiceModel.Dispatcher.SyncMethodInvoker - and delegates to it from a
+/// brand new thread, so the instrumented Invoke runs with no ambient
+/// OperationContext and no ambient HttpContext.
+///
+/// The agent's Wcf3 MethodInvokerWrapper dereferences OperationContext.Current
+/// without a null check in CaptureHttpRequestHeadersAndMethod, and that method is
+/// reached whenever no transaction is found in context storage. Both ambient
+/// contexts are gone on this thread, so both storages miss and the wrapper takes
+/// the transaction-creating branch.
+///
+/// A fresh thread per call is deliberate. On a reused thread, the failing call
+/// leaves its transaction orphaned in ThreadLocalStorage and the next call on
+/// that thread adopts it - which skips the throwing branch and resets the
+/// wrapper's consecutive-failure counter. That makes the failure intermittent.
+/// A fresh thread makes it deterministic.
+/// </summary>
+public class OffThreadOperationInvoker : IOperationInvoker
+{
+    private readonly IOperationInvoker _inner;
+
+    public OffThreadOperationInvoker(IOperationInvoker inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public bool IsSynchronous => _inner.IsSynchronous;
+
+    public object[] AllocateInputs() => _inner.AllocateInputs();
+
+    public object Invoke(object instance, object[] inputs, out object[] outputs)
+    {
+        object result = null;
+        object[] capturedOutputs = null;
+        ExceptionDispatchInfo failure = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                result = _inner.Invoke(instance, inputs, out capturedOutputs);
+            }
+            catch (Exception ex)
+            {
+                failure = ExceptionDispatchInfo.Capture(ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "wcf-off-thread-invoker"
+        };
+
+        thread.Start();
+        thread.Join();
+
+        outputs = capturedOutputs ?? new object[0];
+        failure?.Throw();
+        return result;
+    }
+
+    public IAsyncResult InvokeBegin(object instance, object[] inputs, AsyncCallback callback, object state)
+        => _inner.InvokeBegin(instance, inputs, callback, state);
+
+    public object InvokeEnd(object instance, out object[] outputs, IAsyncResult result)
+        => _inner.InvokeEnd(instance, out outputs, result);
+}
+
+/// <summary>
+/// Installs <see cref="OffThreadOperationInvoker"/> over every dispatch
+/// operation.
+///
+/// Two-stage, and the ordering matters. IServiceBehavior.Validate runs before the
+/// DispatchRuntime is built, so it is used to append an IOperationBehavior to
+/// each OperationDescription. That operation behavior then runs while the
+/// DispatchRuntime is being built, at which point DispatchOperation.Invoker has
+/// already been set by the built-in OperationBehaviorAttribute.
+///
+/// Sweeping ChannelDispatchers from IServiceBehavior.ApplyDispatchBehavior does
+/// NOT work: DispatchRuntime.Operations is still empty there, so only
+/// UnhandledDispatchOperation would be wrapped and the real SyncMethodInvoker
+/// would be left alone.
+/// </summary>
+public class OffThreadInvokerBehavior : IServiceBehavior
+{
+    public void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+    {
+        var attached = 0;
+
+        foreach (var endpoint in serviceDescription.Endpoints)
+        {
+            if (endpoint.Contract == null || endpoint.Contract.Name == "IMetadataExchange")
+            {
+                continue;
+            }
+
+            foreach (var operation in endpoint.Contract.Operations)
+            {
+                if (operation.Behaviors.Find<OffThreadInvokerOperationBehavior>() != null)
+                {
+                    continue;
+                }
+
+                operation.Behaviors.Add(new OffThreadInvokerOperationBehavior());
+                attached++;
+            }
+        }
+
+        ConsoleMFLogger.Info($"OffThreadInvokerBehavior attached to {attached} operation(s)");
+    }
+
+    public void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase,
+        Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+    {
+    }
+}
+
+/// <summary>
+/// Per-operation hook that swaps the invoker.
+/// </summary>
+public class OffThreadInvokerOperationBehavior : IOperationBehavior
+{
+    public void Validate(OperationDescription operationDescription)
+    {
+    }
+
+    public void AddBindingParameters(OperationDescription operationDescription, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    public void ApplyClientBehavior(OperationDescription operationDescription, ClientOperation clientOperation)
+    {
+    }
+
+    public void ApplyDispatchBehavior(OperationDescription operationDescription, DispatchOperation dispatchOperation)
+    {
+        if (dispatchOperation.Invoker == null || dispatchOperation.Invoker is OffThreadOperationInvoker)
+        {
+            return;
+        }
+
+        ConsoleMFLogger.Info($"Wrapping invoker for {operationDescription.Name}: {dispatchOperation.Invoker.GetType().FullName}");
+        dispatchOperation.Invoker = new OffThreadOperationInvoker(dispatchOperation.Invoker);
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceSelfHosted.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceSelfHosted.cs
@@ -77,6 +77,53 @@ public class WCFServiceSelfHosted
     }
 
     /// <summary>
+    /// Hosts the minimal INullOperationContextEchoService/NullOperationContextEchoService
+    /// contract (see NullOperationContextEcho.cs) with an IOperationInvoker that
+    /// dispatches the instrumented SyncMethodInvoker.Invoke onto a fresh thread,
+    /// so it runs with no ambient OperationContext.
+    ///
+    /// Regression coverage for the Wcf3 MethodInvokerWrapper null-dereference in
+    /// CaptureHttpRequestHeadersAndMethod.
+    ///
+    /// This does not delegate to StartService: that method hosts the shared
+    /// IWcfService/WcfService contract, whose SyncGetData implementation makes a
+    /// real external call to https://www.google.com/ on every invocation. A
+    /// tight loop of off-thread calls trips Google's rate limiter after the
+    /// first call, which truncates the run with a FaultException unrelated to
+    /// the null-OperationContext defect. NetTcp is the only binding this test
+    /// uses (see WCFService_Self_NullOperationContext's comment on why), so only
+    /// that binding is implemented here.
+    /// </summary>
+    [LibraryMethod]
+    public void StartServiceWithOffThreadInvoker(string bindingType, int port, string relativePath)
+    {
+        relativePath = relativePath.TrimStart('/');
+
+        if (_wcfService_SelfHosted != null)
+        {
+            StopService();
+        }
+
+        WCFLibraryHelpers.StartAgentWithExternalCall();
+        var bindingTypeEnum = (WCFBindingType)Enum.Parse(typeof(WCFBindingType), bindingType, true);
+        var baseAddress = WCFLibraryHelpers.GetEndpointAddress(bindingTypeEnum, port, relativePath);
+        ConsoleMFLogger.Info($"Starting off-thread-invoker WCF Service using {bindingTypeEnum} binding at endpoint {baseAddress}");
+        _wcfService_SelfHosted = new ServiceHost(typeof(NullOperationContextEchoService), baseAddress);
+        _wcfService_SelfHosted.Description.Behaviors.Add(new OffThreadInvokerBehavior());
+
+        switch (bindingTypeEnum)
+        {
+            case WCFBindingType.NetTcp:
+                _wcfService_SelfHosted.AddServiceEndpoint(typeof(INullOperationContextEchoService), new NetTcpBinding(), baseAddress);
+                break;
+            default:
+                throw new NotImplementedException($"Binding Type {bindingTypeEnum} is not supported by StartServiceWithOffThreadInvoker");
+        }
+
+        _wcfService_SelfHosted.Open();
+    }
+
+    /// <summary>
     /// Stops the WCF Service
     /// </summary>
     [LibraryMethod]


### PR DESCRIPTION
Fixes #3728. 

`MethodInvokerWrapper` dereferenced `OperationContext.Current` with no null check, which throws when a custom `IOperationInvoker` dispatches the operation off the WCF request thread -- after `WrapperExceptionLimit` consecutive failures the agent swaps in the NoOp wrapper per `functionId`, losing `WebTransaction/WCF` naming process-wide until restart.

All four dereference sites are guarded, and the wrapper now returns before creating a transaction when there is no ambient context, recording `Supportability/WCFService/NullOperationContext/<method>`. Bailing out matters: guarding alone still leaves a contentless `WebTransaction/WCF` entry stored in `ThreadLocalStorage` and harvested.

Verified with a new integration test (8 off-thread invocations, so it exceeds the disable threshold) and a standalone repro harness across 7 dispatch modes -- zero NREs, no wrapper disable, and no fabricated transactions, with the inline control unaffected.

Two related defects are deliberately left out of scope: the mislabeled `CreateExecuteEveryTimer() failed` message in `DistributedTracePayloadHandler`, and the missing try/catch on `Agent.TryProcessSyntheticsData`.