### PR TITLE
ci: keep test secrets out of test-runner environments and artifacts

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -656,13 +656,6 @@ jobs:
           dotnet-quality: 'ga'
 
       - name: Run Integration Tests
-        env:
-          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-          CI_BRANCH: ${{ github.ref_name }}
-          CI_COMMIT: ${{ github.sha }}
-          CI_RUN_ID: ${{ github.run_id }}
-          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CI_TRIGGER: ${{ github.event_name }}
         run: |
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "List ports in use"
@@ -699,10 +692,13 @@ jobs:
             if ($exitCode -eq 0) {
               if ($attempt -gt 1) {
                 Write-Host "::warning::Integration tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
-                # Best-effort flaky-retry telemetry (never fails the job).
-                $env:RETRY_TEST_TYPE = "integrationTests"
-                $env:RETRY_TEST_GROUP = "${{ matrix.namespace }}"
-                & bash build/Scripts/report-flaky-retry.sh
+                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
+                # failure-artifact upload globs never collect. Reporting runs in the separate
+                # step below so that no secret is in scope for this step: HostedWebCore and
+                # other test hosts launched here write their environment to the console, and
+                # that console output is captured into the test results.
+                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+                @{ testType = "integrationTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
               }
               break
             }
@@ -721,6 +717,28 @@ jobs:
 
             Write-Host "Get .NET Runtime errors (if any)"
             Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
+          }
+        shell: powershell
+
+      - name: Report flaky retry telemetry
+        if: always()
+        continue-on-error: true
+        env:
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
+          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
+        run: |
+          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+          if (Test-Path $marker) {
+            $info = Get-Content $marker | ConvertFrom-Json
+            $Env:RETRY_TEST_TYPE = $info.testType
+            $Env:RETRY_TEST_GROUP = $info.testGroup
+            & bash build/Scripts/report-flaky-retry.sh
+            Remove-Item $marker -Force -ErrorAction Ignore
           }
         shell: powershell
 
@@ -803,7 +821,6 @@ jobs:
           name: integration-test-results-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
             C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
@@ -902,13 +919,6 @@ jobs:
           dotnet-quality: 'ga'
   
       - name: Run Unbounded Integration Tests
-        env:
-          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-          CI_BRANCH: ${{ github.ref_name }}
-          CI_COMMIT: ${{ github.sha }}
-          CI_RUN_ID: ${{ github.run_id }}
-          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CI_TRIGGER: ${{ github.event_name }}
         run: |
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "List ports in use"
@@ -939,10 +949,13 @@ jobs:
             if ($exitCode -eq 0) {
               if ($attempt -gt 1) {
                 Write-Host "::warning::Unbounded tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
-                # Best-effort flaky-retry telemetry (never fails the job).
-                $env:RETRY_TEST_TYPE = "unboundedTests"
-                $env:RETRY_TEST_GROUP = "${{ matrix.namespace }}"
-                & bash build/Scripts/report-flaky-retry.sh
+                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
+                # failure-artifact upload globs never collect. Reporting runs in the separate
+                # step below so that no secret is in scope for this step: HostedWebCore and
+                # other test hosts launched here write their environment to the console, and
+                # that console output is captured into the test results.
+                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+                @{ testType = "unboundedTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
               }
               break
             }
@@ -961,6 +974,28 @@ jobs:
 
             Write-Host "Get .NET Runtime errors (if any)"
             Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
+          }
+        shell: powershell
+
+      - name: Report flaky retry telemetry
+        if: always()
+        continue-on-error: true
+        env:
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
+          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
+        run: |
+          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+          if (Test-Path $marker) {
+            $info = Get-Content $marker | ConvertFrom-Json
+            $Env:RETRY_TEST_TYPE = $info.testType
+            $Env:RETRY_TEST_GROUP = $info.testGroup
+            & bash build/Scripts/report-flaky-retry.sh
+            Remove-Item $marker -Force -ErrorAction Ignore
           }
         shell: powershell
 
@@ -1043,7 +1078,6 @@ jobs:
           name: unbounded-test-working-directory-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
             C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
@@ -1443,7 +1477,7 @@ jobs:
         env:
           PAYLOAD_SUMMARY_FILE: final_payload_summary.json
           NR_METRIC_API_URL: https://staging-metric-api.newrelic.com/metric/v1
-          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
           CI_BRANCH: ${{ github.ref_name }}
           CI_COMMIT: ${{ github.sha }}
           CI_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -128,7 +128,8 @@ jobs:
       - name: Build & Run Linux Container Integration Tests
         env:
           BUILD_ARCH: ${{ matrix.arch }}
-          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
+          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
           CI_BRANCH: ${{ github.ref_name }}
           CI_COMMIT: ${{ github.sha }}
           CI_RUN_ID: ${{ github.run_id }}

--- a/build/Scripts/report-flaky-retry.sh
+++ b/build/Scripts/report-flaky-retry.sh
@@ -13,9 +13,8 @@
 # so every path exits 0 and errors are swallowed with a warning.
 #
 # Env vars:
-#   NR_TEST_SECRETS   Raw TEST_SECRETS JSON, may carry a UTF-8 BOM. License key
-#                     is read from .IntegrationTestConfiguration.DefaultSetting.LicenseKey
-#                     and the account id from .IntegrationTestConfiguration.DefaultSetting.NewRelicAccountId
+#   NR_CI_INGEST_KEY  Dedicated New Relic ingest license key, used as the Api-Key header
+#   NR_CI_ACCOUNT_ID  New Relic account id, used in the Insights Event API URL path
 #   RETRY_TEST_TYPE   testType attribute (e.g. integrationTests / unboundedTests / containerTests)
 #   RETRY_TEST_GROUP  testGroup attribute (namespace, or "<arch>/<distro>" for container)
 #   CI_BRANCH CI_COMMIT CI_RUN_ID CI_RUN_URL CI_TRIGGER   Optional metadata attributes
@@ -59,21 +58,11 @@ if is_dry_run; then
   exit 0
 fi
 
-# Parse license key + account id from TEST_SECRETS (nested JSON); strip a UTF-8 BOM.
-LICENSE_KEY=""
-ACCOUNT_ID=""
-if [ -n "${NR_TEST_SECRETS:-}" ]; then
-  CLEAN_SECRETS="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//')"
-  LICENSE_KEY="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty' 2>/dev/null)"
-  ACCOUNT_ID="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.NewRelicAccountId // empty' 2>/dev/null)"
-fi
-
-# Mask the extracted license key in CI logs. GitHub Actions only auto-masks the
-# exact TEST_SECRETS blob, not this jq-extracted substring. No-op outside Actions.
-[ -n "$LICENSE_KEY" ] && echo "::add-mask::$LICENSE_KEY"
+LICENSE_KEY="${NR_CI_INGEST_KEY:-}"
+ACCOUNT_ID="${NR_CI_ACCOUNT_ID:-}"
 
 if [ -z "$LICENSE_KEY" ] || [ -z "$ACCOUNT_ID" ]; then
-  echo "WARNING: no New Relic license key / account id available; skipping flaky-retry event." >&2
+  echo "WARNING: NR_CI_INGEST_KEY / NR_CI_ACCOUNT_ID not available; skipping flaky-retry event." >&2
   exit 0
 fi
 

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -6,9 +6,8 @@
 # Env vars:
 #   PAYLOAD_SUMMARY_FILE  Path to final_payload_summary.json (required)
 #   NR_METRIC_API_URL     Metric API endpoint (required unless dry-run)
-#   NR_TEST_SECRETS       Raw TEST_SECRETS JSON, may carry a UTF-8 BOM
-#                         (required unless dry-run). License key is read from
-#                         .IntegrationTestConfiguration.DefaultSetting.LicenseKey
+#   NR_CI_INGEST_KEY      Dedicated New Relic ingest license key, used as the
+#                         Api-Key header (required unless dry-run)
 #   CI_BRANCH CI_COMMIT CI_RUN_ID CI_RUN_URL   Optional metadata attributes
 #   DRY_RUN               "1"/"true" => print request body to stdout, do not POST
 #
@@ -83,19 +82,10 @@ if is_dry_run; then
   exit 0
 fi
 
-# Extract the license key (Api-Key) from TEST_SECRETS; strip a possible UTF-8 BOM.
-LICENSE_KEY=""
-if [ -n "${NR_TEST_SECRETS:-}" ]; then
-  LICENSE_KEY="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//' \
-    | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty')"
-fi
-
-# Mask the extracted license key in CI logs. GitHub Actions only auto-masks the
-# exact TEST_SECRETS blob, not this jq-extracted substring. No-op outside Actions.
-[ -n "$LICENSE_KEY" ] && echo "::add-mask::$LICENSE_KEY"
+LICENSE_KEY="${NR_CI_INGEST_KEY:-}"
 
 if [ -z "$LICENSE_KEY" ]; then
-  echo "WARNING: no New Relic license key available; skipping." >&2
+  echo "WARNING: NR_CI_INGEST_KEY not set; skipping." >&2
   exit 0
 fi
 if [ -z "${NR_METRIC_API_URL:-}" ]; then


### PR DESCRIPTION
## Description

Test secrets were in scope for CI steps that do not need them, including steps that launch test host processes. This narrows secret scope to the steps that actually consume them, and reduces what test-failure artifacts contain.

- Remove test secrets from the two test-running steps and report flaky-retry telemetry from a separate step, keyed off a marker file under `RUNNER_TEMP` that the artifact globs never collect (from NR-601294). The marker is needed because the original call fired only when tests passed on a retry, which a later step cannot otherwise detect.
- Stop publishing `newrelic.config` from the test working directory in the failure artifacts. The `**\*.log` and `TestResults\**\*TestResults.trx` globs are retained, since the .trx files are needed to diagnose failures (from NR-601297).
- Point both telemetry reporting scripts at dedicated `NR_CI_INGEST_KEY` and `NR_CI_ACCOUNT_ID` secrets so no step receives credentials it does not use, and drop the jq extraction, BOM handling and add-mask workaround they no longer need (from NR-601304). `linux_container_tests.yml` is updated too, since it shares `report-flaky-retry.sh`.

**Required before merge:** the `NR_CI_INGEST_KEY` and `NR_CI_ACCOUNT_ID` repository secrets must exist, and the ingest key should be a dedicated key rather than a copy of the test license key. Both scripts guard on an empty key and exit 0, so a missing secret stops telemetry quietly rather than failing a job. Confirm a real run still emits the flaky-retry event and the payload metrics.

`secrets.TEST_SECRETS` is unchanged where it feeds `dotnet user-secrets`; only the reporting path moved.

Verified locally: both workflows parse as YAML, `shellcheck --severity=error` is clean on both scripts, and `NR_TEST_SECRETS` is no longer referenced by any workflow.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] Update credentials runbook to include newly added secrets

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
