### PR TITLE
test: Stop HostedWebCore from writing the process environment to stdout

### DIFF
--- a/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
@@ -3,10 +3,8 @@
 
 
 using System;
-using System.Collections;
 using System.Diagnostics.Contracts;
 using System.IO;
-using System.Text;
 using CommandLine;
 
 namespace HostedWebCore;
@@ -26,15 +24,6 @@ static class Program
         string msg = "Firing up...args: " + string.Join(", ", args);
         Log("Firing up...args: " + string.Join(", ", args));
         Log("Starting directory: " + Directory.GetCurrentDirectory());
-
-        var environmentVariables = new StringBuilder();
-        foreach (DictionaryEntry de in Environment.GetEnvironmentVariables())
-        {
-            // strip newlines in the environment variable value - otherwise our log parsing may fail
-            var valueStr = de.Value?.ToString().Replace("\r", string.Empty).Replace("\n", string.Empty);
-            environmentVariables.Append($"  {de.Key} = {valueStr}; ");
-        }
-        Log("Environment Variables: " + environmentVariables.ToString());
 
         if (Parser.Default == null)
             throw new NullReferenceException("CommandLine.Parser.Default");

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/SubprocessLogValidator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/SubprocessLogValidator.cs
@@ -17,7 +17,6 @@ public static class SubprocessLogValidator
     {
         HWC_FIRING_UP,
         HWC_STARTING_DIRECTORY,
-        HWC_ENV,
         HWC_STARTING_SERVER,
         HWC_DONE,
         ALL_DONE
@@ -27,7 +26,6 @@ public static class SubprocessLogValidator
     {
         "HostedWebCore: Firing up...",
         "HostedWebCore: Starting directory:",
-        "HostedWebCore: Environment Variables:",
         "HostedWebCore: Starting server...",
         "HostedWebCore: Done.",
         null


### PR DESCRIPTION
Removes the startup dump of every environment variable from HostedWebCore, which was being captured into integration test results. The agent already logs the agent-relevant variables at debug level with credential redaction, so the dump was redundant.

Also drops the coupled HWC_ENV state from SubprocessLogValidator, whose expected-line array is indexed by the enum value.

From NR-601296.