### PR TITLE
test: authenticate Bedrock integration tests via OIDC instead of a static key

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -567,6 +567,9 @@ jobs:
     needs: [build-integration-tests, get-test-namespaces]
     name: Run IntegrationTests
     runs-on: windows-2025-vs2026
+    permissions:
+      contents: read   # required: a job-level block replaces the workflow-level one
+      id-token: write  # required for OIDC role assumption (LLM namespace only)
     strategy:
       matrix:
         namespace: ${{ fromJson(needs.get-test-namespaces.outputs.integration-namespaces) }}
@@ -615,6 +618,20 @@ jobs:
         run: |
           "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
         shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+
+      # Bedrock tests authenticate via short-lived OIDC credentials rather than a
+      # long-lived access key (NR-601301).  Gated to the LLM namespace so that no
+      # other matrix job ever holds AWS credentials in its environment.
+      - name: Configure AWS credentials for Bedrock
+        if: matrix.namespace == 'LLM'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_TEST_ROLE_ARN }}
+          role-duration-seconds: 900
+          # Must match DefaultSetting.AwsRegion in TEST_SECRETS.  A mismatch fails
+          # confusingly: STS succeeds in one region while the SDK calls Bedrock in
+          # another.
+          aws-region: us-west-2
 
       - name: Download Agent Home Folders
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -651,7 +651,7 @@ jobs:
           matrix.namespace == 'CatInbound' || matrix.namespace == 'CatOutbound' || matrix.namespace == 'CodeLevelMetrics' ||
           matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
           matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HSM' || matrix.namespace == 'HttpClientInstrumentation' || matrix.namespace == 'HybridHttpContextStorage' ||
-          matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
+          matrix.namespace == 'LLM' || matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
           matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables' ||
           matrix.namespace == 'RequestHeadersCapture.WCF' || matrix.namespace == 'WCF.Client.IIS.ASPDisabled' ||
           matrix.namespace == 'WCF.Client.IIS.ASPEnabled' || matrix.namespace == 'WCF.Service.IIS.ASPDisabled' ||

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -191,6 +191,73 @@ High security mode (HSM) tests require matching settings on the account they run
 
 See the test secrets section above on configuring an appropriate account.
 
+#### LLM / Bedrock tests
+
+The Bedrock tests in the `LLM` namespace call the real AWS Bedrock service. They
+no longer use a static access key.
+
+Before running them:
+
+1. Sign in to AWS however you normally do, and confirm it worked:
+
+   ```
+   aws sts get-caller-identity
+   ```
+
+2. Make sure `AwsRegion` is present under `DefaultSetting` in your
+   `secrets.json`, set to `us-west-2`.
+
+That is all. `AwsTestCredentials` runs at test startup, asks the AWS CLI for your
+current credentials, and passes them to the test application as environment
+variables. You do not need to set `AWS_PROFILE` or `AWS_REGION` yourself, and you
+do not need to export credentials by hand.
+
+Two things are worth knowing if this ever fails:
+
+* The AWS SDK for .NET cannot read an AWS SSO session on its own. SSO credential
+  resolution lives in the `AWSSDK.SSO` and `AWSSDK.SSOOIDC` packages, which the
+  test applications deliberately do not reference. That is why the credentials
+  come via the AWS CLI rather than from the SDK's own profile handling. CI works
+  the same way: `aws-actions/configure-aws-credentials` exports credentials into
+  the job environment, and `AwsTestCredentials` sees they are already present and
+  does nothing.
+* `AWS_REGION` has no effect on these tests. The Bedrock client is constructed
+  with an explicit region taken from `AwsRegion` in your `secrets.json`, so that
+  setting is the one that matters.
+
+Developers reach this AWS account through the org-wide `NRAdmin` or
+`NRPowerUser` permission sets. There is no dedicated Bedrock permission set to
+request.
+
+Three test classes exercise models Bedrock still offers in us-west-2:
+
+* `BedrockInvokeTests` -- `amazon.titan-embed-text-v1`
+* `BedrockConverseTests` -- `us.amazon.nova-micro-v1:0`
+* `BedrockConverseContentBlockTests` -- `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+
+`LLMDisabledTests` and `LLMErrorTests` still name `meta.llama2-13b-chat-v1` and
+`meta.llama2-70b-chat-v1`, which Bedrock has retired along with the rest of the
+Llama 2 and Jurassic-2 families. They pass anyway, because neither asserts a
+successful completion: `LLMDisabledTests` runs with AI monitoring disabled and
+checks that no LLM events are produced, and `LLMErrorTests` checks that a failed
+call produces an error event. A retired model and an IAM-denied model produce the
+same error shape, so both satisfy it.
+
+`LLMApiTests` and `LLMAccountDisabledTests` have their `[Fact]` attributes
+commented out for the same deprecation, so they do not run at all. Migrating
+those to current models would need a change to the agent's own model-ID handling
+in `BedrockLlmModelTypeExtensions`, not just the tests, and is tracked
+separately.
+
+`LLM` is excluded from CI via the `INTEGRATION_EXCLUDE_NAMESPACES` repository
+variable, for reasons unrelated to Bedrock.
+
+The CI role grants only `bedrock:InvokeModel`. The Converse API authorizes
+against that action, but `ConverseStream` would need
+`bedrock:InvokeModelWithResponseStream`, which is deliberately not granted
+because nothing in the repo calls it. A new streaming Bedrock call will get a
+403 until the policy is updated.
+
 #### Selenium tests
 
 We currently have one test that executes a JavaScript ajax request via Selenium. This requires Chrome to be installed.

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -225,10 +225,6 @@ Two things are worth knowing if this ever fails:
   with an explicit region taken from `AwsRegion` in your `secrets.json`, so that
   setting is the one that matters.
 
-Developers reach this AWS account through the org-wide `NRAdmin` or
-`NRPowerUser` permission sets. There is no dedicated Bedrock permission set to
-request.
-
 Three test classes exercise models Bedrock still offers in us-west-2:
 
 * `BedrockInvokeTests` -- `amazon.titan-embed-text-v1`

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AwsTestCredentials.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AwsTestCredentials.cs
@@ -1,0 +1,152 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace NewRelic.Agent.IntegrationTestHelpers;
+
+/// <summary>
+/// Supplies the AWS credential environment variables needed by test applications that call
+/// real AWS services. Currently used by the Bedrock LLM tests. See NR-601301.
+///
+/// In CI, aws-actions/configure-aws-credentials performs the GitHub OIDC exchange and exports
+/// the resulting short-lived credentials into the job environment, which the test application
+/// inherits. Nothing is needed here, so an empty set is returned.
+///
+/// Locally, the AWS SDK for .NET cannot consume an AWS SSO session on its own: SSO credential
+/// resolution lives in the AWSSDK.SSO and AWSSDK.SSOOIDC packages, which the test applications
+/// do not reference. The AWS CLI can resolve the session, so it is asked to materialize the
+/// credentials, which are then handed to the test application as environment variables. That is
+/// the same path CI uses, so local and CI runs exercise identical SDK code.
+///
+/// Credential values are never written to the test log. They travel only through
+/// ProcessStartInfo.EnvironmentVariables, which the fixtures do not log.
+/// </summary>
+public static class AwsTestCredentials
+{
+    private const string AccessKeyIdVariable = "AWS_ACCESS_KEY_ID";
+    private const string SecretAccessKeyVariable = "AWS_SECRET_ACCESS_KEY";
+    private const string SessionTokenVariable = "AWS_SESSION_TOKEN";
+    private const int AwsCliTimeoutMilliseconds = 30000;
+
+    private static readonly object _resolveLock = new object();
+
+    private static IDictionary<string, string> _resolved;
+
+    /// <summary>
+    /// Resolves the AWS credential environment variables, once per test run. Returns an empty
+    /// dictionary when the ambient environment already carries credentials.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no credentials are present and the AWS CLI cannot supply them.
+    /// </exception>
+    public static IDictionary<string, string> GetEnvironmentVariables()
+    {
+        lock (_resolveLock)
+        {
+            return _resolved ??= Resolve();
+        }
+    }
+
+    private static IDictionary<string, string> Resolve()
+    {
+        // Already set, which is the CI case. The test application inherits the parent
+        // environment, so re-exporting would be redundant.
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(AccessKeyIdVariable)))
+        {
+            return new Dictionary<string, string>();
+        }
+
+        var exportedJson = RunAwsExportCredentials();
+
+        JObject parsed;
+        try
+        {
+            parsed = JObject.Parse(exportedJson);
+        }
+        catch (Exception ex)
+        {
+            // The raw output carries live credentials, so it must never reach the message.
+            throw new InvalidOperationException(
+                "Could not parse the output of 'aws configure export-credentials --format process'. " +
+                $"Parse error: {ex.Message}");
+        }
+
+        var accessKeyId = (string)parsed["AccessKeyId"];
+        var secretAccessKey = (string)parsed["SecretAccessKey"];
+        var sessionToken = (string)parsed["SessionToken"];
+
+        if (string.IsNullOrEmpty(accessKeyId) || string.IsNullOrEmpty(secretAccessKey))
+        {
+            throw new InvalidOperationException(
+                "'aws configure export-credentials' returned no usable AWS credentials. " +
+                "Sign in to AWS and run the tests again.");
+        }
+
+        var variables = new Dictionary<string, string>
+        {
+            { AccessKeyIdVariable, accessKeyId },
+            { SecretAccessKeyVariable, secretAccessKey }
+        };
+
+        // Absent for long-lived credentials, present for any assumed-role or SSO session.
+        if (!string.IsNullOrEmpty(sessionToken))
+        {
+            variables.Add(SessionTokenVariable, sessionToken);
+        }
+
+        return variables;
+    }
+
+    private static string RunAwsExportCredentials()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "aws",
+            Arguments = "configure export-credentials --format process",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException("The AWS CLI process could not be started.");
+            }
+
+            // Output is a few hundred bytes, well inside the pipe buffer, so reading the
+            // payload before waiting for exit cannot block.
+            var standardOutput = process.StandardOutput.ReadToEnd();
+
+            if (!process.WaitForExit(AwsCliTimeoutMilliseconds))
+            {
+                throw new InvalidOperationException(
+                    $"The AWS CLI did not exit within {AwsCliTimeoutMilliseconds}ms.");
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var standardError = process.StandardError.ReadToEnd();
+                throw new InvalidOperationException(
+                    $"'aws configure export-credentials' exited with code {process.ExitCode}. " +
+                    $"{standardError.Trim()}");
+            }
+
+            return standardOutput;
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                "Could not run the AWS CLI to resolve credentials for the Bedrock tests. Confirm the " +
+                "AWS CLI is installed and on PATH, and that you are signed in to AWS. " +
+                $"Underlying error: {ex.Message}");
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseContentBlockTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseContentBlockTests.cs
@@ -56,6 +56,13 @@ public abstract class BedrockConverseContentBlockTestsBase<TFixture> : NewRelicI
         _fixture.AddCommand($"BedrockExerciser ConverseWithExtendedThinking {LLMHelpers.ConvertToBase64(_thinkingPrompt)}");
         _fixture.AddCommand($"BedrockExerciser ConverseWithToolUseAndThinking {LLMHelpers.ConvertToBase64(_toolPrompt)}");
 
+        // Bedrock is called for real, so the test application needs AWS credentials in its
+        // environment. Supplied by OIDC in CI, by the AWS CLI locally. See NR-601301.
+        foreach (var awsCredential in AwsTestCredentials.GetEnvironmentVariables())
+        {
+            _fixture.SetAdditionalEnvironmentVariable(awsCredential.Key, awsCredential.Value);
+        }
+
         _fixture.Initialize();
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseTests.cs
@@ -62,6 +62,13 @@ public abstract class BedrockConverseTestsBase<TFixture> : NewRelicIntegrationTe
         _fixture.AddCommand($"BedrockExerciser Converse {LLMHelpers.ConvertToBase64(_prompt)}");
         _fixture.AddCommand($"BedrockExerciser ConverseWithError {LLMHelpers.ConvertToBase64(_prompt)}");
 
+        // Bedrock is called for real, so the test application needs AWS credentials in its
+        // environment. Supplied by OIDC in CI, by the AWS CLI locally. See NR-601301.
+        foreach (var awsCredential in AwsTestCredentials.GetEnvironmentVariables())
+        {
+            _fixture.SetAdditionalEnvironmentVariable(awsCredential.Key, awsCredential.Value);
+        }
+
         _fixture.Initialize();
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockInvokeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockInvokeTests.cs
@@ -70,6 +70,13 @@ public abstract class BedrockInvokeTestsBase<TFixture> : NewRelicIntegrationTest
             _fixture.AddCommand($"BedrockExerciser InvokeModel {model} {LLMHelpers.ConvertToBase64(_prompt)}");
         }
 
+        // Bedrock is called for real, so the test application needs AWS credentials in its
+        // environment. Supplied by OIDC in CI, by the AWS CLI locally. See NR-601301.
+        foreach (var awsCredential in AwsTestCredentials.GetEnvironmentVariables())
+        {
+            _fixture.SetAdditionalEnvironmentVariable(awsCredential.Key, awsCredential.Value);
+        }
+
         _fixture.Initialize();
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMDisabledTests.cs
@@ -38,6 +38,13 @@ public abstract class LlmDisabledTestsBase<TFixture> : NewRelicIntegrationTest<T
 
         _fixture.AddCommand($"BedrockExerciser InvokeModel {_model} {LLMHelpers.ConvertToBase64(_prompt)}");
 
+        // Bedrock is called for real, so the test application needs AWS credentials in its
+        // environment. Supplied by OIDC in CI, by the AWS CLI locally. See NR-601301.
+        foreach (var awsCredential in AwsTestCredentials.GetEnvironmentVariables())
+        {
+            _fixture.SetAdditionalEnvironmentVariable(awsCredential.Key, awsCredential.Value);
+        }
+
         _fixture.Initialize();
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMErrorTests.cs
@@ -39,6 +39,13 @@ public abstract class LlmErrorTestsBase<TFixture> : NewRelicIntegrationTest<TFix
         _fixture.AddCommand($"BedrockExerciser InvokeModel {_accessDeniedModel} {LLMHelpers.ConvertToBase64(_prompt)}");
         _fixture.AddCommand($"BedrockExerciser InvokeModelWithError {_badConfigModel} {LLMHelpers.ConvertToBase64(_prompt)}");
 
+        // Bedrock is called for real, so the test application needs AWS credentials in its
+        // environment. Supplied by OIDC in CI, by the AWS CLI locally. See NR-601301.
+        foreach (var awsCredential in AwsTestCredentials.GetEnvironmentVariables())
+        {
+            _fixture.SetAdditionalEnvironmentVariable(awsCredential.Key, awsCredential.Value);
+        }
+
         _fixture.Initialize();
     }
 

--- a/tests/Agent/IntegrationTests/Shared/AwsConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/AwsConfiguration.cs
@@ -5,24 +5,6 @@ namespace NewRelic.Agent.IntegrationTests.Shared;
 
 public class AwsConfiguration
 {
-    public static string AwsAccessKeyId
-    {
-        get
-        {
-            var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("");
-            return testConfiguration.DefaultSetting.AwsAccessKeyId;
-        }
-    }
-
-    public static string AwsSecretAccessKey
-    {
-        get
-        {
-            var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("");
-            return testConfiguration.DefaultSetting.AwsSecretAccessKey;
-        }
-    }
-
     public static string AwsRegion
     {
         get

--- a/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
@@ -106,11 +106,7 @@ public class TestSettings
     public string LicenseKey { get; set; }
     public string Collector { get; set; }
     public string NewRelicAccountId { get; set; }
-    public string AwsTestRoleArn { get; set; }
-    public string AwsAccessKeyId { get; set; }
-    public string AwsSecretAccessKey { get; set; }
     public string AwsRegion { get; set; }
-    public string AwsAccountNumber { get; set; }
     public string TraceObserverUrl { get; set; }
     public IDictionary<string, string> CustomSettings { get; set; }
     public string TraceObserverPort { get; set; } = "443";

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
@@ -20,8 +20,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LLM;
 
 internal class BedrockModels
 {
+    // No explicit credentials: the AWS SDK default credential chain resolves
+    // identity from the environment (OIDC in CI) or the developer's AWS SSO
+    // profile locally. See NR-601301.
     private static readonly AmazonBedrockRuntimeClient _amazonBedrockRuntimeClient =
-        new AmazonBedrockRuntimeClient(AwsConfiguration.AwsAccessKeyId, AwsConfiguration.AwsSecretAccessKey, AwsConfiguration.AwsRegion.ToRegionId());
+        new AmazonBedrockRuntimeClient(AwsConfiguration.AwsRegion.ToRegionId());
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static async Task<string> InvokeAmazonEmbedAsync(string prompt, bool generateError) => await InvokeTitanAsync(prompt, true, generateError);

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -4,10 +4,7 @@
       "LicenseKey": "YOUR_NEW_RELIC_LICENSE_KEY_HERE",
       "Collector": "collector.newrelic.com",
       "NewRelicAccountId": "YOUR_ACCOUNT_ID_HERE",
-      "AwsTestRoleArn": "YOUR_AWS_TEST_ROLE_ARN_HERE",
-      "AwsAccessKeyId": "YOUR_AWS_ACCESS_KEY_ID_HERE",
-      "AwsSecretAccessKey": "YOUR_AWS_SECRET_ACCESS_KEY_HERE",
-      "AwsAccountNumber": "YOUR_AWS_ACCOUNT_NUMBER_HERE",
+      "AwsRegion": "YOUR_AWS_REGION_HERE",
       "TraceObserverUrl": "YOUR_NR_EDGE_TRACE_OBSERVER_HERE",
       "ContainerTestAcrName": "YOUR_ACR_NAME_HERE"
     },


### PR DESCRIPTION
Removes the long-lived AWS access key from the test configuration surface, from NR-601301. The key itself was already deleted in AWS on 2026-08-01 under NR-601293, so the Bedrock tests could not authenticate by any means before this change.

- CI assumes a repo-scoped role via GitHub OIDC, gated to the `LLM` matrix job so no other job holds AWS credentials.
- Locally, `AwsTestCredentials` asks the AWS CLI for the current credentials at test startup and passes them to the test application. The AWS SDK for .NET cannot read an SSO session without the `AWSSDK.SSO`/`AWSSDK.SSOOIDC` packages, which the test apps deliberately do not reference, so this routes local runs through the same environment-variable path CI uses.
- `AwsAccessKeyId`, `AwsSecretAccessKey`, `AwsAccountNumber` and `AwsTestRoleArn` are gone from `IntegrationTestConfiguration`; `AwsRegion` stays.

The AWS role and its least-privilege policy are already provisioned. The policy grants `bedrock:InvokeModel` on exactly the five models the tests name, and carries an explicit `Deny` on `meta.llama2-70b-chat-v1` because `LLMErrorTests` uses it as its access-denied case and asserts the call is refused -- do not widen that.

Verified that the LLM namespace tests are successful in CI with this change. 