### PR TITLE
feat: Add allocation sampling to continuous profiling for .NET

### DIFF
--- a/licenses/THIRD_PARTY_NOTICES.txt
+++ b/licenses/THIRD_PARTY_NOTICES.txt
@@ -48,6 +48,13 @@ Vendored copy: dotnet/coreclr @ commit 1b04187394cd1de5b316c40a3ad9d9189f4cb5b0
 src/Agent/NewRelic/Profiler/externals/coreclr-headers/. Used to supply CLR
 profiling-API headers to the native profiler build.
 
+One file in that directory, src/pal/prebuilt/inc/corprof.h, is instead taken
+from '.NET Runtime' (https://github.com/dotnet/runtime) @ tag v5.0.17, commit
+6a984143635bde23e728abaaccbde52f5ea8fa3e, because dotnet/coreclr was archived
+before the EventPipe profiling API (ICorProfilerCallback10 /
+ICorProfilerInfo12) was added. dotnet/runtime is released under the same MIT
+license, reproduced below.
+
 The MIT License (MIT)
 
 Copyright (c) .NET Foundation and Contributors

--- a/src/Agent/NewRelic/Agent/Core/Commands/DetailedContinuousProfilerResponseFormatter.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/DetailedContinuousProfilerResponseFormatter.cs
@@ -8,10 +8,10 @@ namespace NewRelic.Agent.Core.Commands;
 
 /// <summary>
 /// The detailed response proposed in the DACI's "Additional Notes" section (not yet decided): the profile
-/// types currently profiling, the effective intervals, and any per-type exceptions ("not supported" for
-/// heap/allocations, since that isn't implemented yet). Only adds the "exceptions" key when there is at
-/// least one exception, matching the proposed spec's "the agent response payload includes exceptions if
-/// present" wording.
+/// types currently profiling, the effective intervals, and any per-type exceptions ("not supported" for a
+/// token this agent does not recognize). Only adds the "exceptions" key when there is at least one
+/// exception, matching the proposed spec's "the agent response payload includes exceptions if present"
+/// wording.
 /// </summary>
 public class DetailedContinuousProfilerResponseFormatter : IContinuousProfilerCommandResponseFormatter
 {

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -6677,6 +6677,8 @@ namespace NewRelic.Agent.Core.Config
     public partial class configurationContinuousProfiling
     {
         
+        private configurationContinuousProfilingAllocation allocationField;
+        
         private bool enabledField;
         
         private int samplingIntervalMsField;
@@ -6686,8 +6688,21 @@ namespace NewRelic.Agent.Core.Config
         /// </summary>
         public configurationContinuousProfiling()
         {
+            this.allocationField = new configurationContinuousProfilingAllocation();
             this.enabledField = false;
             this.samplingIntervalMsField = 10000;
+        }
+        
+        public configurationContinuousProfilingAllocation allocation
+        {
+            get
+            {
+                return this.allocationField;
+            }
+            set
+            {
+                this.allocationField = value;
+            }
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -6725,6 +6740,65 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationContinuousProfiling Clone()
         {
             return ((configurationContinuousProfiling)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationContinuousProfilingAllocation
+    {
+        
+        private bool enabledField;
+        
+        private int maxSamplesPerMinuteField;
+        
+        /// <summary>
+        /// configurationContinuousProfilingAllocation class constructor
+        /// </summary>
+        public configurationContinuousProfilingAllocation()
+        {
+            this.enabledField = false;
+            this.maxSamplesPerMinuteField = 200;
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        public bool enabled
+        {
+            get
+            {
+                return this.enabledField;
+            }
+            set
+            {
+                this.enabledField = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(200)]
+        public int maxSamplesPerMinute
+        {
+            get
+            {
+                return this.maxSamplesPerMinuteField;
+            }
+            set
+            {
+                this.maxSamplesPerMinuteField = value;
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationContinuousProfilingAllocation object
+        /// </summary>
+        public virtual configurationContinuousProfilingAllocation Clone()
+        {
+            return ((configurationContinuousProfilingAllocation)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -2238,6 +2238,45 @@
                     </xs:annotation>
 
                     <xs:complexType>
+                        <xs:all>
+                            <xs:element name="allocation" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Controls allocation sampling within continuous profiling. Allocation
+                                        sampling is driven by CLR AllocationTick events rather than by the
+                                        periodic thread sampler, so it has its own enable flag and its own
+                                        sample budget. It requires continuous profiling itself to be enabled.
+                                        Available only on .NET 5+ (it needs the runtime's EventPipe profiling
+                                        API); on .NET Framework it is silently unavailable.
+                                    </xs:documentation>
+                                </xs:annotation>
+
+                                <xs:complexType>
+                                    <xs:attribute name="enabled" type="xs:boolean" default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Set this to "true" to enable allocation sampling. The default is
+                                                false. Environment variable:
+                                                NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="maxSamplesPerMinute" type="xs:int" default="200">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Upper bound on the number of allocation samples captured per
+                                                minute. Each sample costs a stack walk on the allocating
+                                                application thread, so this is the feature's main overhead
+                                                control. The value is clamped to the range [1, 60000]. The
+                                                default is 200. Environment variable:
+                                                NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:all>
+
                         <xs:attribute name="enabled" type="xs:boolean" default="false">
                             <xs:annotation>
                                 <xs:documentation>

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -2245,7 +2245,10 @@
                                         Controls allocation sampling within continuous profiling. Allocation
                                         sampling is driven by CLR AllocationTick events rather than by the
                                         periodic thread sampler, so it has its own enable flag and its own
-                                        sample budget. It requires continuous profiling itself to be enabled.
+                                        sample budget, and it can be enabled independently of the
+                                        continuousProfiling "enabled" attribute (which controls thread
+                                        sampling). It is still disabled by high security mode, and by a
+                                        server-side setting that disables continuous profiling.
                                         Available only on .NET 5+ (it needs the runtime's EventPipe profiling
                                         API); on .NET Framework it is silently unavailable.
                                     </xs:documentation>
@@ -2256,7 +2259,8 @@
                                         <xs:annotation>
                                             <xs:documentation>
                                                 Set this to "true" to enable allocation sampling. The default is
-                                                false. Environment variable:
+                                                false. This does not require the continuousProfiling "enabled"
+                                                attribute to be true. Environment variable:
                                                 NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED
                                             </xs:documentation>
                                         </xs:annotation>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3004,6 +3004,52 @@ public class DefaultConfiguration : IConfiguration
     public bool ContinuousProfilingIncludeAgentCode =>
         TryGetAppSettingAsBoolWithDefault("NewRelic.ContinuousProfilingIncludeAgentCode", false);
 
+    // The native AllocationSampler refuses a non-positive budget outright and clamps at
+    // MaxSupportedSamplesPerMinute (Profiler/ContinuousProfiler/AllocationSampler.h, currently 60000). These
+    // mirror that accepted range so a typo (0, -1) can't resolve to a value the native side will reject --
+    // which would leave the managed side believing allocation sampling is running while no session was ever
+    // opened. The native validation stays the trust boundary; this is the belt to its braces. Keep the ceiling
+    // in step with AllocationSampler::MaxSupportedSamplesPerMinute.
+    private const int MinContinuousProfilingAllocationMaxSamplesPerMinute = 1;
+    private const int MaxContinuousProfilingAllocationMaxSamplesPerMinute = 60000;
+
+    private bool? _continuousProfilingAllocationEnabled;
+    // Allocation sampling is a SUB-FEATURE of continuous profiling, matching its nested position in the XSD
+    // (<continuousProfiling><allocation/></continuousProfiling>) and the precedent set by
+    // OpenTelemetryMetricsEnabled/OpenTelemetryTracingEnabled: the child flag is ANDed with its parent, so
+    // turning continuous profiling off turns allocation sampling off too. That also inherits the parent's
+    // high-security-mode kill and its server-side-config override for free; there is deliberately no
+    // allocation-specific server-side key, since the parent's already lets the server disable the whole
+    // feature.
+    //
+    // This flag is about the FEATURE being wanted, not about the thread sampler running: the two samplers'
+    // lifecycles are independent inside ContinuousProfilingService (allocation sampling is AllocationTick-
+    // driven and needs no periodic thread walk), so "allocation sampling active while the thread sampler is
+    // stopped" is a legitimate, reachable state -- e.g. after a stop_continuous_profiler command for "cpu".
+    public bool ContinuousProfilingAllocationEnabled => _continuousProfilingAllocationEnabled ??=
+        ContinuousProfilingEnabled &&
+        EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("NewRelic.ContinuousProfilingAllocationEnabled", _localConfiguration.continuousProfiling.allocation.enabled), "NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED");
+
+    private int? _continuousProfilingAllocationMaxSamplesPerMinute;
+    public int ContinuousProfilingAllocationMaxSamplesPerMinute
+    {
+        get
+        {
+            if (_continuousProfilingAllocationMaxSamplesPerMinute.HasValue)
+                return _continuousProfilingAllocationMaxSamplesPerMinute.Value;
+
+            // Same env > appSettings > element precedence (and same clamp-last shape) as
+            // ContinuousProfilingSamplingIntervalMs. EnvironmentOverrides falls back to the (non-null)
+            // appSettings-or-element value, so the result is never null.
+            var configured = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("NewRelic.ContinuousProfilingAllocationMaxSamplesPerMinute", _localConfiguration.continuousProfiling.allocation.maxSamplesPerMinute), "NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE")
+                .GetValueOrDefault();
+
+            var clamped = Math.Min(MaxContinuousProfilingAllocationMaxSamplesPerMinute, Math.Max(MinContinuousProfilingAllocationMaxSamplesPerMinute, configured));
+            _continuousProfilingAllocationMaxSamplesPerMinute = clamped;
+            return clamped;
+        }
+    }
+
     public static bool GetLoggingEnabledValue(IEnvironment environment, configurationLog localLogConfiguration)
     {
         return EnvironmentOverrides(environment, localLogConfiguration.enabled, "NEW_RELIC_LOG_ENABLED");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3014,20 +3014,26 @@ public class DefaultConfiguration : IConfiguration
     private const int MaxContinuousProfilingAllocationMaxSamplesPerMinute = 60000;
 
     private bool? _continuousProfilingAllocationEnabled;
-    // Allocation sampling is a SUB-FEATURE of continuous profiling, matching its nested position in the XSD
-    // (<continuousProfiling><allocation/></continuousProfiling>) and the precedent set by
-    // OpenTelemetryMetricsEnabled/OpenTelemetryTracingEnabled: the child flag is ANDed with its parent, so
-    // turning continuous profiling off turns allocation sampling off too. That also inherits the parent's
-    // high-security-mode kill and its server-side-config override for free; there is deliberately no
-    // allocation-specific server-side key, since the parent's already lets the server disable the whole
-    // feature.
+    // INDEPENDENT of ContinuousProfilingEnabled, deliberately: allocation sampling is driven by CLR
+    // AllocationTick events, not by the periodic thread walk, so it neither needs nor implies the thread
+    // sampler. "Allocation sampling on, thread sampling off" is a supported, durable configuration.
     //
-    // This flag is about the FEATURE being wanted, not about the thread sampler running: the two samplers'
-    // lifecycles are independent inside ContinuousProfilingService (allocation sampling is AllocationTick-
-    // driven and needs no periodic thread walk), so "allocation sampling active while the thread sampler is
-    // stopped" is a legitimate, reachable state -- e.g. after a stop_continuous_profiler command for "cpu".
+    // It is NOT independent of the two GUARDS that flag consults, and this checks them directly rather than
+    // ANDing with that sibling property's value:
+    //   * !HighSecurityModeEnabled -- allocation samples carry stack frames and allocated type names, exactly
+    //     the class of data HSM disables continuous profiling for. Same defense-in-depth reasoning as there:
+    //     no server-side "strip the key" backstop exists for this setting, so the local guard is the only
+    //     enforcement.
+    //   * The server-side continuous-profiling kill switch. Read as "has the server disabled continuous
+    //     profiling?" -- a server FALSE turns allocation sampling off too, while a server TRUE is not treated
+    //     as turning it on, because that key is about the feature as a whole and says nothing about whether
+    //     this customer wants allocation sampling specifically. (There is deliberately no allocation-specific
+    //     server-side key; add one only if per-signal server control is actually needed.)
+    // Reaching those guards by ANDing ContinuousProfilingEnabled would have coupled allocation's availability
+    // to the thread sampler's local `enabled` flag, which is the opposite of the independence above.
     public bool ContinuousProfilingAllocationEnabled => _continuousProfilingAllocationEnabled ??=
-        ContinuousProfilingEnabled &&
+        !HighSecurityModeEnabled &&
+        _serverConfiguration.RpmConfig.ContinuousProfilingEnabled != false &&
         EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("NewRelic.ContinuousProfilingAllocationEnabled", _localConfiguration.continuousProfiling.allocation.enabled), "NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED");
 
     private int? _continuousProfilingAllocationMaxSamplesPerMinute;

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -829,5 +829,11 @@ public class ReportedConfiguration : IConfiguration
     [JsonProperty("continuous_profiling.include_agent_code")]
     public bool ContinuousProfilingIncludeAgentCode => _configuration.ContinuousProfilingIncludeAgentCode;
 
+    [JsonProperty("continuous_profiling.allocation.enabled")]
+    public bool ContinuousProfilingAllocationEnabled => _configuration.ContinuousProfilingAllocationEnabled;
+
+    [JsonProperty("continuous_profiling.allocation.max_samples_per_minute")]
+    public int ContinuousProfilingAllocationMaxSamplesPerMinute => _configuration.ContinuousProfilingAllocationMaxSamplesPerMinute;
+
     #endregion
 }

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/AllocationSample.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/AllocationSample.cs
@@ -1,0 +1,33 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Agent.Core.ContinuousProfiling;
+
+public class AllocationSample
+{
+    public string ThreadName { get; }
+    public long OsThreadId { get; }
+    public long TraceIdHigh { get; }
+    public long TraceIdLow { get; }
+    public long SpanId { get; }
+    public long TimestampMillis { get; }
+    public ulong AllocatedSize { get; }
+    public string TypeName { get; }
+    public IReadOnlyList<string> Frames { get; } // leaf-first
+
+    public AllocationSample(string threadName, long osThreadId, long traceIdHigh, long traceIdLow, long spanId,
+        long timestampMillis, ulong allocatedSize, string typeName, IReadOnlyList<string> frames)
+    {
+        ThreadName = threadName;
+        OsThreadId = osThreadId;
+        TraceIdHigh = traceIdHigh;
+        TraceIdLow = traceIdLow;
+        SpanId = spanId;
+        TimestampMillis = timestampMillis;
+        AllocatedSize = allocatedSize;
+        TypeName = typeName;
+        Frames = frames;
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/BufferParser.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/BufferParser.cs
@@ -13,6 +13,7 @@ public static class BufferParser
     private const byte StartSample = 0x02;
     private const byte EndBatch = 0x06;
     private const byte BatchStatsOpcode = 0x07;
+    private const byte AllocationSampleOpcode = 0x08;
 
     /// <summary>
     /// Per-sweep native BatchStats (opcode 0x07). <see cref="MicrosSuspended"/> is the actual runtime-suspend
@@ -44,9 +45,19 @@ public static class BufferParser
     /// none). Callers use it to surface the suspend-window / coverage counters.
     /// </summary>
     public static IReadOnlyList<ManagedThreadSample> Parse(byte[] buffer, int length, out BatchStats stats)
+        => Parse(buffer, length, out stats, out _);
+
+    /// <summary>
+    /// Parse overload that also captures allocation samples (opcode 0x08), which share the same
+    /// per-batch frame-interning table as thread samples.
+    /// </summary>
+    public static IReadOnlyList<ManagedThreadSample> Parse(byte[] buffer, int length, out BatchStats stats,
+        out IReadOnlyList<AllocationSample> allocations)
     {
         stats = null;
         var samples = new List<ManagedThreadSample>();
+        var allocationSamples = new List<AllocationSample>();
+        allocations = allocationSamples;
         if (buffer == null || length <= 0)
             return samples;
 
@@ -66,6 +77,9 @@ public static class BufferParser
                         break;
                     case StartSample:
                         samples.Add(ReadSample(buffer, ref pos, frameDictionary, version, length));
+                        break;
+                    case AllocationSampleOpcode:
+                        allocationSamples.Add(ReadAllocationSample(buffer, ref pos, frameDictionary, length));
                         break;
                     case BatchStatsOpcode:
                         {
@@ -88,6 +102,37 @@ public static class BufferParser
             // truncated/garbage past `length`: return what parsed cleanly (Global Constraint: never throw)
         }
         return samples;
+    }
+
+    private static AllocationSample ReadAllocationSample(byte[] b, ref int pos, Dictionary<int, string> dict, int length)
+    {
+        var threadName = ReadString(b, ref pos, length);
+        var osThreadId = ReadLong(b, ref pos, length);
+        var traceHigh = ReadLong(b, ref pos, length);
+        var traceLow = ReadLong(b, ref pos, length);
+        var spanId = ReadLong(b, ref pos, length);
+        var timestampMillis = ReadLong(b, ref pos, length);
+        var allocatedSize = unchecked((ulong)ReadLong(b, ref pos, length));
+        var typeName = ReadString(b, ref pos, length);
+
+        var frames = new List<string>();
+        while (true)
+        {
+            var code = ReadShort(b, ref pos, length);
+            if (code == 0) break;
+            if (code < 0)
+            {
+                var value = ReadString(b, ref pos, length);
+                dict[-code] = value;
+                frames.Add(value);
+            }
+            else
+            {
+                frames.Add(dict.TryGetValue(code, out var v) ? v : "<unknown>");
+            }
+        }
+        return new AllocationSample(threadName, osThreadId, traceHigh, traceLow, spanId, timestampMillis,
+            allocatedSize, typeName, frames);
     }
 
     private static ManagedThreadSample ReadSample(byte[] b, ref int pos, Dictionary<int, string> dict, int version, int length)

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingCommandResult.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingCommandResult.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Agent.Core.ContinuousProfiling;
 /// </summary>
 public class ContinuousProfilingCommandResult
 {
-    /// <summary>Profile-type tokens ("cpu") currently profiling, after this command was applied.</summary>
+    /// <summary>Profile-type tokens ("cpu", "heap") currently profiling, after this command was applied.</summary>
     public IReadOnlyList<string> ActiveTypes { get; }
 
     public int SampleIntervalMs { get; }
@@ -24,8 +24,9 @@ public class ContinuousProfilingCommandResult
     public int CpuReportIntervalMs { get; }
 
     /// <summary>
-    /// Profile-type token (or unrecognized token) -> reason it could not be started/stopped, e.g.
-    /// "heap" -> "not supported". Empty when nothing requested was unsupported.
+    /// Requested token -> reason it could not be started/stopped, e.g. an unrecognized "cpus" ->
+    /// "not supported". Empty when everything requested was acted on, which is now the case for every
+    /// recognized token ("all"/"cpu"/"heap").
     /// </summary>
     public IReadOnlyDictionary<string, string> Exceptions { get; }
 

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingCommandTypes.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingCommandTypes.cs
@@ -5,12 +5,12 @@ namespace NewRelic.Agent.Core.ContinuousProfiling;
 
 /// <summary>
 /// Translates the start_continuous_profiler/stop_continuous_profiler "include" tokens ("all", "cpu", "heap")
-/// into the two things this agent can actually act on today: whether to touch the cpu+off_cpu sampler bundle
-/// (the only thing <see cref="ContinuousProfilingService"/> can start/stop right now -- on/off-CPU
-/// classification is a per-sample attribute produced by a single sampler, not two independently toggleable
-/// modes), and whether "heap" (allocation profiling) was requested -- which always reports "not supported"
-/// since allocation profiling isn't implemented yet. Per the spec: "all" = cpu + off_cpu + allocations;
-/// "cpu" = cpu + off_cpu only; "heap" = allocations only.
+/// into the two samplers <see cref="ContinuousProfilingService"/> can independently start and stop: the
+/// cpu+off_cpu bundle (one bundle, not two toggles -- on/off-CPU classification is a per-sample attribute
+/// produced by a single sampler) and the allocation sampler. Both are now really acted on: "heap" starts and
+/// stops allocation sampling under the same command-ownership rules as "cpu". Per the spec:
+/// "all" = cpu + off_cpu + allocations; "cpu" = cpu + off_cpu only; "heap" = allocations only. Only an
+/// unrecognized token is reported back as "not supported".
 /// </summary>
 public static class ContinuousProfilingCommandTypes
 {

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
@@ -948,14 +948,26 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 // Both sample types are read into the SAME buffer, sequentially -- and the allocation source
                 // is read repeatedly, so a single drain buffer serves several reads in a row. Deliberate: the buffer is
                 // sized for native's 4 MB thread-batch cap, and a second dedicated buffer would double that
-                // permanent per-process footprint for allocation batches native caps at 256 KB
+                // permanent per-process footprint for allocation batches native caps at 128 KB
                 // (AllocationSampler::MaxAllocationBufferBytes). It is safe because the reads are strictly
                 // sequential and each parse fully materializes its results before the next read overwrites the
                 // bytes -- BufferParser copies every string out (Encoding.Unicode.GetString), so no parsed
                 // object aliases the buffer -- and because _drainInFlight already makes this the only drain
                 // touching it.
+                //
+                // Gated on _isActive for the same reason the allocation read below is gated on
+                // _allocationActive: the shared drain timer can be armed by EITHER sampler, so in an
+                // allocation-only configuration (which this feature supports, and which its own integration
+                // test uses) an ungated read would P/Invoke into a never-started thread sampler on every tick
+                // for the life of the process.
+                //
+                // Nothing is lost by skipping a stopped sampler's residual batch: StopLocked clears
+                // _activeIntervalMs along with _isActive, so periodNanos is 0 by the time such a batch could be
+                // drained and OtlpProfileBuilder emits no cpu/off_cpu profile without a period -- those samples
+                // were already unreportable. It also closes the one path that could ship a profile-LESS payload
+                // (residual thread samples + no allocation samples + no period => a request with zero profiles).
                 var samples = EmptyThreadSamples;
-                if (TryReadIntoDrainBuffer(_sampleSource, out var bytesRead))
+                if (_isActive && TryReadIntoDrainBuffer(_sampleSource, out var bytesRead))
                 {
                     samples = BufferParser.Parse(_drainBuffer, bytesRead, out var batchStats);
 
@@ -968,9 +980,10 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                             batchStats.MicrosSuspended, batchStats.Threads, batchStats.Frames, batchStats.Skipped, CountOnCpu(samples), samples.Count);
                 }
 
-                // Gated on _allocationActive, unlike the thread read above: the drain timer can be armed by
-                // the thread sampler alone, and in that (default) case an ungated read would P/Invoke into a
-                // never-started allocation sampler on every single tick for the life of the process.
+                // Gated on _allocationActive, the mirror of the thread read's _isActive gate above: the drain
+                // timer can be armed by the thread sampler alone, and in that (default) case an ungated read
+                // would P/Invoke into a never-started allocation sampler on every tick for the life of the
+                // process.
                 var allocationSamples = EmptyAllocationSamples;
                 var allocationSamplesDropped = 0;
                 if (_allocationActive)

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
@@ -380,14 +380,9 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             return;
         }
 
+        // Without this, a live budget change would silently do nothing.
         if (maxSamplesPerMinute != _allocationMaxSamplesPerMinute)
-        {
-            // Re-pace in place: the native sampler's Start is idempotent and replaces its sub-sampler at the
-            // new budget WITHOUT reopening its session, so unlike the thread sampler's retune this needs no
-            // stop/start and never touches the shared drain timer (the budget is a per-minute sample cap, not
-            // a drain cadence). Without this, a live budget change would silently do nothing.
-            StartOrRepaceAllocationLocked(maxSamplesPerMinute);
-        }
+            RepaceAllocationLocked(maxSamplesPerMinute);
     }
 
     /// <summary>
@@ -515,25 +510,26 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
 
             try
             {
-                // A new session starts optimistic: clear any backoff state left over from a PREVIOUS session.
-                // Without this, disabling CP while a probe is pending and re-enabling later would leave
-                // _sendBackoffActive stuck true forever -- EndBackoffProbe's own !_isActive guard (below) means
-                // the probe that fires while disabled never clears it, and nothing else ever will.
-                //
-                // Ints first, then the volatile flag last -- a volatile write publishes everything written
-                // before it to another thread's next volatile read of the same field (release semantics). The
-                // old order (flag first) published nothing. Matches ResumeAfterReconnect's order.
-                _consecutiveSendFailures = 0;
-                _backoffIndex = 0;
-                // Supersede any probe still pending from a previous session (e.g. a retune's stop/start), so it
-                // no-ops instead of resuming sampling this fresh session didn't schedule.
-                _backoffGeneration++;
-                _sendBackoffActive = false;
+                var wasBackingOff = ClearSendBackoffForFreshStartLocked();
 
                 // Arm the reverse-guard flag before starting native sampling, while still holding the gate
                 // above -- ThreadProfilingService's forward guard can only observe this flag after acquiring
                 // the same lock, so there is no window for it to see a stale "not active" value here.
                 _isActive = true;
+
+                // Clearing the gate above superseded the pending probe -- the only thing that would ever have
+                // resumed the OTHER sampler if a trip had paused it. Resume it here or it stays Stop()'d forever
+                // with _allocationActive still reading true, so nothing ever tries again and DrainOnce reads a dead
+                // sampler indefinitely.
+                //
+                // ORDER IS LOAD-BEARING: this MUST come before this sampler's own native start, which can throw.
+                // There is no data dependency between the two, and if the resume sat after the throwing call, an
+                // own-start failure would skip it entirely -- leaving the other sampler stopped with its flag true
+                // and the gate now permanently clear (no probe left to fire), which is unrecoverable short of a
+                // stop command or a process restart. The catch below only unwinds THIS sampler, so it cannot repair
+                // that. Debt to the other sampler is paid first, then this one takes its own risk.
+                if (wasBackingOff && _allocationActive)
+                    ResumeAllocationAfterBackoffLocked();
 
                 // Start native sampling first, then begin draining it. Both run under _lifecycleLock, which is
                 // fine: lifecycle transitions are rare (config-driven), so the native call here does not touch
@@ -589,7 +585,7 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
 
     /// <summary>
     /// Starts the allocation sampler, unless it is already running. A no-op while already active -- use
-    /// <see cref="StartOrRepaceAllocationLocked"/> to change the budget of a running sampler.
+    /// <see cref="RepaceAllocationLocked"/> to change the budget of a running sampler.
     /// </summary>
     private void StartAllocationLocked(int maxSamplesPerMinute)
     {
@@ -601,24 +597,27 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
         // session. Allocation sampling walks only the allocating thread and try_locks the same native
         // SuspendMutex, so a tick that collides with either walker is simply dropped -- the enforcement is
         // already in the native tick path, and deferring here would add a state machine that buys nothing.
-        StartOrRepaceAllocationLocked(maxSamplesPerMinute);
-    }
-
-    /// <summary>
-    /// Starts the allocation sampler, or re-paces it at a new budget if it is already running (the native
-    /// sampler's Start is idempotent and re-pacing does not reopen its session).
-    /// </summary>
-    private void StartOrRepaceAllocationLocked(int maxSamplesPerMinute)
-    {
-        var wasActive = _allocationActive;
-
         try
         {
+            // Same optimistic reset the thread sampler's start performs, for the same reason and with the same
+            // hazard if omitted: a probe pending from a previous session would otherwise leave the gate stuck
+            // true forever (TryResumeSamplingLocked's "neither sampler active" guard means a probe firing while
+            // disabled never clears it, and nothing else ever will), so allocation sampling would run with every
+            // drain silently gated off.
+            var wasBackingOff = ClearSendBackoffForFreshStartLocked();
+
             // Armed before the call that can throw, and unwound in the catch -- same shape as StartLocked, so
             // a half-started allocation sampler cannot leave the flag lying true with nothing sampling (which
             // would also pin the shared drain timer open forever).
             _allocationActive = true;
             _allocationMaxSamplesPerMinute = maxSamplesPerMinute;
+
+            // Mirror of StartLocked, including the ordering requirement: this start just superseded the probe
+            // that would have resumed the thread sampler, so resume it here -- BEFORE this sampler's own
+            // throwing native call -- rather than risk leaving it paused forever with _isActive still true.
+            // See the equivalent comment in StartLocked for why the order is load-bearing.
+            if (wasBackingOff && _isActive)
+                ResumeThreadSamplingAfterBackoffLocked();
 
             // Stop(), never Shutdown(), is the disable -- so Start() here is always legal to call again. See
             // IAllocationSampleSource.Shutdown for why getting that backwards is unrecoverable.
@@ -630,13 +629,44 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             if (_drainIntervalMs == 0)
                 ArmDrainScheduleLocked(_configuration.ContinuousProfilingSamplingIntervalMs);
 
-            Log.Info(wasActive
-                ? "[ContinuousProfiling] Allocation sampling re-paced to at most {0} samples/minute."
-                : "[ContinuousProfiling] Allocation sampling started; up to {0} samples/minute.", maxSamplesPerMinute);
+            Log.Info("[ContinuousProfiling] Allocation sampling started; up to {0} samples/minute.", maxSamplesPerMinute);
         }
         catch (Exception ex)
         {
             Log.Error(ex, "[ContinuousProfiling] Failed to start allocation sampling.");
+            StopAllocationLocked();
+        }
+    }
+
+    /// <summary>
+    /// Changes the budget of an ALREADY-RUNNING allocation sampler. Unlike the thread sampler's retune this
+    /// needs no stop/start and never touches the shared drain timer: the native sampler's Start is idempotent
+    /// and replaces its sub-sampler at the new budget without reopening its session, and the budget is a
+    /// per-minute sample cap rather than a drain cadence.
+    /// </summary>
+    private void RepaceAllocationLocked(int maxSamplesPerMinute)
+    {
+        try
+        {
+            _allocationMaxSamplesPerMinute = maxSamplesPerMinute;
+
+            // Deliberately does NOT clear the backoff gate the way a fresh start does: a budget edit is no
+            // evidence that a broken send path has recovered, so collapsing a legitimate backoff round on one
+            // would be wrong. While backing off, the sampler is intentionally paused and the drain is gated, so
+            // re-arming it here would buy real stack walks on customer threads whose output is discarded.
+            // Recording the budget is sufficient -- the probe resumes at _allocationMaxSamplesPerMinute.
+            if (_sendBackoffActive)
+            {
+                Log.Debug("[ContinuousProfiling] Allocation budget recorded as {0} samples/minute; it takes effect when sampling resumes after the current send backoff.", maxSamplesPerMinute);
+                return;
+            }
+
+            _allocationSampleSource.Start(maxSamplesPerMinute);
+            Log.Info("[ContinuousProfiling] Allocation sampling re-paced to at most {0} samples/minute.", maxSamplesPerMinute);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[ContinuousProfiling] Failed to re-pace allocation sampling.");
             StopAllocationLocked();
         }
     }
@@ -665,6 +695,84 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
         {
             _allocationActive = false;
             _allocationMaxSamplesPerMinute = 0;
+        }
+    }
+
+    /// <summary>
+    /// A sampler is starting, so the session becomes optimistic again: clears any send-failure backoff state
+    /// left over from before this start and supersedes the pending probe. Returns whether a backoff was in fact
+    /// in progress -- the caller MUST then resume the other sampler if that sampler is active, because the
+    /// superseded probe was the only thing that would ever have done so.
+    ///
+    /// Shared by BOTH start paths so backoff entry and exit stay symmetric across the two samplers: the trip
+    /// (<see cref="TripBackoffAndScheduleProbeLocked"/>) pauses both, so any start that cancels the recovery
+    /// owes both a resume.
+    /// </summary>
+    private bool ClearSendBackoffForFreshStartLocked()
+    {
+        // Without this, disabling a sampler while a probe is pending and re-enabling it later would leave
+        // _sendBackoffActive stuck true forever -- TryResumeSamplingLocked's "neither sampler active" guard
+        // means the probe that fires while disabled never clears it, and nothing else ever will.
+        //
+        // Ints first, then the volatile flag last -- a volatile write publishes everything written
+        // before it to another thread's next volatile read of the same field (release semantics). The
+        // old order (flag first) published nothing. Matches ResumeAfterReconnect's order.
+        _consecutiveSendFailures = 0;
+        _backoffIndex = 0;
+        // Supersede any probe still pending from a previous session (e.g. a retune's stop/start), so it
+        // no-ops instead of resuming sampling this fresh session didn't schedule.
+        _backoffGeneration++;
+
+        var wasBackingOff = _sendBackoffActive;
+        _sendBackoffActive = false;
+        return wasBackingOff;
+    }
+
+    /// <summary>
+    /// Resumes the allocation sampler that a backoff trip paused, on behalf of a thread-sampler start that has
+    /// just superseded the probe. Self-contained error handling on purpose: a failure to resume allocation
+    /// sampling must fail only allocation sampling, not unwind the thread-sampler start that called it.
+    /// </summary>
+    private void ResumeAllocationAfterBackoffLocked()
+    {
+        try
+        {
+            _allocationSampleSource.Start(_allocationMaxSamplesPerMinute);
+
+            // Every resume path owns this reset (see TryResumeSamplingLocked/ArmDrainScheduleLocked): without
+            // it the first profile after the resume reports a duration spanning the entire paused window --
+            // up to the 300s backoff cap -- instead of one real drain interval. Kept here rather than relying
+            // on a caller's trailing ArmDrainScheduleLocked, so the guarantee holds no matter who calls this.
+            Interlocked.Exchange(ref _lastDrainTimestamp, Stopwatch.GetTimestamp());
+            Log.Info("[ContinuousProfiling] Allocation sampling resumed after backoff; up to {0} samples/minute.", _allocationMaxSamplesPerMinute);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[ContinuousProfiling] Failed to resume allocation sampling after backoff.");
+            StopAllocationLocked();
+        }
+    }
+
+    /// <summary>
+    /// The mirror of <see cref="ResumeAllocationAfterBackoffLocked"/>: resumes the paused thread sampler on
+    /// behalf of an allocation start that has just superseded the probe, without letting a failure there unwind
+    /// the allocation start.
+    /// </summary>
+    private void ResumeThreadSamplingAfterBackoffLocked()
+    {
+        try
+        {
+            _native.Start(_activeIntervalMs);
+
+            // See the note in ResumeAllocationAfterBackoffLocked -- this path is the one that most needs it,
+            // since the thread-sample profiles are the time-valued ones whose period/duration is read directly.
+            Interlocked.Exchange(ref _lastDrainTimestamp, Stopwatch.GetTimestamp());
+            Log.Info("[ContinuousProfiling] Thread sampling resumed after backoff.");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[ContinuousProfiling] Failed to resume thread sampling after backoff.");
+            StopLocked();
         }
     }
 

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
@@ -20,8 +20,20 @@ namespace NewRelic.Agent.Core.ContinuousProfiling;
 /// starts the native sampler and schedules a periodic drain; when disabled it stops both; when
 /// the sampling interval changes while running it retunes the drain schedule.
 ///
-/// Each drain reads one batch from the <see cref="ISampleSource"/> into a reused buffer, parses it,
-/// builds an OTLP profile, and hands it to the <see cref="IProfilesTransport"/>. All drain work is
+/// TWO INDEPENDENT SAMPLERS, ONE DRAIN. The timer-driven thread sampler
+/// (<see cref="INativeContinuousProfiler"/> + <see cref="ISampleSource"/>, state: <see cref="_isActive"/> /
+/// <see cref="_activeIntervalMs"/>) and the AllocationTick-driven allocation sampler
+/// (<see cref="IAllocationSampleSource"/>, state: <see cref="_allocationActive"/> /
+/// <see cref="_allocationMaxSamplesPerMinute"/>) start and stop on their own config flags, in either
+/// combination. They SHARE one recurring drain tick, whose arming is therefore refcounted on
+/// "either sampler is running" (<see cref="ArmDrainScheduleLocked"/> /
+/// <see cref="DisarmDrainScheduleIfIdleLocked"/>) rather than owned by the thread-sampling path -- as is the
+/// managed-&gt;native trace-context seam, which both samplers correlate through. They also share the
+/// send-failure backoff, since one drain produces one request carrying both sample types.
+///
+/// Each drain reads one batch from each active source into a reused buffer, parses them,
+/// builds a single OTLP request carrying both sample types, and hands it to the
+/// <see cref="IProfilesTransport"/>. All drain work is
 /// wrapped so a failure is logged and metered but never propagates into the customer's application.
 ///
 /// Drains are gated on the agent having connected (<see cref="OnAgentConnected"/>): the profiles
@@ -52,6 +64,11 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     private const string SupportabilitySamplesMetric = "Supportability/DotNET/ContinuousProfiling/Samples";
     private const string SupportabilityErrorMetric = "Supportability/DotNET/ContinuousProfiling/Error";
     private const string SupportabilityDrainBufferBoundaryMetric = "Supportability/DotNET/ContinuousProfiling/DrainBufferBoundary";
+    // Allocation samples are counted separately from thread samples: the two come from different native
+    // sources at wildly different cadences (timer-driven sweep vs. subsampled AllocationTick), so a combined
+    // count would tell you nothing about either. This is also the only observation path for allocation
+    // sampling actually producing data in the field.
+    private const string SupportabilityAllocationSamplesMetric = "Supportability/DotNET/ContinuousProfiling/AllocationSamples";
 
     // Send-failure backoff, generally modeled on ConnectionManager.ConnectionRetryBackoffSequence (same
     // values as the collector-response-handling reconnect schedule) -- but, unlike that sequence, this one
@@ -70,6 +87,13 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
 
     private readonly ISampleSource _sampleSource;
     private readonly INativeContinuousProfiler _native;
+
+    // The allocation sampler: an INDEPENDENT native sampler with its own config gate, its own EventPipe
+    // session and its own buffer queue, drained through the SAME drain tick as the thread sampler so both
+    // sample types ride one wire payload per drain (see OtlpProfileBuilder.Build's allocationSamples
+    // parameter). Its Shutdown() is terminal -- see StopAllocationLocked/Dispose.
+    private readonly IAllocationSampleSource _allocationSampleSource;
+
     private readonly IProfilesTransport _transport;
     private readonly IScheduler _scheduler;
     private readonly IAgentHealthReporter _agentHealthReporter;
@@ -144,7 +168,29 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     // volatile: written under _lifecycleLock (StartLocked/StopLocked), read lock-free by DrainOnce on the
     // scheduler thread. An int write is already atomic on every platform, so this is purely for cross-thread
     // visibility -- without it DrainOnce could read a stale 0 and emit a profile with period=0.
+    //
+    // Strictly the THREAD sampler's interval: it is the profile period for the cpu/off_cpu profiles, and 0
+    // means "no thread sampling", which is what suppresses those profiles. It is deliberately NOT the drain
+    // cadence (that is _drainIntervalMs), because the drain can be running for the allocation sampler alone.
     private volatile int _activeIntervalMs;
+
+    // Whether the allocation sampler is currently started. Fully separate from _isActive: the two samplers
+    // have independent lifecycles (independent config flags, and allocation sampling is AllocationTick-driven
+    // so it needs no periodic thread walk), and either one alone is enough to keep the shared drain running.
+    //
+    // volatile for the same reason as _isActive/_activeIntervalMs: every write is under _lifecycleLock, but
+    // DrainOnce reads it lock-free on the scheduler thread to decide whether to touch the allocation buffer.
+    private volatile bool _allocationActive;
+
+    // The budget the allocation sampler was last started with, so a backoff probe can resume it at the same
+    // pacing and ApplyConfigChange can detect a live budget change. Read/written only under _lifecycleLock.
+    private int _allocationMaxSamplesPerMinute;
+
+    // The interval the recurring drain timer is currently armed at; 0 == not armed. The drain timer is SHARED
+    // by both samplers, so its arm/disarm is refcounted on (_isActive || _allocationActive) rather than owned
+    // by the thread-sampling path -- see ArmDrainScheduleLocked/DisarmDrainScheduleIfIdleLocked. Read/written
+    // only under _lifecycleLock.
+    private int _drainIntervalMs;
 
     // Profile-type tokens ("cpu") currently owned by an agent command rather than local/server config.
     // ApplyConfigChange must not start/stop/retune a type present here -- only a matching StopFromCommand
@@ -155,6 +201,11 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     private readonly HashSet<string> _commandControlledTypes = new HashSet<string>();
 
     private static readonly IReadOnlyDictionary<string, string> EmptyCommandExceptions = new Dictionary<string, string>();
+
+    // Allocation-free stand-ins for "this sweep read nothing of this type", so a drain that skips one source
+    // still has a non-null, zero-count list to test and to hand to OtlpProfileBuilder.
+    private static readonly IReadOnlyList<ManagedThreadSample> EmptyThreadSamples = new ManagedThreadSample[0];
+    private static readonly IReadOnlyList<AllocationSample> EmptyAllocationSamples = new AllocationSample[0];
 
     // Command-provided interval bounds mirror DefaultConfiguration's ContinuousProfilingSamplingIntervalMs
     // clamp (DefaultConfiguration.cs: MinContinuousProfilingSamplingIntervalMs/MaxContinuousProfilingSamplingIntervalMs,
@@ -169,6 +220,14 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     // Interlocked gives both atomicity and a full fence; volatile alone would not fix the 64-bit tearing.
     private long _lastDrainTimestamp;
 
+    /// <summary>
+    /// Whether the THREAD sampler is running. Deliberately not widened to include allocation sampling: this
+    /// is what <c>ThreadProfilingService</c>'s forward guard reads to avoid running concurrently with a
+    /// profiler that suspends threads, and allocation sampling suspends nothing (its tick handler walks only
+    /// the current thread, and try_locks the shared native SuspendMutex so it yields to a thread-profiling
+    /// walk rather than colliding with it). Reporting allocation-only as "active" here would block thread
+    /// profiling for no reason.
+    /// </summary>
     public bool IsActive => _isActive;
 
     /// <summary>
@@ -180,10 +239,11 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     /// </summary>
     public IThreadProfilingStatus ThreadProfilingStatus { get; set; }
 
-    public ContinuousProfilingService(ISampleSource sampleSource, INativeContinuousProfiler native, IProfilesTransport transport, IScheduler scheduler, IAgentHealthReporter agentHealthReporter)
+    public ContinuousProfilingService(ISampleSource sampleSource, INativeContinuousProfiler native, IAllocationSampleSource allocationSampleSource, IProfilesTransport transport, IScheduler scheduler, IAgentHealthReporter agentHealthReporter)
     {
         _sampleSource = sampleSource;
         _native = native;
+        _allocationSampleSource = allocationSampleSource;
         _transport = transport;
         _scheduler = scheduler;
         _agentHealthReporter = agentHealthReporter;
@@ -224,17 +284,26 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     }
 
     /// <summary>
-    /// Starts the drain schedule if continuous profiling is enabled in the current configuration.
-    /// Safe to call more than once; a no-op while already active.
+    /// Starts whichever samplers the current configuration enables, and the drain schedule they share.
+    /// Safe to call more than once; a no-op for anything already active.
     /// </summary>
     public void StartIfEnabled()
     {
         lock (_lifecycleLock)
         {
-            if (!_configuration.ContinuousProfilingEnabled)
+            if (_disposed)
                 return;
 
-            StartLocked(_configuration.ContinuousProfilingSamplingIntervalMs);
+            // Each sampler consults its OWN enabled flag, so a disabled thread sampler must not short-circuit
+            // the allocation sampler (or vice versa). The thread sampler goes first so that, when both are
+            // enabled, it is the one that arms the shared drain timer -- at ITS interval, which is also the
+            // profile period -- instead of the allocation path arming it and the thread start having to retune
+            // it a moment later.
+            if (_configuration.ContinuousProfilingEnabled)
+                StartLocked(_configuration.ContinuousProfilingSamplingIntervalMs);
+
+            if (_configuration.ContinuousProfilingAllocationEnabled)
+                StartAllocationLocked(_configuration.ContinuousProfilingAllocationMaxSamplesPerMinute);
         }
     }
 
@@ -254,32 +323,70 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             // an incidental config-update event (an unrelated SSC push, a reconnect) must not silently
             // override an operator's explicit start/stop_continuous_profiler command. See
             // _commandControlledTypes and StartFromCommand/StopFromCommand.
-            if (_commandControlledTypes.Contains(ContinuousProfilingCommandTypes.Cpu))
-                return;
+            //
+            // The guard covers the THREAD sampler only. Allocation sampling is not command-controllable yet,
+            // so its config-driven reconciliation must still run when the cpu bundle is command-owned --
+            // hence a guarded call rather than an early return out of the whole method. The thread sampler
+            // is reconciled first for the same reason as in StartIfEnabled (it owns the drain cadence).
+            if (!_commandControlledTypes.Contains(ContinuousProfilingCommandTypes.Cpu))
+                ApplyThreadSamplingConfigChangeLocked();
 
-            var enabled = _configuration.ContinuousProfilingEnabled;
+            ApplyAllocationConfigChangeLocked();
+        }
+    }
 
-            if (!enabled)
-            {
-                if (_isActive)
-                    StopLocked();
-                return;
-            }
-
-            var intervalMs = _configuration.ContinuousProfilingSamplingIntervalMs;
-
-            if (!_isActive)
-            {
-                StartLocked(intervalMs);
-                return;
-            }
-
-            if (intervalMs != _activeIntervalMs)
-            {
-                // Retune: stop the current recurrence and reschedule at the new interval.
+    private void ApplyThreadSamplingConfigChangeLocked()
+    {
+        if (!_configuration.ContinuousProfilingEnabled)
+        {
+            if (_isActive)
                 StopLocked();
-                StartLocked(intervalMs);
-            }
+            return;
+        }
+
+        var intervalMs = _configuration.ContinuousProfilingSamplingIntervalMs;
+
+        if (!_isActive)
+        {
+            StartLocked(intervalMs);
+            return;
+        }
+
+        if (intervalMs != _activeIntervalMs)
+        {
+            // Retune: stop the current recurrence and reschedule at the new interval.
+            StopLocked();
+            StartLocked(intervalMs);
+        }
+    }
+
+    /// <summary>
+    /// Reconciles the allocation sampler with the current configuration: start, stop, or re-pace it.
+    /// </summary>
+    private void ApplyAllocationConfigChangeLocked()
+    {
+        if (!_configuration.ContinuousProfilingAllocationEnabled)
+        {
+            if (_allocationActive)
+                StopAllocationLocked();
+            return;
+        }
+
+        var maxSamplesPerMinute = _configuration.ContinuousProfilingAllocationMaxSamplesPerMinute;
+
+        if (!_allocationActive)
+        {
+            StartAllocationLocked(maxSamplesPerMinute);
+            return;
+        }
+
+        if (maxSamplesPerMinute != _allocationMaxSamplesPerMinute)
+        {
+            // Re-pace in place: the native sampler's Start is idempotent and replaces its sub-sampler at the
+            // new budget WITHOUT reopening its session, so unlike the thread sampler's retune this needs no
+            // stop/start and never touches the shared drain timer (the budget is a per-minute sample cap, not
+            // a drain cadence). Without this, a live budget change would silently do nothing.
+            StartOrRepaceAllocationLocked(maxSamplesPerMinute);
         }
     }
 
@@ -432,17 +539,12 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 // fine: lifecycle transitions are rare (config-driven), so the native call here does not touch
                 // the lock-free hot path (DrainOnce).
                 _native.Start(intervalMs);
-                // trackAsAgentWork: false -- this action IS the CP drain itself (reads the native sample
-                // pipeline this very flag exists to annotate). Marking this thread poisons its own read;
-                // see follow-up #16 / Scheduler.CreateExecuteEveryTimer.
-                _scheduler.ExecuteEvery(_drainAction, TimeSpan.FromMilliseconds(intervalMs), trackAsAgentWork: false);
                 _activeIntervalMs = intervalMs;
-                Interlocked.Exchange(ref _lastDrainTimestamp, Stopwatch.GetTimestamp());
 
-                // Arm trace-context correlation only now that native sampling is running, and publish the seam so
-                // the wrapper hot path starts pushing the current trace/span on each app thread.
-                _continuousProfilingContext.Enable(_native);
-                ContinuousProfilingContext.Instance = _continuousProfilingContext;
+                // The thread sampler's interval is the authoritative drain cadence (it doubles as the profile
+                // period), so this retunes a timer the allocation path may already have armed at the config
+                // interval.
+                ArmDrainScheduleLocked(intervalMs);
 
                 Log.Info("[ContinuousProfiling] Session started; draining every {0} ms.", intervalMs);
             }
@@ -462,12 +564,15 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     {
         try
         {
-            // Disarm correlation first so the wrapper hot path stops pushing before native sampling stops.
-            // Restore the inert default instance so IsEnabled is false again everywhere.
-            _continuousProfilingContext.Disable();
-            ContinuousProfilingContext.Instance = new ContinuousProfilingContext();
+            // Cleared BEFORE the disarm below, not just in the finally: the shared drain schedule is released
+            // only when NEITHER sampler needs it, so an _isActive still reading true at that point would make
+            // the release a no-op and leave the timer armed with nothing running. (This also has to be right
+            // on the StartLocked-unwind path, where StopLocked is called with _isActive still true.) The
+            // finally is kept as a redundant guarantee that a throw anywhere below cannot leave them stale.
+            _isActive = false;
+            _activeIntervalMs = 0;
 
-            _scheduler.StopExecuting(_drainAction);
+            DisarmDrainScheduleIfIdleLocked();
             _native.Stop();
             Log.Info("[ContinuousProfiling] Session stopped.");
         }
@@ -479,6 +584,153 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
         {
             _isActive = false;
             _activeIntervalMs = 0;
+        }
+    }
+
+    /// <summary>
+    /// Starts the allocation sampler, unless it is already running. A no-op while already active -- use
+    /// <see cref="StartOrRepaceAllocationLocked"/> to change the budget of a running sampler.
+    /// </summary>
+    private void StartAllocationLocked(int maxSamplesPerMinute)
+    {
+        if (_allocationActive)
+            return;
+
+        // Deliberately NO equivalent of StartLocked's thread-profiling deferral. That guard exists because the
+        // thread sampler suspends the runtime to walk every thread, which must not overlap a thread-profiling
+        // session. Allocation sampling walks only the allocating thread and try_locks the same native
+        // SuspendMutex, so a tick that collides with either walker is simply dropped -- the enforcement is
+        // already in the native tick path, and deferring here would add a state machine that buys nothing.
+        StartOrRepaceAllocationLocked(maxSamplesPerMinute);
+    }
+
+    /// <summary>
+    /// Starts the allocation sampler, or re-paces it at a new budget if it is already running (the native
+    /// sampler's Start is idempotent and re-pacing does not reopen its session).
+    /// </summary>
+    private void StartOrRepaceAllocationLocked(int maxSamplesPerMinute)
+    {
+        var wasActive = _allocationActive;
+
+        try
+        {
+            // Armed before the call that can throw, and unwound in the catch -- same shape as StartLocked, so
+            // a half-started allocation sampler cannot leave the flag lying true with nothing sampling (which
+            // would also pin the shared drain timer open forever).
+            _allocationActive = true;
+            _allocationMaxSamplesPerMinute = maxSamplesPerMinute;
+
+            // Stop(), never Shutdown(), is the disable -- so Start() here is always legal to call again. See
+            // IAllocationSampleSource.Shutdown for why getting that backwards is unrecoverable.
+            _allocationSampleSource.Start(maxSamplesPerMinute);
+
+            // Only arm the shared drain timer if nothing has armed it yet: when the thread sampler is running,
+            // ITS interval is the authoritative cadence and must not be overwritten by the config interval
+            // (which can differ -- an agent command can start the thread sampler at a command-supplied one).
+            if (_drainIntervalMs == 0)
+                ArmDrainScheduleLocked(_configuration.ContinuousProfilingSamplingIntervalMs);
+
+            Log.Info(wasActive
+                ? "[ContinuousProfiling] Allocation sampling re-paced to at most {0} samples/minute."
+                : "[ContinuousProfiling] Allocation sampling started; up to {0} samples/minute.", maxSamplesPerMinute);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[ContinuousProfiling] Failed to start allocation sampling.");
+            StopAllocationLocked();
+        }
+    }
+
+    private void StopAllocationLocked()
+    {
+        try
+        {
+            // Cleared first, for the same reason as in StopLocked: the drain-schedule release is refcounted on
+            // this flag.
+            _allocationActive = false;
+            _allocationMaxSamplesPerMinute = 0;
+
+            DisarmDrainScheduleIfIdleLocked();
+
+            // Stop(), NOT Shutdown(): this runs on every config-driven disable, and the native sampler's
+            // Shutdown is a terminal latch that would refuse every later Start for the life of the process.
+            _allocationSampleSource.Stop();
+            Log.Info("[ContinuousProfiling] Allocation sampling stopped.");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[ContinuousProfiling] Failed to stop allocation sampling.");
+        }
+        finally
+        {
+            _allocationActive = false;
+            _allocationMaxSamplesPerMinute = 0;
+        }
+    }
+
+    /// <summary>
+    /// Arms (or retunes) the drain timer both samplers share, and arms the managed-&gt;native trace-context
+    /// push. Called after a sampler has actually started, so correlation is only ever armed while something
+    /// is sampling.
+    /// </summary>
+    private void ArmDrainScheduleLocked(int intervalMs)
+    {
+        if (_drainIntervalMs != intervalMs)
+        {
+            // IScheduler has no "reschedule", so a cadence change is a stop followed by a fresh registration.
+            // StopExecuting does not wait for an in-flight drain, which is exactly the overlap _drainInFlight
+            // guards (see that field).
+            if (_drainIntervalMs != 0)
+                _scheduler.StopExecuting(_drainAction);
+
+            // Marked un-armed for the duration of the swap, so if ExecuteEvery throws, this reads "no timer"
+            // rather than still claiming the cadence it just stopped -- otherwise the next Arm call would see a
+            // matching interval, skip re-registering, and leave the drain silently dead.
+            _drainIntervalMs = 0;
+            // trackAsAgentWork: false -- this action IS the CP drain itself (reads the native sample
+            // pipeline this very flag exists to annotate). Marking this thread poisons its own read;
+            // see follow-up #16 / Scheduler.CreateExecuteEveryTimer.
+            _scheduler.ExecuteEvery(_drainAction, TimeSpan.FromMilliseconds(intervalMs), trackAsAgentWork: false);
+            _drainIntervalMs = intervalMs;
+        }
+
+        Interlocked.Exchange(ref _lastDrainTimestamp, Stopwatch.GetTimestamp());
+
+        // Publish the seam so the wrapper hot path starts pushing the current trace/span on each app thread.
+        // Guarded on IsEnabled so the second sampler to start doesn't re-Enable an already-armed context: that
+        // would bump the push-change-detection epoch for no reason (nothing cleared the native map), costing
+        // one redundant push per app thread.
+        //
+        // The push target is the THREAD sampler's native seam even when only allocation sampling is running.
+        // That is correct, not a shortcut: the native ContinuousProfiler owns the per-thread trace-context map
+        // and AllocationSampler reads that same instance, and the native SetTraceContext is unconditional --
+        // it does not require the thread sampler's session to be started. Without arming this, allocation
+        // samples would silently lose all trace/span correlation whenever the thread sampler is stopped.
+        if (!_continuousProfilingContext.IsEnabled)
+        {
+            _continuousProfilingContext.Enable(_native);
+            ContinuousProfilingContext.Instance = _continuousProfilingContext;
+        }
+    }
+
+    /// <summary>
+    /// Releases the shared drain timer and the trace-context seam, but only once NEITHER sampler is running.
+    /// Callers clear their own active flag first (see <see cref="StopLocked"/>/<see cref="StopAllocationLocked"/>).
+    /// </summary>
+    private void DisarmDrainScheduleIfIdleLocked()
+    {
+        if (_isActive || _allocationActive)
+            return; // the other sampler still needs the shared drain
+
+        // Disarm correlation first so the wrapper hot path stops pushing before native sampling stops.
+        // Restore the inert default instance so IsEnabled is false again everywhere.
+        _continuousProfilingContext.Disable();
+        ContinuousProfilingContext.Instance = new ContinuousProfilingContext();
+
+        if (_drainIntervalMs != 0)
+        {
+            _scheduler.StopExecuting(_drainAction);
+            _drainIntervalMs = 0;
         }
     }
 
@@ -510,42 +762,39 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 if (!_isConnected || _sendBackoffActive)
                     return;
 
-                var bytesRead = _sampleSource.ReadBatch(_drainBuffer);
-                if (bytesRead <= 0)
-                    return;
-
-                // Defensive clamp: a misbehaving native source could report more bytes than the buffer
-                // holds. Never trust it far enough to hand an out-of-range length to BufferParser.Parse,
-                // which would walk off the end of _drainBuffer.
-                if (bytesRead > _drainBuffer.Length)
+                // Both sample types are read into the SAME buffer, sequentially. Deliberate: the buffer is
+                // sized for native's 4 MB thread-batch cap, and a second dedicated buffer would double that
+                // permanent per-process footprint for allocation batches native caps at 64 KB
+                // (AllocationSampler::MaxAllocationBufferBytes). It is safe because the reads are strictly
+                // sequential and each parse fully materializes its results before the next read overwrites the
+                // bytes -- BufferParser copies every string out (Encoding.Unicode.GetString), so no parsed
+                // object aliases the buffer -- and because _drainInFlight already makes this the only drain
+                // touching it.
+                var samples = EmptyThreadSamples;
+                if (TryReadIntoDrainBuffer(_sampleSource, out var bytesRead))
                 {
-                    Log.Debug("[ContinuousProfiling] ReadBatch reported {0} bytes, exceeding the {1}-byte buffer; discarding this drain.", bytesRead, _drainBuffer.Length);
-                    SafeReportError();
-                    return;
+                    samples = BufferParser.Parse(_drainBuffer, bytesRead, out var batchStats);
+
+                    // Surface the native BatchStats for CP overhead/fidelity analysis (and OTel FinalStats parity):
+                    // microsSuspended = the stop-the-world window this sweep; skipped = threads/frames the walk missed.
+                    // onCpu/total is the live signal that the native on-CPU classification is working, since NR CP
+                    // is no-send-guarded and has no other observation path for it.
+                    if (batchStats != null && Log.IsFinestEnabled)
+                        Log.Finest("[ContinuousProfiling] batch stats: microsSuspended={0} threads={1} frames={2} skipped={3} onCpu={4}/{5}",
+                            batchStats.MicrosSuspended, batchStats.Threads, batchStats.Frames, batchStats.Skipped, CountOnCpu(samples), samples.Count);
                 }
 
-                // The managed buffer matches native's own cap (see DrainBufferSize), so this can't fire
-                // today -- native already truncates to at most that many bytes before ReadThreadSamples
-                // ever copies. It's a tripwire against the two constants drifting apart again: if native's
-                // cap is ever raised past ours without a matching change here, this is what would catch
-                // the resulting silent loss of BatchStats/tail samples instead of shipping corrupted data.
-                if (bytesRead >= _drainBuffer.Length)
-                {
-                    Log.Debug("[ContinuousProfiling] ReadBatch filled the entire {0}-byte drain buffer; the batch may have been truncated.", _drainBuffer.Length);
-                    _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilityDrainBufferBoundaryMetric);
-                }
+                // Gated on _allocationActive, unlike the thread read above: the drain timer can be armed by
+                // the thread sampler alone, and in that (default) case an ungated read would P/Invoke into a
+                // never-started allocation sampler on every single tick for the life of the process.
+                var allocationSamples = EmptyAllocationSamples;
+                if (_allocationActive && TryReadIntoDrainBuffer(_allocationSampleSource, out var allocationBytesRead))
+                    BufferParser.Parse(_drainBuffer, allocationBytesRead, out _, out allocationSamples);
 
-                var samples = BufferParser.Parse(_drainBuffer, bytesRead, out var batchStats);
-
-                // Surface the native BatchStats for CP overhead/fidelity analysis (and OTel FinalStats parity):
-                // microsSuspended = the stop-the-world window this sweep; skipped = threads/frames the walk missed.
-                // onCpu/total is the live signal that the native on-CPU classification is working, since NR CP
-                // is no-send-guarded and has no other observation path for it.
-                if (batchStats != null && Log.IsFinestEnabled)
-                    Log.Finest("[ContinuousProfiling] batch stats: microsSuspended={0} threads={1} frames={2} skipped={3} onCpu={4}/{5}",
-                        batchStats.MicrosSuspended, batchStats.Threads, batchStats.Frames, batchStats.Skipped, CountOnCpu(samples), samples.Count);
-
-                if (samples.Count == 0)
+                // Either sample type alone is worth a payload: an allocation-only sweep is normal whenever the
+                // thread sampler is stopped, and a thread-only sweep is the common case. Only a sweep that
+                // produced neither is dropped.
+                if (samples.Count == 0 && allocationSamples.Count == 0)
                     return;
 
                 var now = Stopwatch.GetTimestamp();
@@ -556,10 +805,14 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 var startUnixNano = ToUnixNano(DateTime.UtcNow) - durationNano;
                 Interlocked.Exchange(ref _lastDrainTimestamp, now);
 
-                // The sampling interval (ms) is the profile's period; convert to nanoseconds for period_type=cpu/ns.
+                // The THREAD sampling interval (ms) is the profile's period; convert to nanoseconds for
+                // period_type=cpu/ns. Zero when the thread sampler is stopped, which is what suppresses the
+                // cpu/off_cpu profiles on an allocation-only sweep; the allocation profiles carry no period
+                // (they are event-driven, not time-valued) and so are emitted regardless.
                 var periodNanos = (long)_activeIntervalMs * 1_000_000L;
                 // Exclude the agent's own threads/frames unless the undocumented appSettings opt-in is set.
-                var request = OtlpProfileBuilder.Build(samples, startUnixNano, durationNano, ServiceName, periodNanos, _configuration.ContinuousProfilingIncludeAgentCode);
+                // Both sample types go into ONE request, so a drain is still one wire payload.
+                var request = OtlpProfileBuilder.Build(samples, startUnixNano, durationNano, ServiceName, periodNanos, _configuration.ContinuousProfilingIncludeAgentCode, allocationSamples);
 
                 bool sent;
                 try
@@ -578,7 +831,14 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 if (sent)
                 {
                     _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilityDrainMetric);
-                    _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilitySamplesMetric, samples.Count);
+
+                    // Each count is reported only when that sample type actually contributed, so an
+                    // allocation-only sweep doesn't emit a meaningless "0 thread samples" data point (and vice
+                    // versa).
+                    if (samples.Count > 0)
+                        _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilitySamplesMetric, samples.Count);
+                    if (allocationSamples.Count > 0)
+                        _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilityAllocationSamplesMetric, allocationSamples.Count);
                 }
                 else
                 {
@@ -600,6 +860,46 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             // why a plain store here was never observed to fail.
             Interlocked.Exchange(ref _drainInFlight, 0);
         }
+    }
+
+    /// <summary>
+    /// Reads one batch from <paramref name="source"/> into the shared <see cref="_drainBuffer"/> and validates
+    /// its length. Returns false -- with <paramref name="bytesRead"/> zeroed -- when there was nothing to read
+    /// or the batch must be discarded, so a caller can never parse an unvalidated length.
+    /// </summary>
+    private bool TryReadIntoDrainBuffer(ISampleSource source, out int bytesRead)
+    {
+        bytesRead = source.ReadBatch(_drainBuffer);
+
+        if (bytesRead <= 0)
+        {
+            bytesRead = 0;
+            return false;
+        }
+
+        // Defensive clamp: a misbehaving native source could report more bytes than the buffer
+        // holds. Never trust it far enough to hand an out-of-range length to BufferParser.Parse,
+        // which would walk off the end of _drainBuffer.
+        if (bytesRead > _drainBuffer.Length)
+        {
+            Log.Debug("[ContinuousProfiling] ReadBatch reported {0} bytes, exceeding the {1}-byte buffer; discarding this drain.", bytesRead, _drainBuffer.Length);
+            SafeReportError();
+            bytesRead = 0;
+            return false;
+        }
+
+        // The managed buffer matches native's own cap (see DrainBufferSize), so this can't fire
+        // today -- native already truncates to at most that many bytes before ReadThreadSamples
+        // ever copies. It's a tripwire against the two constants drifting apart again: if native's
+        // cap is ever raised past ours without a matching change here, this is what would catch
+        // the resulting silent loss of BatchStats/tail samples instead of shipping corrupted data.
+        if (bytesRead >= _drainBuffer.Length)
+        {
+            Log.Debug("[ContinuousProfiling] ReadBatch filled the entire {0}-byte drain buffer; the batch may have been truncated.", _drainBuffer.Length);
+            _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilityDrainBufferBoundaryMetric);
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -655,6 +955,12 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
         _sendBackoffActive = true;
         _native.Stop();
 
+        // Pause allocation sampling too: both sample types ride the one request that just failed, so there is
+        // nothing to gain from continuing to pay for allocation stack walks on customer threads while the drain
+        // is gated off. Stop(), never Shutdown() -- the probe below has to be able to resume it.
+        if (_allocationActive)
+            _allocationSampleSource.Stop();
+
         // Open a new backoff round and tag the probe with its generation. Any probe from a prior round
         // (which IScheduler cannot cancel) is now stale and will no-op when it fires -- otherwise it could
         // resume sampling and clear _sendBackoffActive in the middle of this round, collapsing it early.
@@ -677,10 +983,19 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     /// </summary>
     private bool TryResumeSamplingLocked()
     {
-        if (!_isActive)
+        // Resume whatever is still wanted -- either sampler alone is enough to make resuming worthwhile, and
+        // only "neither" means the session was disabled while backing off and must stay stopped.
+        if (!_isActive && !_allocationActive)
             return false;
 
-        _native.Start(_activeIntervalMs);
+        if (_isActive)
+            _native.Start(_activeIntervalMs);
+
+        // Re-pacing at the same budget: the native sampler's Start re-arms the handler and resets the
+        // sub-sampler without reopening its session, which is exactly right after a paused window.
+        if (_allocationActive)
+            _allocationSampleSource.Start(_allocationMaxSamplesPerMinute);
+
         Interlocked.Exchange(ref _lastDrainTimestamp, Stopwatch.GetTimestamp());
         return true;
     }
@@ -805,6 +1120,9 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             if (_isActive)
                 StopLocked();
 
+            if (_allocationActive)
+                StopAllocationLocked();
+
             // Explicit, deterministic join of the native worker thread on normal teardown. The native
             // destructor also guards against a never-joined thread (defense in depth against
             // std::terminate), but Dispose is the clean path -- never let a failure here escape Dispose.
@@ -815,6 +1133,22 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             catch (Exception ex)
             {
                 Log.Error(ex, "[ContinuousProfiling] Failed to shut down the native profiler.");
+            }
+
+            // The ONLY place the allocation sampler may be shut down. Its native Shutdown closes the EventPipe
+            // session, drains any in-flight tick handler, and then LATCHES: every subsequent Start is refused
+            // for the life of the process. That is why nothing else in this class calls it -- a disable, a
+            // retune or a backoff pause must use Stop, or allocation sampling would end permanently the first
+            // time it was toggled. Unconditional (like _native.Shutdown above) so the native session is closed
+            // deterministically even if this service never started sampling, and separately try/caught so a
+            // failure in one shutdown cannot skip the other.
+            try
+            {
+                _allocationSampleSource.Shutdown();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[ContinuousProfiling] Failed to shut down the native allocation sampler.");
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
@@ -31,7 +31,8 @@ namespace NewRelic.Agent.Core.ContinuousProfiling;
 /// managed-&gt;native trace-context seam, which both samplers correlate through. They also share the
 /// send-failure backoff, since one drain produces one request carrying both sample types.
 ///
-/// Each drain reads one batch from each active source into a reused buffer, parses them,
+/// Each drain reads one batch from the thread sampler and EVERY pending batch from the allocation
+/// sampler (see <see cref="ReadAllAllocationBatches"/>) into a reused buffer, parses them,
 /// builds a single OTLP request carrying both sample types, and hands it to the
 /// <see cref="IProfilesTransport"/>. All drain work is
 /// wrapped so a failure is logged and metered but never propagates into the customer's application.
@@ -69,6 +70,17 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     // count would tell you nothing about either. This is also the only observation path for allocation
     // sampling actually producing data in the field.
     private const string SupportabilityAllocationSamplesMetric = "Supportability/DotNET/ContinuousProfiling/AllocationSamples";
+
+    // Sub-sampled allocation samples that were TAKEN but never reached a profile. One number, because the
+    // operator's question is one question -- "is the budget I configured actually arriving?" -- and it is the
+    // signal the previous behavior lacked entirely (drop every backpressured tick, log at Finest). Two
+    // contributing causes, distinguished in the log rather than by separate metrics:
+    //   * native: no free queue slot AND a full pending batch (see AllocationBatchAccumulator), or a batch
+    //     abandoned/unpublishable, reported in band via BatchStats.Skipped;
+    //   * managed: this drain's own MaxAllocationSamplesPerDrain truncation, below.
+    // It does NOT count samples never taken in the first place -- a failed stack walk, a lost suspend-lock
+    // race -- which are pre-existing fidelity events with different causes and different remedies.
+    private const string SupportabilityAllocationSamplesDroppedMetric = "Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped";
 
     // Send-failure backoff, generally modeled on ConnectionManager.ConnectionRetryBackoffSequence (same
     // values as the collector-response-handling reconnect schedule) -- but, unlike that sequence, this one
@@ -213,6 +225,33 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     // never flows through IConfiguration, so it can't reuse that private clamp.
     private const int MinCommandIntervalMs = 1000;
     private const int MaxCommandIntervalMs = 60000;
+
+    // Upper bound on ReadBatch calls against the ALLOCATION source in one drain. The drain must read that
+    // source until it comes up empty, not once: the native side publishes a batch per subsampled tick when
+    // it can, so a single read per drain capped delivery at one batch per drain interval no matter how many
+    // samples the budget allowed (the defect this and AllocationBatchAccumulator fix together).
+    //
+    // Sized off the native queue rather than picked round: two slots means two reads clear a steady-state
+    // backlog and a third confirms empty, plus headroom for the batch the native side flushes DURING this
+    // loop (its read frees a slot, which lets a pending accumulated batch publish immediately -- see
+    // AllocationSampler::ReadAllocationSamples). A cap at all, rather than "loop until zero", so a
+    // misbehaving native source can never spin the drain thread indefinitely.
+    private const int MaxAllocationBatchReadsPerDrain = 8;
+
+    // Ceiling on allocation samples carried by ONE drain's profile. The native side is now bounded by its own
+    // batch cap, but that bound is expressed in BYTES and the per-sample cost differs by ~25x between a
+    // repeated stack (~98 bytes, interned) and wholly distinct ones (~2.5 KB), so it does not bound the
+    // sample COUNT this side has to build, serialize and POST. This does.
+    //
+    // Sized against the wire, not the budget: at the ~90 bytes/sample an OTLP profile costs for a repeated
+    // stack (measured: a 1-sample drain was 2101 bytes, an 84-sample drain 9384), 2000 samples is ~180 KB,
+    // comfortably inside ProfilesTransport.MaxPayloadBytes; a maximally diverse workload interns far more
+    // string data per sample, which is what that ceiling is there to catch. It is also ~60x the demand of the
+    // shipped defaults (200/minute at a 10 s drain = ~33 per drain), so a normal deployment never meets it.
+    // Excess samples are dropped, counted on SupportabilityAllocationSamplesDroppedMetric and logged --
+    // deliberately NOT held over for the next drain, which would just move the backlog managed-side and
+    // stretch every subsequent profile's time window.
+    private const int MaxAllocationSamplesPerDrain = 2000;
 
     // Accessed exclusively via Interlocked.Read/Exchange. It's a 64-bit value written from DrainOnce's
     // scheduler thread AND from EndBackoffProbeIfCurrent/ResumeAfterReconnect (both under _lifecycleLock,
@@ -879,8 +918,8 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     }
 
     /// <summary>
-    /// Drains at most one batch and ships it. Catches everything: a drain failure must never surface
-    /// in the instrumented application.
+    /// Drains both sample sources and ships ONE profile carrying whatever they produced. Catches everything:
+    /// a drain failure must never surface in the instrumented application.
     /// </summary>
     public void DrainOnce()
     {
@@ -906,9 +945,10 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 if (!_isConnected || _sendBackoffActive)
                     return;
 
-                // Both sample types are read into the SAME buffer, sequentially. Deliberate: the buffer is
+                // Both sample types are read into the SAME buffer, sequentially -- and the allocation source
+                // is read repeatedly, so a single drain buffer serves several reads in a row. Deliberate: the buffer is
                 // sized for native's 4 MB thread-batch cap, and a second dedicated buffer would double that
-                // permanent per-process footprint for allocation batches native caps at 64 KB
+                // permanent per-process footprint for allocation batches native caps at 256 KB
                 // (AllocationSampler::MaxAllocationBufferBytes). It is safe because the reads are strictly
                 // sequential and each parse fully materializes its results before the next read overwrites the
                 // bytes -- BufferParser copies every string out (Encoding.Unicode.GetString), so no parsed
@@ -932,8 +972,17 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                 // the thread sampler alone, and in that (default) case an ungated read would P/Invoke into a
                 // never-started allocation sampler on every single tick for the life of the process.
                 var allocationSamples = EmptyAllocationSamples;
-                if (_allocationActive && TryReadIntoDrainBuffer(_allocationSampleSource, out var allocationBytesRead))
-                    BufferParser.Parse(_drainBuffer, allocationBytesRead, out _, out allocationSamples);
+                var allocationSamplesDropped = 0;
+                if (_allocationActive)
+                    allocationSamples = ReadAllAllocationBatches(out allocationSamplesDropped);
+
+                // Reported before the empty-sweep early-return below and regardless of whether this drain's
+                // send succeeds -- unlike Drain/Samples, which describe THIS request. A drop count is a fact
+                // about the native sampler that has already been consumed from its counter, so skipping the
+                // report on a failed send (or an otherwise empty sweep) would lose it silently, which is
+                // exactly the blind spot this metric exists to close.
+                if (allocationSamplesDropped > 0)
+                    _agentHealthReporter.ReportSupportabilityCountMetric(SupportabilityAllocationSamplesDroppedMetric, allocationSamplesDropped);
 
                 // Either sample type alone is worth a payload: an allocation-only sweep is normal whenever the
                 // thread sampler is stopped, and a thread-only sweep is the common case. Only a sweep that
@@ -1004,6 +1053,92 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             // why a plain store here was never observed to fail.
             Interlocked.Exchange(ref _drainInFlight, 0);
         }
+    }
+
+    /// <summary>
+    /// Drains EVERY allocation batch the native sampler currently holds -- reading until a read comes up
+    /// empty (bounded by <see cref="MaxAllocationBatchReadsPerDrain"/>) -- and returns all of their samples
+    /// as one list, plus the native dropped-sample count they carry.
+    ///
+    /// Reading once per drain was half of a delivery ceiling of ~1 allocation sample per drain interval: the
+    /// native queue holds two batches and each read frees one slot, so a single read could never keep up with
+    /// a sampler producing a batch per subsampled tick. Every batch read here still rides ONE profile/export
+    /// for this drain -- this widens what a drain collects, not how often it sends.
+    ///
+    /// The shared <see cref="_drainBuffer"/> is safe to reuse across iterations for the same reason it is
+    /// safe to share between the two sample sources: <see cref="BufferParser"/> copies every string out, so
+    /// no parsed sample aliases the buffer once the parse returns.
+    /// </summary>
+    private IReadOnlyList<AllocationSample> ReadAllAllocationBatches(out int droppedSamples)
+    {
+        droppedSamples = 0;
+
+        // Only allocated when a second non-empty batch actually shows up: the common (non-backpressured)
+        // case is one batch per drain, whose parsed list can be handed on as-is.
+        IReadOnlyList<AllocationSample> firstBatch = null;
+        List<AllocationSample> combined = null;
+
+        var kept = 0;
+        for (var reads = 0; reads < MaxAllocationBatchReadsPerDrain; reads++)
+        {
+            if (!TryReadIntoDrainBuffer(_allocationSampleSource, out var bytesRead))
+                break; // nothing left (or a batch this method already reported as an error)
+
+            BufferParser.Parse(_drainBuffer, bytesRead, out var stats, out var batch);
+
+            // Native reports its dropped-sample delta IN BAND, as BatchStats.Skipped on each allocation
+            // batch (the same field the thread sampler uses for samples its walk missed) -- so no extra
+            // P/Invoke, and a drop count can never arrive without a batch to carry it.
+            if (stats != null)
+                droppedSamples += stats.Skipped;
+
+            if (batch.Count == 0)
+                continue;
+
+            // Per-drain ceiling. Counted as dropped (same metric, same question) and logged with its own
+            // cause so a reader can tell it apart from a native buffer-space drop; reading stops here, since
+            // anything further read would only be dropped too -- and leaving it in the native queue means the
+            // NEXT drain delivers it instead of it being lost.
+            if (kept + batch.Count > MaxAllocationSamplesPerDrain)
+            {
+                var dropped = kept + batch.Count - MaxAllocationSamplesPerDrain;
+                droppedSamples += dropped;
+                Log.Debug("[ContinuousProfiling] Allocation samples exceeded the {0}-per-drain cap; dropping {1} from this drain.",
+                    MaxAllocationSamplesPerDrain, dropped);
+
+                // `room` is always >= 1 here: the loop breaks as soon as `kept` REACHES the cap, so a batch
+                // that straddles it is partially taken rather than refused whole.
+                var room = MaxAllocationSamplesPerDrain - kept;
+
+                // Take the part that fits, then stop.
+                var partial = new List<AllocationSample>(room);
+                for (var i = 0; i < room; i++)
+                    partial.Add(batch[i]);
+                batch = partial;
+            }
+
+            kept += batch.Count;
+
+            if (firstBatch == null)
+            {
+                firstBatch = batch;
+            }
+            else
+            {
+                if (combined == null)
+                {
+                    combined = new List<AllocationSample>(firstBatch.Count + batch.Count);
+                    combined.AddRange(firstBatch);
+                }
+
+                combined.AddRange(batch);
+            }
+
+            if (kept >= MaxAllocationSamplesPerDrain)
+                break;
+        }
+
+        return combined ?? firstBatch ?? EmptyAllocationSamples;
     }
 
     /// <summary>

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingService.cs
@@ -192,12 +192,12 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
     // only under _lifecycleLock.
     private int _drainIntervalMs;
 
-    // Profile-type tokens ("cpu") currently owned by an agent command rather than local/server config.
-    // ApplyConfigChange must not start/stop/retune a type present here -- only a matching StopFromCommand
-    // call or process restart releases it (see StartFromCommand/StopFromCommand below). Modeled as a set,
-    // not a bool, because the command spec is per-type ("all"/"cpu"/"heap"): today only "cpu" can ever be
-    // a member (heap/allocations isn't implemented), but this generalizes once a second independently
-    // toggleable type exists, without another redesign of the guard.
+    // Profile-type tokens ("cpu", "heap") currently owned by an agent command rather than local/server config.
+    // ApplyConfigChange must not start/stop/retune/re-pace a type present here -- only a matching
+    // StopFromCommand call or process restart releases it (see StartFromCommand/StopFromCommand below).
+    // A set, not a bool, because the command spec is per-type ("all"/"cpu"/"heap") and the two samplers are
+    // independently toggleable: a command may own the cpu bundle, allocation sampling, or both, and each
+    // guard in ApplyConfigChange consults only its own token.
     private readonly HashSet<string> _commandControlledTypes = new HashSet<string>();
 
     private static readonly IReadOnlyDictionary<string, string> EmptyCommandExceptions = new Dictionary<string, string>();
@@ -319,19 +319,20 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
             if (_disposed)
                 return;
 
-            // An agent command owns the cpu bundle until a matching stop command or process restart --
-            // an incidental config-update event (an unrelated SSC push, a reconnect) must not silently
-            // override an operator's explicit start/stop_continuous_profiler command. See
+            // An agent command owns whichever types it started until a matching stop command or process
+            // restart -- an incidental config-update event (an unrelated SSC push, a reconnect) must not
+            // silently override an operator's explicit start/stop_continuous_profiler command. See
             // _commandControlledTypes and StartFromCommand/StopFromCommand.
             //
-            // The guard covers the THREAD sampler only. Allocation sampling is not command-controllable yet,
-            // so its config-driven reconciliation must still run when the cpu bundle is command-owned --
-            // hence a guarded call rather than an early return out of the whole method. The thread sampler
-            // is reconciled first for the same reason as in StartIfEnabled (it owns the drain cadence).
+            // Ownership is tracked PER TYPE, so each sampler gets its own guard rather than one early return
+            // out of the whole method: a command owning only the cpu bundle must still leave allocation
+            // sampling reconciled from config, and vice versa. The thread sampler is reconciled first for the
+            // same reason as in StartIfEnabled (it owns the drain cadence).
             if (!_commandControlledTypes.Contains(ContinuousProfilingCommandTypes.Cpu))
                 ApplyThreadSamplingConfigChangeLocked();
 
-            ApplyAllocationConfigChangeLocked();
+            if (!_commandControlledTypes.Contains(ContinuousProfilingCommandTypes.Heap))
+                ApplyAllocationConfigChangeLocked();
         }
     }
 
@@ -398,15 +399,15 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
 
             var exceptions = new Dictionary<string, string>();
             var startCpuBundle = false;
+            var startHeap = false;
 
             foreach (var token in requestedTypes)
             {
                 ContinuousProfilingCommandTypes.Classify(token, out var startsCpuBundle, out var requestsHeap);
                 startCpuBundle |= startsCpuBundle;
+                startHeap |= requestsHeap;
 
-                if (requestsHeap)
-                    exceptions[ContinuousProfilingCommandTypes.Heap] = "not supported";
-                else if (!startsCpuBundle)
+                if (!startsCpuBundle && !requestsHeap)
                     exceptions[token] = "not supported"; // unrecognized token
             }
 
@@ -421,6 +422,22 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                     StartLocked(clamped);
                 }
                 // else: already running -- idempotent no-op per spec; a repeat start does not retune.
+            }
+
+            // Second, for the same reason StartIfEnabled orders the two this way: when a single command starts
+            // both ("all"), the thread sampler is the one that arms the shared drain, at its own interval.
+            if (startHeap)
+            {
+                _commandControlledTypes.Add(ContinuousProfilingCommandTypes.Heap);
+
+                // The command carries no allocation budget of its own (sampleIntervalMs/cpuReportIntervalMs are
+                // both cpu-shaped, and the command spec defines no per-command heap budget), so a command-started
+                // allocation sampler is paced from configuration exactly like a config-started one. No clamp here:
+                // the budget is normalized at the native P/Invoke boundary.
+                if (!_allocationActive)
+                    StartAllocationLocked(_configuration.ContinuousProfilingAllocationMaxSamplesPerMinute);
+                // else: already running -- idempotent no-op, matching the cpu bundle above; a repeat start does
+                // not re-pace.
             }
 
             return BuildCommandResultLocked(exceptions);
@@ -441,15 +458,15 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
 
             var exceptions = new Dictionary<string, string>();
             var stopCpuBundle = false;
+            var stopHeap = false;
 
             foreach (var token in requestedTypes)
             {
                 ContinuousProfilingCommandTypes.Classify(token, out var startsCpuBundle, out var requestsHeap);
                 stopCpuBundle |= startsCpuBundle;
+                stopHeap |= requestsHeap;
 
-                if (requestsHeap)
-                    exceptions[ContinuousProfilingCommandTypes.Heap] = "not supported";
-                else if (!startsCpuBundle)
+                if (!startsCpuBundle && !requestsHeap)
                     exceptions[token] = "not supported"; // unrecognized token
             }
 
@@ -464,15 +481,34 @@ public class ContinuousProfilingService : ConfigurationBasedService, IContinuous
                     StopLocked();
             }
 
+            if (stopHeap)
+            {
+                // Same ownership release as the cpu bundle above: unconditional, so a stop for a type that was
+                // never command-started (or is already stopped) still hands it back to config control.
+                _commandControlledTypes.Remove(ContinuousProfilingCommandTypes.Heap);
+
+                if (_allocationActive)
+                    StopAllocationLocked();
+            }
+
             return BuildCommandResultLocked(exceptions);
         }
     }
 
     private ContinuousProfilingCommandResult BuildCommandResultLocked(IReadOnlyDictionary<string, string> exceptions)
     {
-        var activeTypes = _isActive
-            ? new[] { ContinuousProfilingCommandTypes.Cpu }
-            : Array.Empty<string>();
+        // Built rather than a fixed single-element array: the two samplers are independently active, so any of
+        // the four combinations can be the answer. The allocation only happens on a command path (rare,
+        // operator-driven), never on the drain hot path.
+        var activeTypes = new List<string>(2);
+        if (_isActive)
+            activeTypes.Add(ContinuousProfilingCommandTypes.Cpu);
+        if (_allocationActive)
+            activeTypes.Add(ContinuousProfilingCommandTypes.Heap);
+
+        // Deliberately still cpu-only: both reported intervals describe the THREAD sampler (the allocation
+        // sampler's pacing is a per-minute sample budget, not an interval, and the response shape defined by the
+        // command spec has no field for it).
         var intervalMs = _isActive ? _activeIntervalMs : _configuration.ContinuousProfilingSamplingIntervalMs;
 
         return new ContinuousProfilingCommandResult(activeTypes, intervalMs, intervalMs, exceptions);

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingServiceFactory.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ContinuousProfilingServiceFactory.cs
@@ -44,7 +44,14 @@ public static class ContinuousProfilingServiceFactory
             var profilesTransport = new ProfilesTransport(profilesDispatcher.Post, null, agentHealthReporter);
             var sampleSource = new NativeContinuousProfilerSampleSource(nativeMethods);
 
-            return new ContinuousProfilingService(sampleSource, sampleSource, profilesTransport, container.Resolve<IScheduler>(), agentHealthReporter);
+            // The allocation sampler is a SEPARATE native object with its own EventPipe session and buffer
+            // queue, so it gets its own adapter here rather than sharing the thread sampler's. Constructed
+            // unconditionally for the same reason everything else here is: it only stores the INativeMethods
+            // reference, and no P/Invoke is bound until ContinuousProfilingService actually starts it (which it
+            // does only when allocation sampling is configured on).
+            var allocationSampleSource = new NativeContinuousProfilerAllocationSampleSource(nativeMethods);
+
+            return new ContinuousProfilingService(sampleSource, sampleSource, allocationSampleSource, profilesTransport, container.Resolve<IScheduler>(), agentHealthReporter);
         }
         catch (Exception ex)
         {

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/IAllocationSampleSource.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/IAllocationSampleSource.cs
@@ -1,0 +1,36 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Core.ContinuousProfiling;
+
+/// <summary>
+/// The allocation sampler's lifecycle plus drain surface. Deliberately ONE interface rather than the
+/// <see cref="ISampleSource"/> / <see cref="INativeContinuousProfiler"/> split the thread-sampling path uses:
+/// that split exists so the session service can depend on start/stop without also owning the trace-context
+/// push, and the allocation sampler has no trace-context surface of its own (it reads the thread sampler's
+/// shared native map). Start/Stop/ReadBatch here are three views of a single small native object, so keeping
+/// them together costs the service one constructor dependency instead of two.
+/// </summary>
+public interface IAllocationSampleSource : ISampleSource
+{
+    /// <summary>
+    /// Starts (or re-arms) allocation sampling with the given per-minute sample budget. Idempotent, and
+    /// calling it again while already started simply re-paces the sub-sampler at the new budget without
+    /// opening a second native session -- which is how a live budget change is applied.
+    /// </summary>
+    void Start(int maxSamplesPerMinute);
+
+    /// <summary>
+    /// Stops producing samples while leaving the underlying native session open, so a later
+    /// <see cref="Start"/> can resume. This -- never <see cref="Shutdown"/> -- is what a disable must call.
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// TERMINAL teardown: closes the native session and drains in-flight sampling. The native sampler latches
+    /// on this call and REFUSES every subsequent <see cref="Start"/> for the life of the process, so this must
+    /// be called exactly once, only from real agent teardown. Any path that can run more than once (a config
+    /// toggle, an agent command, a retune) must use <see cref="Stop"/>/<see cref="Start"/> instead.
+    /// </summary>
+    void Shutdown();
+}

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/NativeContinuousProfilerAllocationSampleSource.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/NativeContinuousProfilerAllocationSampleSource.cs
@@ -1,0 +1,27 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Core.ContinuousProfiling;
+
+/// <summary>
+/// Thin adapter over <see cref="INativeMethods"/> for the allocation-sampling path -- mirrors
+/// <see cref="NativeContinuousProfilerSampleSource"/>'s shape for the thread-sampling path, but kept
+/// as its own class since allocation sampling is independently gated (own config, own start/stop).
+/// </summary>
+public class NativeContinuousProfilerAllocationSampleSource : IAllocationSampleSource
+{
+    private readonly INativeMethods _nativeMethods;
+
+    public NativeContinuousProfilerAllocationSampleSource(INativeMethods nativeMethods)
+    {
+        _nativeMethods = nativeMethods;
+    }
+
+    public void Start(int maxSamplesPerMinute) => _nativeMethods.AllocationSamplerStart(maxSamplesPerMinute);
+
+    public void Stop() => _nativeMethods.AllocationSamplerStop();
+
+    public void Shutdown() => _nativeMethods.AllocationSamplerShutdown();
+
+    public int ReadBatch(byte[] destination) => _nativeMethods.ContinuousProfilerReadAllocationSamples(destination.Length, destination);
+}

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/OtlpProfileBuilder.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/OtlpProfileBuilder.cs
@@ -226,7 +226,7 @@ public static class OtlpProfileBuilder
                 // rather than wrap: an unchecked cast of a garbage/misparsed size would emit a NEGATIVE byte
                 // count, which is meaningless to the ingest.
                 var allocatedSize = allocation.AllocatedSize > long.MaxValue ? long.MaxValue : (long)allocation.AllocatedSize;
-                resolvedAllocations.Add(new ResolvedAllocationSample(stackIndex, threadIdAttr, threadNameAttr, typeNameAttr, linkIndex, allocatedSize));
+                resolvedAllocations.Add(new ResolvedAllocationSample(stackIndex, threadIdAttr, threadNameAttr, typeNameAttr, linkIndex, allocatedSize, allocation.TimestampMillis));
             }
 
             if (resolvedAllocations.Count > 0)
@@ -326,7 +326,12 @@ public static class OtlpProfileBuilder
         public readonly int LinkIndex;
         public readonly long AllocatedSize;
 
-        public ResolvedAllocationSample(int stackIndex, int threadIdAttr, int threadNameAttr, int typeNameAttr, int linkIndex, long allocatedSize)
+        // When the allocation actually happened (native's AllocationTick timestamp, ms since the UNIX epoch),
+        // carried through so each emitted Sample can stamp its own event time instead of inheriting the drain's
+        // window. See BuildAllocationProfile.
+        public readonly long TimestampMillis;
+
+        public ResolvedAllocationSample(int stackIndex, int threadIdAttr, int threadNameAttr, int typeNameAttr, int linkIndex, long allocatedSize, long timestampMillis)
         {
             StackIndex = stackIndex;
             ThreadIdAttr = threadIdAttr;
@@ -334,6 +339,7 @@ public static class OtlpProfileBuilder
             TypeNameAttr = typeNameAttr;
             LinkIndex = linkIndex;
             AllocatedSize = allocatedSize;
+            TimestampMillis = timestampMillis;
         }
     }
 
@@ -344,6 +350,15 @@ public static class OtlpProfileBuilder
     // No period_type/period is set: allocation sampling is event-driven, so there is no sampling interval to
     // report. (BuildProfile's `periodNanos > 0` gate models the same "omit when not applicable" rule for the
     // timer-driven profiles; this is a separate function so the CPU path keeps its own shape.)
+    //
+    // Each Sample DOES carry its own timestamps_unix_nano -- the one place in this builder that does. It is
+    // load-bearing, not decoration: a drain can deliver a backlog spanning MANY intervals (batches accumulated
+    // under back-pressure survive the pre-connect window and send-backoff pauses of up to 300s), and the
+    // profile-level [time_unix_nano, +duration_nano) window belongs to the DRAIN, not to the allocations. Without
+    // a per-sample time, every sample in such a backlog is attributed to the moment it was drained: an
+    // allocation-rate chart shows a spike at drain time and a hole where the workload actually allocated. One
+    // timestamp per value, per the proto ("If both fields are populated, they MUST contain the same number of
+    // elements"). The cpu/off_cpu profiles have no equivalent per-sample time to report, so they emit none.
     private static Profile BuildAllocationProfile(ProfilesDictionary dictionary, Dictionary<string, int> stringTable,
         long startUnixNano, long durationNano, string sampleTypeName, string sampleTypeUnit,
         List<ResolvedAllocationSample> resolved, System.Func<ResolvedAllocationSample, long> valueForSample)
@@ -363,6 +378,7 @@ public static class OtlpProfileBuilder
         {
             var protoSample = new Sample { StackIndex = r.StackIndex, LinkIndex = r.LinkIndex };
             protoSample.Values.Add(valueForSample(r));
+            AddSampleTimestamp(protoSample, r.TimestampMillis);
             protoSample.AttributeIndices.Add(r.ThreadIdAttr);
             protoSample.AttributeIndices.Add(r.ThreadNameAttr);
             protoSample.AttributeIndices.Add(r.TypeNameAttr);
@@ -370,6 +386,22 @@ public static class OtlpProfileBuilder
         }
 
         return profile;
+    }
+
+    // Stamps one allocation Sample with the time the allocation actually happened (see BuildAllocationProfile
+    // for why that is not the drain's window). Called once per emitted Sample, so allocated_objects and
+    // allocated_space each carry their own copy -- Sample.timestamps_unix_nano is per-Sample, and the two
+    // profiles hold distinct Sample messages for the same event.
+    private static void AddSampleTimestamp(Sample protoSample, long timestampMillis)
+    {
+        // Only a real timestamp is emitted. A non-positive value cannot have come from the native encoder
+        // (it stamps every sample off the clock), so it means a malformed/unset value: 0 would place the
+        // sample at the epoch and a negative one would wrap through the unsigned cast into the year 584 --
+        // both worse for a consumer than falling back to the profile-level window. Leaving
+        // timestamps_unix_nano empty for such a sample is spec-legal: `values` is always populated, and the
+        // "same number of elements" rule only applies when BOTH fields are.
+        if (timestampMillis > 0)
+            protoSample.TimestampsUnixNano.Add((ulong)timestampMillis * 1_000_000UL);
     }
 
     // Emits one Profile (off_cpu:nanoseconds or cpu:nanoseconds) from the already-resolved samples, applying

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/OtlpProfileBuilder.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/OtlpProfileBuilder.cs
@@ -12,7 +12,7 @@ using ProtoValueType = OpenTelemetry.Proto.Profiles.V1Development.ValueType;
 namespace NewRelic.Agent.Core.ContinuousProfiling;
 
 /// <summary>
-/// Maps collected <see cref="ManagedThreadSample"/>s into an OTLP
+/// Maps collected <see cref="ManagedThreadSample"/>s and <see cref="AllocationSample"/>s into a single OTLP
 /// <see cref="ExportProfilesServiceRequest"/>. Strings, functions, locations, stacks,
 /// attributes, and links are interned into the shared <see cref="ProfilesDictionary"/>
 /// tables (index 0 of every table is the zero value per the OTLP spec).
@@ -24,6 +24,10 @@ public static class OtlpProfileBuilder
     private const string ThreadIdKey = "thread.id";
     private const string ThreadNameKey = "thread.name";
 
+    // Allocation samples carry the allocated object's type as an OTel-semconv-shaped attribute so the UI can
+    // group "what was allocated" independently of "where it was allocated" (the stack).
+    private const string TypeNameKey = "type.name";
+
     // OTLP-idiomatic on/off-CPU split: profiles.proto documents ONLY `cpu`/`off_cpu`/`allocated_objects`/
     // `allocated_space` as sample types (:291-295, :317) -- no Google-pprof-style "samples:count" convention.
     // `Profile.sample_type` is singular, so cpu + off_cpu are two separate Profile messages that SHARE this
@@ -32,6 +36,14 @@ public static class OtlpProfileBuilder
     private const string OffCpuSampleTypeName = "off_cpu";
     private const string CpuSampleTypeName = "cpu";
     private const string NanosecondsUnit = "nanoseconds"; // == PeriodTypeUnit
+
+    // Allocation sampling (AllocationTick-driven) contributes two more of profiles.proto's documented sample
+    // types. Unlike cpu/off_cpu these are NOT a partition: every allocation sample appears in BOTH profiles --
+    // they are two measurements of the same event set (how many objects, how many bytes).
+    private const string AllocatedObjectsSampleTypeName = "allocated_objects";
+    private const string CountUnit = "count";
+    private const string AllocatedSpaceSampleTypeName = "allocated_space";
+    private const string BytesUnit = "bytes";
 
     // period_type describes the cadence of periodic sampling. We take an all-thread stack snapshot every
     // configured interval, so period = interval in nanoseconds. Type "cpu" / unit "nanoseconds" mirrors the
@@ -83,8 +95,12 @@ public static class OtlpProfileBuilder
     // includeAgentCode: when false, samples taken on the agent's own threads (owning frame under
     // "NewRelic.Agent.Core.") are dropped so the profile carries only the customer application. Defaults to
     // true (no filtering) for callers/tests that don't care; the CP service passes the configured value,
-    // which defaults to false.
-    public static ExportProfilesServiceRequest Build(IReadOnlyList<ManagedThreadSample> samples, long startUnixNano, long durationNano, string serviceName, long periodNanos = 0, bool includeAgentCode = true)
+    // which defaults to false. It applies to the THREAD sampler only -- allocation samples are attributed to
+    // the allocating call site, not to a sampled thread, and are reported as-is.
+    //
+    // allocationSamples: optional AllocationTick-driven samples. When non-empty they add the
+    // allocated_objects/allocated_space profiles to this same request, interned into this same dictionary.
+    public static ExportProfilesServiceRequest Build(IReadOnlyList<ManagedThreadSample> samples, long startUnixNano, long durationNano, string serviceName, long periodNanos = 0, bool includeAgentCode = true, IReadOnlyList<AllocationSample> allocationSamples = null)
     {
         var dictionary = new ProfilesDictionary();
 
@@ -179,6 +195,50 @@ public static class OtlpProfileBuilder
                     CpuSampleTypeName, NanosecondsUnit, resolved, valueForSample: _ => periodNanos, includeSample: r => r.OnCpu));
         }
 
+        // allocated_objects:count + allocated_space:bytes. Emitted independently of periodNanos: allocation
+        // sampling is event-driven (fires on AllocationTick), so neither profile is time-valued and there is no
+        // sampling cadence to report -- period_type/period are deliberately left unset on both (see
+        // BuildAllocationProfile). Resolve dictionary indices ONCE through the SAME caches the thread-sample
+        // path used above, so a stack/string/attribute/link shared with a thread sample is interned once for
+        // the whole request. Both profiles are emitted or neither is: they always carry the same sample count,
+        // and the OTLP profiles ingest rejects a Profile with zero samples ("no_samples" drop).
+        if (allocationSamples != null && allocationSamples.Count > 0)
+        {
+            var resolvedAllocations = new List<ResolvedAllocationSample>(allocationSamples.Count);
+            foreach (var allocation in allocationSamples)
+            {
+                // Defensive: a sample with no frames cannot be interned into a stack. Skip it rather than throw
+                // and lose the entire drain's payload (thread samples included) to one malformed sample.
+                if (allocation?.Frames == null)
+                    continue;
+
+                var stackIndex = InternStack(dictionary, stringTable, functionTable, locationTable, stackTable, attributeTable, allocation.Frames);
+                var threadIdAttr = InternAttribute(dictionary, stringTable, attributeTable, ThreadIdKey, new AnyValue { IntValue = allocation.OsThreadId });
+                var threadNameAttr = InternAttribute(dictionary, stringTable, attributeTable, ThreadNameKey, new AnyValue { StringValue = allocation.ThreadName ?? string.Empty });
+                var typeNameAttr = InternAttribute(dictionary, stringTable, attributeTable, TypeNameKey, new AnyValue { StringValue = allocation.TypeName ?? string.Empty });
+                // Trace/span context is a required part of an allocation sample (it is captured at the
+                // allocating call site, inside the transaction). A sample taken outside any transaction still
+                // resolves to the reserved index-0 "no link" sentinel, same as on the thread path.
+                var linkIndex = InternLink(dictionary, linkTable, allocation.TraceIdHigh, allocation.TraceIdLow, allocation.SpanId);
+
+                // Sample.values is int64 while AllocatedSize is uint64 (the native side reinterprets the raw
+                // ETW/AllocationTick bytes). A real allocation never exceeds long.MaxValue bytes, but saturate
+                // rather than wrap: an unchecked cast of a garbage/misparsed size would emit a NEGATIVE byte
+                // count, which is meaningless to the ingest.
+                var allocatedSize = allocation.AllocatedSize > long.MaxValue ? long.MaxValue : (long)allocation.AllocatedSize;
+                resolvedAllocations.Add(new ResolvedAllocationSample(stackIndex, threadIdAttr, threadNameAttr, typeNameAttr, linkIndex, allocatedSize));
+            }
+
+            if (resolvedAllocations.Count > 0)
+            {
+                scopeProfiles.Profiles.Add(BuildAllocationProfile(dictionary, stringTable, startUnixNano, durationNano,
+                    AllocatedObjectsSampleTypeName, CountUnit, resolvedAllocations, valueForSample: _ => 1L));
+
+                scopeProfiles.Profiles.Add(BuildAllocationProfile(dictionary, stringTable, startUnixNano, durationNano,
+                    AllocatedSpaceSampleTypeName, BytesUnit, resolvedAllocations, valueForSample: r => r.AllocatedSize));
+            }
+        }
+
         var resourceProfiles = new ResourceProfiles
         {
             Resource = new Resource(),
@@ -251,6 +311,65 @@ public static class OtlpProfileBuilder
             LinkIndex = linkIndex;
             OnCpu = onCpu;
         }
+    }
+
+    // A single allocation sample's shared-dictionary indices, resolved once and reused by both allocation
+    // profiles. Deliberately separate from ResolvedSample rather than a shared/generic type: the two carry
+    // different payloads (type.name + allocated size vs. on/off-CPU) and keeping them apart leaves the
+    // hot CPU path untouched.
+    private readonly struct ResolvedAllocationSample
+    {
+        public readonly int StackIndex;
+        public readonly int ThreadIdAttr;
+        public readonly int ThreadNameAttr;
+        public readonly int TypeNameAttr;
+        public readonly int LinkIndex;
+        public readonly long AllocatedSize;
+
+        public ResolvedAllocationSample(int stackIndex, int threadIdAttr, int threadNameAttr, int typeNameAttr, int linkIndex, long allocatedSize)
+        {
+            StackIndex = stackIndex;
+            ThreadIdAttr = threadIdAttr;
+            ThreadNameAttr = threadNameAttr;
+            TypeNameAttr = typeNameAttr;
+            LinkIndex = linkIndex;
+            AllocatedSize = allocatedSize;
+        }
+    }
+
+    // Emits one Profile (allocated_objects:count or allocated_space:bytes) from the already-resolved allocation
+    // samples. Every resolved sample is included -- these two profiles are not a partition of the input the way
+    // cpu/off_cpu are, only the per-sample VALUE differs between them.
+    //
+    // No period_type/period is set: allocation sampling is event-driven, so there is no sampling interval to
+    // report. (BuildProfile's `periodNanos > 0` gate models the same "omit when not applicable" rule for the
+    // timer-driven profiles; this is a separate function so the CPU path keeps its own shape.)
+    private static Profile BuildAllocationProfile(ProfilesDictionary dictionary, Dictionary<string, int> stringTable,
+        long startUnixNano, long durationNano, string sampleTypeName, string sampleTypeUnit,
+        List<ResolvedAllocationSample> resolved, System.Func<ResolvedAllocationSample, long> valueForSample)
+    {
+        var profile = new Profile
+        {
+            TimeUnixNano = (ulong)startUnixNano,
+            DurationNano = (ulong)durationNano,
+            SampleType = new ProtoValueType
+            {
+                TypeStrindex = InternString(dictionary, stringTable, sampleTypeName),
+                UnitStrindex = InternString(dictionary, stringTable, sampleTypeUnit),
+            },
+        };
+
+        foreach (var r in resolved)
+        {
+            var protoSample = new Sample { StackIndex = r.StackIndex, LinkIndex = r.LinkIndex };
+            protoSample.Values.Add(valueForSample(r));
+            protoSample.AttributeIndices.Add(r.ThreadIdAttr);
+            protoSample.AttributeIndices.Add(r.ThreadNameAttr);
+            protoSample.AttributeIndices.Add(r.TypeNameAttr);
+            profile.Samples.Add(protoSample);
+        }
+
+        return profile;
     }
 
     // Emits one Profile (off_cpu:nanoseconds or cpu:nanoseconds) from the already-resolved samples, applying

--- a/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ProfilesTransport.cs
+++ b/src/Agent/NewRelic/Agent/Core/ContinuousProfiling/ProfilesTransport.cs
@@ -32,6 +32,33 @@ public class ProfilesTransport : IProfilesTransport
     private const string DataUsageApi = "OTLP";
     private const string DataUsageArea = "Profiles";
 
+    /// <summary>
+    /// Hard ceiling on one serialized profiles POST. A drain used to carry a single allocation sample -- a
+    /// measured 2101-byte request -- and once allocation samples batch properly it carries as many as the
+    /// configured budget allows (a measured 9784 bytes for ~100 samples, i.e. ~88 bytes marginal each), so
+    /// this path needed an upper bound rather than trusting the producer. Conservative on purpose: OTLP
+    /// ingest endpoints commonly reject requests around this size, and a profile is disposable (never
+    /// retried), so refusing to ship an oversized one costs one drain and nothing else.
+    ///
+    /// This is the LAST line of defence, not the primary one -- <c>ContinuousProfilingService</c> caps
+    /// samples per drain before building, so a payload reaching this check means that cap is mis-sized for
+    /// the workload's stack diversity (the per-sample byte cost differs by ~25x between a repeated stack and
+    /// wholly distinct ones). Public so the cap and this ceiling can be reasoned about (and tested) together.
+    /// </summary>
+    public const int MaxPayloadBytes = 1024 * 1024;
+
+    /// <summary>
+    /// How many samples per profile the DIAGNOSTIC JSON dump includes. That dump is rendered whenever
+    /// Debug logging is on -- which is routine support advice, not an exotic setting -- and it used to be
+    /// one sample per drain. Rendering (and writing to the log file) an unbounded document per drain is a
+    /// real cost paid inside the customer's process, so the dump is now sample-bounded: enough to show the
+    /// shape, the dictionary, the link table and the attributes, without scaling with throughput.
+    /// The AUDIT log is deliberately exempt (see <see cref="Send"/>).
+    /// </summary>
+    public const int MaxDiagnosticSamplesPerProfile = 25;
+
+    private const string SupportabilityPayloadTooLargeMetric = "Supportability/DotNET/ContinuousProfiling/PayloadTooLarge";
+
     // Compact, single-line protobuf-JSON (proto3 rules: bytes -> base64, enums -> names; default values emitted
     // so the shape matches the OTel dump). No indentation -- like every other collector payload we log.
     private static readonly JsonFormatter DiagnosticJsonFormatter =
@@ -68,6 +95,17 @@ public class ProfilesTransport : IProfilesTransport
         var profile = request.ResourceProfiles?.Count > 0 ? "built" : "empty";
         Log.Debug("[ContinuousProfiling] Posting profile ({0}); {1} bytes to {2}.", profile, bytes.Length, _endpoint);
 
+        // Refuse rather than ship an oversized POST. Reported as a failed send on purpose: that feeds the
+        // service's send-failure backoff, which pauses sampling briefly -- exactly the right reflex for "we
+        // are producing more than the wire will take", and it self-corrects because the next drain's payload
+        // is built from a fresh (smaller) sweep.
+        if (bytes.Length > MaxPayloadBytes)
+        {
+            Log.Debug("[ContinuousProfiling] Dropping profile: {0} bytes exceeds the {1}-byte payload ceiling.", bytes.Length, MaxPayloadBytes);
+            _agentHealthReporter?.ReportSupportabilityCountMetric(SupportabilityPayloadTooLargeMetric);
+            return false;
+        }
+
         // Log + audit the send exactly like HttpCollectorWire.SendData so CP payloads are observable like
         // every other collector payload (tools scrape these lines): Finest "Invoking" before the send, the
         // payload and response at Debug, and the audit log for Sent/Received. One requestGuid threads them.
@@ -75,7 +113,20 @@ public class ProfilesTransport : IProfilesTransport
 
         // Serialized-payload analog of HttpCollectorWire's serializedData, built once for the Debug line and
         // the audit log -- and only when a sink is listening (the JSON render is not free).
-        var payloadJson = (Log.IsDebugEnabled || AuditLog.IsAuditLogEnabled) ? ToDiagnosticJson(request) : null;
+        //
+        // Two sinks, two policies, deliberately:
+        //   * AUDIT LOG is an explicit "capture the exact payloads" switch, so it still gets the whole thing.
+        //   * DEBUG logging is routine support advice, so it gets a sample-bounded copy. Before allocation
+        //     samples batched, a drain's dump held one sample; it now holds as many as the budget delivers,
+        //     and rendering + writing that per drain is overhead inside the customer's process for a log
+        //     nobody reads to the end. The dictionary/stringTable/linkTable are NOT truncated, so the dump
+        //     stays a valid, greppable document with every frame name and trace id still in it.
+        var omittedSamples = 0;
+        string payloadJson = null;
+        if (AuditLog.IsAuditLogEnabled)
+            payloadJson = ToDiagnosticJson(request);
+        else if (Log.IsDebugEnabled)
+            payloadJson = ToDiagnosticJson(TruncateSamplesForDiagnostics(request, MaxDiagnosticSamplesPerProfile, out omittedSamples));
 
         var result = _httpPost(bytes, _endpoint);
 
@@ -83,6 +134,9 @@ public class ProfilesTransport : IProfilesTransport
         DataTransportAuditLogger.Log(DataTransportAuditLogger.AuditLogDirection.Sent, DataTransportAuditLogger.AuditLogSource.InstrumentedApp, payloadJson);
 
         Log.Debug("Request({0}): Invoked \"{1}\" with : {2}", requestGuid, ProfilesMethodName, payloadJson);
+        if (omittedSamples > 0)
+            Log.Debug("Request({0}): the logged payload omits {1} sample(s) per the {2}-sample-per-profile diagnostic cap; the POSTed payload carried all of them.",
+                requestGuid, omittedSamples, MaxDiagnosticSamplesPerProfile);
         Log.Debug("Request({0}): Invocation of \"{1}\" yielded response : {2}", requestGuid, ProfilesMethodName, result.ResponseContent);
         if (!result.Accepted)
             Log.Debug("Request({0}): Invocation of \"{1}\" was not accepted (status {2}).", requestGuid, ProfilesMethodName, result.StatusCode);
@@ -98,6 +152,39 @@ public class ProfilesTransport : IProfilesTransport
         }
 
         return result.Accepted;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="request"/> with each profile's sample list capped at
+    /// <paramref name="maxSamplesPerProfile"/>, for DIAGNOSTIC rendering only -- the real payload is never
+    /// touched. <paramref name="omitted"/> reports how many samples were left out across all profiles.
+    /// Returns the original instance (and 0) when nothing needs truncating, so the common case copies
+    /// nothing. Public + static so it is unit-testable without the static logger.
+    /// </summary>
+    public static ExportProfilesServiceRequest TruncateSamplesForDiagnostics(ExportProfilesServiceRequest request, int maxSamplesPerProfile, out int omitted)
+    {
+        omitted = 0;
+        if (request == null)
+            return null;
+
+        // Count first: cloning a large request is the expensive part, so do it only if it buys something.
+        foreach (var resourceProfiles in request.ResourceProfiles)
+            foreach (var scopeProfiles in resourceProfiles.ScopeProfiles)
+                foreach (var profile in scopeProfiles.Profiles)
+                    if (profile.Samples.Count > maxSamplesPerProfile)
+                        omitted += profile.Samples.Count - maxSamplesPerProfile;
+
+        if (omitted == 0)
+            return request;
+
+        var truncated = request.Clone();
+        foreach (var resourceProfiles in truncated.ResourceProfiles)
+            foreach (var scopeProfiles in resourceProfiles.ScopeProfiles)
+                foreach (var profile in scopeProfiles.Profiles)
+                    while (profile.Samples.Count > maxSamplesPerProfile)
+                        profile.Samples.RemoveAt(profile.Samples.Count - 1);
+
+        return truncated;
     }
 
     // Compact single-line protobuf-JSON for the payload log line + audit log. Public + static so it can be

--- a/src/Agent/NewRelic/Agent/Core/INativeMethods.cs
+++ b/src/Agent/NewRelic/Agent/Core/INativeMethods.cs
@@ -26,4 +26,32 @@ public interface INativeMethods
     void ContinuousProfilerSetAgentWork();
     void ContinuousProfilerResetAgentWork();
     void ContinuousProfilerShutdown();
+
+    /// <summary>
+    /// Starts (or resumes) allocation sampling, capped at <paramref name="maxSamplesPerMinute"/> samples
+    /// per minute. Safe to call repeatedly; pairs with <see cref="AllocationSamplerStop"/> as the
+    /// enable/disable half of the lifecycle. Has no effect after <see cref="AllocationSamplerShutdown"/>.
+    /// </summary>
+    void AllocationSamplerStart(int maxSamplesPerMinute);
+
+    /// <summary>
+    /// Pauses allocation sampling, leaving the native EventPipe session open so a later
+    /// <see cref="AllocationSamplerStart"/> can resume it. This -- never
+    /// <see cref="AllocationSamplerShutdown"/> -- is what a config/command-driven disable must call.
+    /// </summary>
+    void AllocationSamplerStop();
+
+    /// <summary>
+    /// Tears down allocation sampling permanently: closes the native EventPipe session and drains any
+    /// in-flight callback. TERMINAL -- the native sampler refuses every subsequent
+    /// <see cref="AllocationSamplerStart"/>, so this must be called exactly once, at agent shutdown.
+    /// </summary>
+    void AllocationSamplerShutdown();
+
+    /// <summary>
+    /// Drains one filled allocation-sample buffer into <paramref name="buffer"/>, returning the number of
+    /// bytes written (0 when nothing is ready). Same wire format as
+    /// <see cref="ContinuousProfilerReadThreadSamples"/>, carrying opcode 0x08 allocation samples.
+    /// </summary>
+    int ContinuousProfilerReadAllocationSamples(int len, byte[] buffer);
 }

--- a/src/Agent/NewRelic/Agent/Core/NativeMethods.cs
+++ b/src/Agent/NewRelic/Agent/Core/NativeMethods.cs
@@ -154,6 +154,41 @@ public class LinuxNativeMethods : INativeMethods
     {
         ExternContinuousProfilerShutdown();
     }
+
+    // Allocation sampling. Note the asymmetry with the continuous profiler above: AllocationSamplerShutdown
+    // is TERMINAL native-side (every later Start is refused), while ContinuousProfilerShutdown is
+    // restartable. Enable/disable must therefore use AllocationSamplerStop/AllocationSamplerStart.
+    [DllImport(DllName, EntryPoint = "AllocationSamplerStart", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerStart(int maxSamplesPerMinute);
+
+    [DllImport(DllName, EntryPoint = "AllocationSamplerStop", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerStop();
+
+    [DllImport(DllName, EntryPoint = "AllocationSamplerShutdown", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerShutdown();
+
+    [DllImport(DllName, EntryPoint = "ContinuousProfilerReadAllocationSamples", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int ExternContinuousProfilerReadAllocationSamples(int len, byte[] buffer);
+
+    public void AllocationSamplerStart(int maxSamplesPerMinute)
+    {
+        ExternAllocationSamplerStart(maxSamplesPerMinute);
+    }
+
+    public void AllocationSamplerStop()
+    {
+        ExternAllocationSamplerStop();
+    }
+
+    public void AllocationSamplerShutdown()
+    {
+        ExternAllocationSamplerShutdown();
+    }
+
+    public int ContinuousProfilerReadAllocationSamples(int len, byte[] buffer)
+    {
+        return ExternContinuousProfilerReadAllocationSamples(len, buffer);
+    }
 }
 
 public class WindowsNativeMethods : INativeMethods
@@ -303,5 +338,40 @@ public class WindowsNativeMethods : INativeMethods
     public void ContinuousProfilerShutdown()
     {
         ExternContinuousProfilerShutdown();
+    }
+
+    // Allocation sampling. Note the asymmetry with the continuous profiler above: AllocationSamplerShutdown
+    // is TERMINAL native-side (every later Start is refused), while ContinuousProfilerShutdown is
+    // restartable. Enable/disable must therefore use AllocationSamplerStop/AllocationSamplerStart.
+    [DllImport(DllName, EntryPoint = "AllocationSamplerStart", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerStart(int maxSamplesPerMinute);
+
+    [DllImport(DllName, EntryPoint = "AllocationSamplerStop", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerStop();
+
+    [DllImport(DllName, EntryPoint = "AllocationSamplerShutdown", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void ExternAllocationSamplerShutdown();
+
+    [DllImport(DllName, EntryPoint = "ContinuousProfilerReadAllocationSamples", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int ExternContinuousProfilerReadAllocationSamples(int len, byte[] buffer);
+
+    public void AllocationSamplerStart(int maxSamplesPerMinute)
+    {
+        ExternAllocationSamplerStart(maxSamplesPerMinute);
+    }
+
+    public void AllocationSamplerStop()
+    {
+        ExternAllocationSamplerStop();
+    }
+
+    public void AllocationSamplerShutdown()
+    {
+        ExternAllocationSamplerShutdown();
+    }
+
+    public int ContinuousProfilerReadAllocationSamples(int len, byte[] buffer)
+    {
+        return ExternContinuousProfilerReadAllocationSamples(len, buffer);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -313,11 +313,11 @@ public interface IConfiguration
     bool ContinuousProfilingIncludeAgentCode { get; }
 
     /// <summary>
-    /// Gets whether allocation sampling is enabled. Allocation sampling is a sub-feature of continuous
-    /// profiling: this is false whenever <see cref="ContinuousProfilingEnabled"/> is false, regardless of the
-    /// allocation-specific setting. Defaults to false. Note that the two SAMPLERS have independent lifecycles
-    /// even though the config flags are hierarchical -- allocation sampling is event-driven (CLR
-    /// AllocationTick) and does not need the periodic thread sampler to be running.
+    /// Gets whether allocation sampling is enabled. Independent of <see cref="ContinuousProfilingEnabled"/>:
+    /// allocation sampling is driven by CLR AllocationTick events rather than by the periodic thread sampler,
+    /// so either signal can be enabled without the other. It does, however, respect the same two guards that
+    /// flag does -- high security mode disables it, and so does a server-side continuous-profiling disable --
+    /// because allocation samples carry stack frames and allocated type names. Defaults to false.
     /// </summary>
     bool ContinuousProfilingAllocationEnabled { get; }
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -311,4 +311,19 @@ public interface IConfiguration
     /// the CP UI ships a self-frames filter (like the thread profiler's).
     /// </summary>
     bool ContinuousProfilingIncludeAgentCode { get; }
+
+    /// <summary>
+    /// Gets whether allocation sampling is enabled. Allocation sampling is a sub-feature of continuous
+    /// profiling: this is false whenever <see cref="ContinuousProfilingEnabled"/> is false, regardless of the
+    /// allocation-specific setting. Defaults to false. Note that the two SAMPLERS have independent lifecycles
+    /// even though the config flags are hierarchical -- allocation sampling is event-driven (CLR
+    /// AllocationTick) and does not need the periodic thread sampler to be running.
+    /// </summary>
+    bool ContinuousProfilingAllocationEnabled { get; }
+
+    /// <summary>
+    /// Gets the per-minute allocation-sample budget, clamped to [1, 60000]. Each sample costs a stack walk on
+    /// the allocating application thread, so this is the feature's primary overhead control. Defaults to 200.
+    /// </summary>
+    int ContinuousProfilingAllocationMaxSamplesPerMinute { get; }
 }

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationBatchAccumulator.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationBatchAccumulator.h
@@ -1,0 +1,332 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "SampleBufferQueue.h"
+#include "SampleBufferWriter.h"
+
+// AllocationBatchAccumulator decides WHEN an allocation sample becomes a published batch. It exists
+// because the obvious answer -- one batch per sample, published immediately -- caps delivery at one
+// sample per managed drain interval:
+//
+//   The SampleBufferQueue has two slots and the managed drain frees one per ReadBatch call. If every
+//   sample is its own batch, then in steady state every tick beyond the first after a drain finds both
+//   slots full and is thrown away. At the shipped defaults (200 samples/minute, a 10 s drain) that is a
+//   ceiling of 6 samples/minute -- 3% of the configured budget -- and the survivor is deterministically
+//   "the first tick after each drain" rather than the sub-sampler's uniform selection, so the profile is
+//   biased as well as sparse. Measured on a real run: 1577 selected ticks dropped, 18 delivered.
+//
+// So back-pressure here means "batch more samples together", not "drop them". A sample encodes into a
+// PENDING batch, and that batch is sealed and published as soon as there is a slot to publish it into.
+// When there is no slot, the batch stays OPEN and the next sample appends to it. Nothing is dropped
+// until the pending batch itself runs out of room (MaxAllocationBufferBytes -- room for well over a
+// thousand samples that share a stack, or a few dozen with wholly distinct ones; see that constant for
+// the two regimes) while the queue is still full: a genuinely saturated state, where dropping is the
+// only option left.
+// In the common non-backpressured case the behavior is byte-for-byte what it was before: one sample per
+// batch, published on the spot, no added latency.
+//
+// TWO THINGS ARE LOAD-BEARING AND EASY TO GET WRONG:
+//
+//  1. THE WRITER INSTANCE MUST PERSIST WITH THE BATCH. SampleBufferWriter's frame-interning table lives
+//     in the WRITER OBJECT, not in the byte buffer, and it is what makes a positive frame code mean
+//     "back-reference to the string defined earlier in THIS batch". Keeping the buffer across ticks but
+//     constructing a fresh writer around it each tick would restart interning at index 1 while the
+//     buffer already contained definitions for 1..n -- redefining indices the batch had already used and
+//     silently corrupting every sample after the first. Hence one writer member, alive for as long as
+//     the batch it is writing, and BeginBatch() (which clears the buffer and the interning table
+//     TOGETHER) called only when actually starting a fresh batch.
+//
+//  2. A PARTIALLY WRITTEN SAMPLE POISONS THE WHOLE BATCH. The encoder has no rollback: a record that
+//     stops mid-field desynchronizes the managed decoder for everything after it. If encoding throws,
+//     the owner must call AbandonBatch() rather than leaving the half-written record in place.
+//
+// Dropped samples are reported IN BAND, as the `skipped` field of the existing BatchStats record (opcode
+// 0x07) -- the same field the thread sampler already uses for "samples the walk missed". No new opcode,
+// no BufferParser change: the managed drain reads BatchStats.Skipped off each allocation batch and
+// reports it as a supportability metric. The count is a DELTA (drops since the previous published
+// batch), and it is only retired once the batch carrying it is actually published, so a failed publish
+// cannot lose it.
+//
+// NOT THREAD-SAFE, by design: the owner (AllocationSampler) already serializes every entry point on its
+// tick mutex, so a second lock here would be pure overhead. Like SampleBufferQueue, it is deliberately
+// free of CLR and logging dependencies -- the owner does all the logging -- which is also what makes it
+// directly unit-testable against a real SampleBufferQueue.
+namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
+{
+    class AllocationBatchAccumulator
+    {
+    public:
+        // Bytes that must ALWAYS be left available so an open batch can be closed: a BatchStats record
+        // (opcode + int64 + 3x int32) plus the EndBatch opcode. Public because the owner's per-frame
+        // overflow check has to reserve it too.
+        static constexpr size_t BatchTailBytes = (1 + 8 + 4 + 4 + 4) + 1;
+
+        // A StartBatch record: opcode + version byte + int64 timestamp.
+        static constexpr size_t StartBatchBytes = 1 + 1 + 8;
+
+        // Reservation used ONLY by the pre-walk gate (CanAcceptSample), which has to answer "is it worth
+        // walking the stack?" before the frames -- and therefore this sample's real size -- are known. It is
+        // therefore a deliberate OVER-reservation sized for the expensive regime, not an average:
+        //
+        //   * a sample appended to a batch that already interned its stack costs ~100 bytes
+        //     (AllocationSampler::MaxAllocationBufferBytes documents both regimes, and
+        //     AllocationBatchAccumulatorTest measures this one), so 4 KB over-reserves ~40x -- which costs
+        //     nothing that matters: the gate closes ~3% of a 128 KB batch early, i.e. it stops accepting
+        //     around sample ~1290 instead of ~1330.
+        //   * a sample whose frames are all NEW costs ~2.5 KB (roughly 20 fresh 60-char frames), so for the
+        //     diverse-stack workload -- the one that can actually fill a batch -- 4 KB is about right, and
+        //     erring high is the safe direction: the gate refuses a tick slightly before the batch is truly
+        //     full rather than letting BeginSample discover it has no room after paying for a stack walk.
+        //
+        // Being coarse here is fine precisely BECAUSE BeginSample re-checks with the sample's exact size, so
+        // this number never decides whether a resolved sample fits -- only whether resolving it is worth it.
+        static constexpr size_t TypicalSampleBytes = 4 * 1024;
+
+        // `queue` and `maxBytes` are the same queue the managed reader drains and the same per-batch byte
+        // ceiling a single-sample batch used before -- a pending batch is capped exactly like any other.
+        AllocationBatchAccumulator(SampleBufferQueue& queue, size_t maxBytes) noexcept
+            : _queue(queue), _writer(_buffer, maxBytes)
+        {
+        }
+
+        // Cheap pre-flight check for the owner's tick handler: is there anywhere for a sample to GO, so
+        // that paying for a stack walk and frame-name resolution is worthwhile? False only in the
+        // saturated state (no free slot AND an open batch with no room), which is the one case where
+        // dropping the tick before the walk is still the right answer.
+        //
+        // Safe as a gate because there is exactly one producer: only the consumer frees a queue slot, so
+        // a free slot observed here is still free when this same thread publishes, and the pending
+        // batch's room is only ever changed by this thread.
+        bool CanAcceptSample() const noexcept
+        {
+            if (_queue.HasFreeSlot())
+            {
+                return true;
+            }
+
+            // No slot to publish into, so the sample joins the pending batch instead of being dropped.
+            // A batch that is not open yet is empty, so it always has room.
+            if (!_batchOpen)
+            {
+                return true;
+            }
+
+            return _writer.WillFit(TypicalSampleBytes + BatchTailBytes);
+        }
+
+        // Count one sample the owner is dropping for a reason of its own (a saturated CanAcceptSample, a
+        // failed stack walk after the decision to sample was already made, ...). Feeds the in-band
+        // BatchStats.Skipped delta.
+        void RecordDroppedSample() noexcept
+        {
+            ++_droppedPending;
+            ++_droppedTotal;
+        }
+
+        // Open (or continue) a batch with room for a sample of `requiredBytes`, and return the writer to
+        // encode it with -- or nullptr when the sample must be dropped, in which case it has already
+        // been counted.
+        //
+        // `requiredBytes` is the sample's EXACT worst-case encoded size, which is why the caller resolves
+        // its frame names first: knowing the real size lets the cap-driven flush happen at a sample
+        // boundary instead of truncating a sample's frame list at the buffer's edge. The only sample that
+        // still truncates is one whose frames alone exceed the entire buffer cap (the owner's per-frame
+        // check catches that), exactly as before this class existed.
+        //
+        // Can throw (the writer allocates); the owner encodes inside a try/catch that calls
+        // AbandonBatch().
+        SampleBufferWriter* BeginSample(size_t requiredBytes, int64_t batchTimestampNanos)
+        {
+            if (_batchOpen && !_writer.WillFit(requiredBytes + BatchTailBytes))
+            {
+                // The open batch cannot hold this sample. Publishing is the only way to empty it, so a
+                // flush is only attempted when a slot is known to be free -- a failed publish would have
+                // to throw away every sample already in the batch.
+                if (_queue.HasFreeSlot())
+                {
+                    CloseAndPublish();
+                }
+                else
+                {
+                    // Saturated: nothing to flush into and no room to append. Drop THIS sample only --
+                    // the batch stays intact, so the samples already in it are still delivered as soon
+                    // as a slot frees.
+                    RecordDroppedSample();
+                    return nullptr;
+                }
+            }
+
+            if (!_batchOpen)
+            {
+                // BeginBatch clears the buffer AND resets the frame-interning table, which is why it is
+                // called here and nowhere else: doing it between appends to an open batch would corrupt
+                // that batch's frame codes (see the header comment).
+                _writer.BeginBatch();
+                _writer.WriteStartBatch(batchTimestampNanos);
+                _batchOpen = true;
+                _samplesInBatch = 0;
+            }
+
+            return &_writer;
+        }
+
+        // The owner has finished writing a complete sample (through its frame-list terminator). Publishes
+        // immediately if there is a slot -- which keeps the common case at one sample per batch and one
+        // drain interval of latency -- and otherwise leaves the batch open for the next sample to append
+        // to, which is the entire point of this class.
+        //
+        // Can throw (sealing the batch writes to the buffer); see BeginSample.
+        void EndSample()
+        {
+            if (!_batchOpen)
+            {
+                return; // defensive: no sample was begun
+            }
+
+            ++_samplesInBatch;
+
+            if (_queue.HasFreeSlot())
+            {
+                CloseAndPublish();
+            }
+        }
+
+        // Seal and publish an open batch if there is a slot for it. Called by the owner from the managed
+        // drain path so a batch accumulated under back-pressure is handed over as soon as the reader
+        // frees a slot, instead of waiting for the next allocation tick to notice -- which would strand
+        // the tail of every allocation burst for as long as the workload stayed quiet. Returns whether a
+        // batch was published.
+        bool FlushIfPending()
+        {
+            if (!_batchOpen || !_queue.HasFreeSlot())
+            {
+                return false;
+            }
+
+            return CloseAndPublish();
+        }
+
+        // Throw away the open batch, counting everything in it as dropped. The owner's ONLY correct
+        // response to an exception raised while encoding a sample: the writer cannot roll back a partial
+        // record, and a partial record desynchronizes the managed decoder for every sample after it.
+        void AbandonBatch() noexcept
+        {
+            if (!_batchOpen)
+            {
+                return;
+            }
+
+            _droppedPending += _samplesInBatch;
+            _droppedTotal += _samplesInBatch;
+            _samplesInBatch = 0;
+            _batchOpen = false;
+            _buffer.clear();
+        }
+
+        // Cumulative count of samples this accumulator has dropped, for diagnostics and tests. The
+        // number reported to the managed side is the per-batch DELTA, not this.
+        uint64_t DroppedTotal() const noexcept
+        {
+            return _droppedTotal;
+        }
+
+        // Drops not yet carried out to the managed side by a published batch.
+        uint64_t DroppedPending() const noexcept
+        {
+            return _droppedPending;
+        }
+
+        // Whether a batch is currently open (i.e. holding samples that are not published yet).
+        bool HasOpenBatch() const noexcept
+        {
+            return _batchOpen;
+        }
+
+        // How many samples the open batch is holding.
+        uint32_t SamplesInPendingBatch() const noexcept
+        {
+            return _samplesInBatch;
+        }
+
+        AllocationBatchAccumulator(const AllocationBatchAccumulator&) = delete;
+        AllocationBatchAccumulator(AllocationBatchAccumulator&&) = delete;
+        AllocationBatchAccumulator& operator=(const AllocationBatchAccumulator&) = delete;
+        AllocationBatchAccumulator& operator=(AllocationBatchAccumulator&&) = delete;
+
+    private:
+        // Seal the open batch (BatchStats + EndBatch) and hand it to the queue. Returns false when the
+        // publish failed, in which case the sealed bytes are unrecoverable and every sample in them is
+        // counted as dropped.
+        bool CloseAndPublish()
+        {
+            // The drop delta rides out in this batch. int32 because that is the BatchStats field width;
+            // a delta that large is impossible in one batch window, but clamp rather than wrap, and keep
+            // any remainder pending for the next batch.
+            const int32_t skipped = ClampToInt32(_droppedPending);
+            _writer.WriteBatchStats(0, 0, 0, skipped);
+            _writer.WriteEndBatch();
+
+            const uint32_t samples = _samplesInBatch;
+            _batchOpen = false;
+            _samplesInBatch = 0;
+
+            if (!_queue.TryPublish(_buffer))
+            {
+                // Unreachable through either caller (both check HasFreeSlot first, and only the consumer
+                // frees a slot) but handled rather than assumed: the batch is already sealed, so its
+                // samples are lost. The drop delta written above stays pending, since the batch carrying
+                // it never arrived.
+                _droppedPending += samples;
+                _droppedTotal += samples;
+                _buffer.clear();
+                return false;
+            }
+
+            // Published, so the delta this batch carries is now reported. TryPublish SWAPPED our bytes
+            // into the slot, leaving us the slot's recycled (already-drained) storage -- clearing keeps
+            // its capacity, so steady-state batching does not reallocate.
+            _droppedPending -= static_cast<uint64_t>(skipped);
+            _buffer.clear();
+            return true;
+        }
+
+        static int32_t ClampToInt32(uint64_t value) noexcept
+        {
+            // Parenthesized to defeat the windows.h `max` function-like macro, and copied to a local
+            // because binding a static constexpr member to a const reference odr-uses it, which a
+            // header-only class cannot satisfy before C++17 (the Linux build is C++11/14).
+            const uint64_t ceiling = static_cast<uint64_t>((std::numeric_limits<int32_t>::max)());
+            return static_cast<int32_t>(value < ceiling ? value : ceiling);
+        }
+
+        // The queue this accumulator publishes into; owned by the caller and must outlive this object.
+        SampleBufferQueue& _queue;
+
+        // The pending batch's bytes. Declared BEFORE _writer, which wraps a reference to it.
+        std::vector<uint8_t> _buffer;
+
+        // The batch's encoder. ONE instance for the life of this object, so its per-batch frame-interning
+        // table stays consistent across the ticks that append to a single batch (see the header comment).
+        SampleBufferWriter _writer;
+
+        // Whether _buffer currently holds an unsealed batch (StartBatch written, EndBatch not yet).
+        bool _batchOpen{ false };
+
+        // Samples written into the open batch, so an abandoned or unpublishable batch can be counted
+        // accurately rather than as one lost sample.
+        uint32_t _samplesInBatch{ 0 };
+
+        // Drops not yet reported to the managed side (written as BatchStats.Skipped on the next
+        // successful publish, and only retired then).
+        uint64_t _droppedPending{ 0 };
+
+        // Cumulative drops, for diagnostics/tests only.
+        uint64_t _droppedTotal{ 0 };
+    };
+}}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
@@ -1,0 +1,651 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <cor.h>
+#include <corprof.h>
+
+#include "../Logging/Logger.h"
+#include "../ThreadProfiler/namecache.h"
+#include "AllocationSubSampler.h"
+#include "FrameNameResolver.h"
+#include "OsThreadName.h"
+#include "SampleBufferQueue.h"
+#include "SampleBufferWriter.h"
+#include "SuspendMutex.h"
+#include "TraceContextMap.h"
+
+// AllocationSampler is the event-driven counterpart to ContinuousProfiler's timer-driven thread walker.
+// It has NO worker thread of its own -- it is driven entirely by CLR EventPipe AllocationTick callbacks
+// delivered ON THE ALLOCATING APP THREAD (ICorProfilerCallback10::EventPipeEventDelivered, routed here
+// by CorProfilerCallbackImpl). Everything it does therefore runs on a customer thread in the middle of
+// an allocation, which drives every design choice below:
+//
+//   * The CLR raises AllocationTick roughly every 100 KB allocated -- ~10^5/second in an allocation-heavy
+//     app -- so the handler bails as early and as cheaply as possible. Order: session gate -> tick
+//     try-lock -> sub-sample -> payload parse -> back-pressure -> stack walk -> encode.
+//   * It NEVER blocks the app thread. Every lock it takes is a try_lock; a lost race costs one allocation
+//     sample, which is statistically irrelevant to a subsampled profile and is never a correctness issue.
+//   * It NEVER throws. This is a COM callback boundary; an escaping exception would propagate into the
+//     runtime's EventPipe dispatch.
+//   * Session teardown must NEVER block agent shutdown -- see the Shutdown() comment.
+//
+// Concurrency model: allocation ticks arrive on MANY app threads at once, but almost all of this class's
+// state (the sub-sampler's RNG, the name cache, the frame resolver's scratch frame, the encode buffer)
+// is single-threaded-only. Rather than sprinkling locks over each, one try_lock'd _tickMutex makes the
+// whole handler mutually exclusive: exactly one thread handles a tick at a time and the rest return
+// immediately. That also makes this class the single producer SampleBufferQueue::HasFreeSlot assumes.
+namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
+{
+    class AllocationSampler
+    {
+    public:
+        // GCAllocationTick's event id in the Microsoft-Windows-DotNETRuntime provider (the GC keyword's
+        // 10th event). Exposed so the CorProfilerCallbackImpl dispatch can filter without duplicating
+        // this knowledge.
+        static constexpr DWORD AllocationTickEventId = 10;
+
+        // The ONLY payload version ParseAllocationTickPayload can read. The v4 layout is parsed partly
+        // from the front and partly from the BACK of the buffer (AllocatedSize is the last field), so a
+        // different version must be rejected rather than misread: an older v2/v3 payload would yield a
+        // slice of the Address field as the allocation size, and a hypothetical future v5 that appends a
+        // field would do the same. v4 has been the newest version since .NET Core 3.0; if a future
+        // runtime ships v5, allocation sampling goes quiet (no samples) until this is updated -- which is
+        // the correct failure mode for telemetry.
+        static constexpr DWORD AllocationTickSupportedVersion = 4;
+
+        // Dispatch predicate for CorProfilerCallbackImpl::EventPipeEventDelivered. Provider identity is
+        // the caller's business (it holds the EVENTPIPE_PROVIDER handle for the session it created); this
+        // only answers "is this the event we can parse?".
+        static bool IsAllocationTickEvent(DWORD eventId, DWORD eventVersion) noexcept
+        {
+            return eventId == AllocationTickEventId && eventVersion == AllocationTickSupportedVersion;
+        }
+
+        // Called during Profiler Initialize. Like ContinuousProfiler::Init this does no heavy lifting: it
+        // stores the ICorProfilerInfo4, probes for the ICorProfilerInfo12 that EventPipe sessions require
+        // (.NET 5+ / CoreCLR only -- absent on .NET Framework), and creates the frame-name resolver. It
+        // starts no threads and opens no session.
+        //
+        // `sharedTraceContexts` is the ContinuousProfiler's OWN map (not owned here, must outlive this
+        // object): the managed side pushes trace context through a single export that writes that map, so
+        // allocation samples can only be correlated by reading the same instance.
+        void Init(ICorProfilerInfo4* corProfilerInfo, TraceContextMap* sharedTraceContexts) noexcept
+        {
+            LogInfo(L"Initializing AllocationSampler");
+
+            _corProfilerInfo = corProfilerInfo;
+            _traceContexts = sharedTraceContexts;
+
+            if (corProfilerInfo == nullptr)
+            {
+                return;
+            }
+
+            HRESULT hr = corProfilerInfo->QueryInterface(__uuidof(ICorProfilerInfo12), (void**)&_corProfilerInfo12);
+            if (SUCCEEDED(hr))
+            {
+                LogInfo(L"AllocationSampler: ICorProfilerInfo12 available");
+            }
+            else
+            {
+                LogInfo(L"AllocationSampler: ICorProfilerInfo12 unavailable (.NET Framework or old CoreCLR) -- allocation sampling disabled");
+            }
+
+            try
+            {
+                // Its OWN resolver over its OWN name cache -- deliberately NOT shared with
+                // ContinuousProfiler's. Sharing would put two threads (an app thread here, the sampling
+                // thread there) inside the same non-thread-safe LRU cache and scratch buffer, which is
+                // heap corruption rather than a stale name; and a mutex around it would let an app thread
+                // block behind the sampler resolving a hundred threads' stacks. See FrameNameResolver.h.
+                _frameNames.reset(new FrameNameResolver(_nameCache, corProfilerInfo));
+            }
+            catch (const std::exception&)
+            {
+                LogError(L"AllocationSampler: failed to create the frame name resolver; frames will be empty");
+            }
+        }
+
+        // Whether allocation sampling can work in this process at all (i.e. the runtime is new enough to
+        // expose the EventPipe profiling API). Lets the caller skip setting COR_PRF_HIGH_MONITOR_EVENT_PIPE
+        // and skip Start() entirely on .NET Framework.
+        bool IsAvailable() const noexcept
+        {
+            return _corProfilerInfo12 != nullptr;
+        }
+
+        // Open the AllocationTick EventPipe session and arm the handler. No-op (logged) when
+        // ICorProfilerInfo12 is unavailable. Idempotent: a second Start() after a Stop() re-arms the
+        // handler and resets the sub-sampler WITHOUT opening a second session -- overwriting _sessionId
+        // would orphan the first session (nothing could ever stop it) and double the runtime's event cost.
+        void Start(uint32_t maxSamplesPerMinute) noexcept
+        {
+            if (!_corProfilerInfo12)
+            {
+                LogDebug(L"AllocationSampler: Start ignored; the EventPipe profiling API is unavailable in this runtime");
+                return;
+            }
+
+            try
+            {
+                {
+                    // Held so a tick in flight can never observe a half-replaced sub-sampler. Start() runs
+                    // on the agent's own thread, where a brief wait is fine (unlike the tick path, which
+                    // only ever try_locks).
+                    std::lock_guard<std::mutex> tickLock(_tickMutex);
+                    _subSampler.reset(new AllocationSubSampler(maxSamplesPerMinute, SubSampleCycleSeconds));
+                }
+
+                if (_sessionId != 0)
+                {
+                    _sessionActive.store(true);
+                    LogTrace(L"AllocationSampler: re-armed the existing EventPipe session");
+                    return;
+                }
+
+                COR_PRF_EVENTPIPE_PROVIDER_CONFIG providerConfig{};
+                providerConfig.providerName = _X("Microsoft-Windows-DotNETRuntime");
+                // GCKeyword (0x1). AllocationTick is a GC-keyword event and, despite being documented at
+                // Informational level, is only emitted at Verbose.
+                providerConfig.keywords = 0x1;
+                providerConfig.loggingLevel = COR_PRF_EVENTPIPE_VERBOSE;
+                providerConfig.filterData = nullptr;
+
+                EVENTPIPE_SESSION sessionId = 0;
+                HRESULT hr = _corProfilerInfo12->EventPipeStartSession(1, &providerConfig, FALSE, &sessionId);
+                if (FAILED(hr))
+                {
+                    LogError(L"AllocationSampler: EventPipeStartSession failed: ", std::hex, std::showbase, hr,
+                        std::resetiosflags(std::ios_base::basefield | std::ios_base::showbase));
+                    _sessionActive.store(false);
+                    return;
+                }
+
+                // Publish the id BEFORE arming the handler so Shutdown() can always find a session that
+                // ticks may already be arriving on.
+                _sessionId = sessionId;
+                _sessionActive.store(true);
+                LogInfo(L"AllocationSampler: EventPipe session started");
+            }
+            catch (const std::exception&)
+            {
+                _sessionActive.store(false);
+                LogError(L"AllocationSampler: exception starting the EventPipe session");
+            }
+        }
+
+        // Stop producing samples but leave the EventPipe session open. Mirrors ContinuousProfiler::Stop's
+        // semantics (which parks its worker thread rather than destroying it): the expensive/risky
+        // teardown lives in Shutdown(). The runtime keeps raising AllocationTick, but the handler returns
+        // on its first branch.
+        void Stop() noexcept
+        {
+            _sessionActive.store(false);
+        }
+
+        // Close the EventPipe session. NEVER blocks agent shutdown indefinitely: EventPipeStopSession has
+        // to rendezvous with the runtime's own EventPipe machinery, so it is run on a DETACHED thread with
+        // a bounded wait. On timeout the call is abandoned (the detached thread keeps its own references
+        // alive, so nothing dangles) instead of hanging the agent's shutdown path behind the runtime.
+        //
+        // std::async is deliberately NOT used here: the std::future it returns has a BLOCKING destructor,
+        // so the "bounded wait" would be silently undone by the future going out of scope -- the exact
+        // hang this is written to avoid.
+        void Shutdown() noexcept
+        {
+            _sessionActive.store(false);
+
+            if (!_corProfilerInfo12 || _sessionId == 0)
+            {
+                return;
+            }
+
+            // Claim the session so a second Shutdown() (the destructor always calls it as a safety net)
+            // cannot stop the same session twice.
+            const EVENTPIPE_SESSION sessionId = _sessionId;
+            _sessionId = 0;
+
+            try
+            {
+                auto signal = std::make_shared<StopSessionSignal>();
+                CComPtr<ICorProfilerInfo12> info12 = _corProfilerInfo12; // keeps the interface alive for the detached thread
+
+                std::thread stopper([info12, sessionId, signal]() {
+                    info12->EventPipeStopSession(sessionId);
+                    {
+                        std::lock_guard<std::mutex> l(signal->Mtx);
+                        signal->Done = true;
+                    }
+                    signal->Cv.notify_all();
+                });
+                stopper.detach();
+
+                std::unique_lock<std::mutex> l(signal->Mtx);
+                const bool stopped = signal->Cv.wait_for(l, std::chrono::seconds(StopSessionTimeoutSeconds),
+                    [signal]() { return signal->Done; });
+
+                if (stopped)
+                {
+                    LogTrace(L"AllocationSampler: EventPipe session stopped");
+                }
+                else
+                {
+                    LogError(L"AllocationSampler: EventPipeStopSession did not return within ",
+                        static_cast<uint32_t>(StopSessionTimeoutSeconds), L"s; abandoning it rather than blocking shutdown");
+                }
+            }
+            catch (const std::exception&)
+            {
+                LogError(L"AllocationSampler: exception stopping the EventPipe session");
+            }
+        }
+
+        // Drain the oldest filled sample buffer into the caller's array; the allocation-sample counterpart
+        // of ContinuousProfiler::ReadThreadSamples, decoded by the same managed BufferParser. Returns the
+        // number of bytes written (0 when nothing is ready or the args are invalid). Never throws.
+        int32_t ReadAllocationSamples(int32_t len, unsigned char* buf) noexcept
+        {
+            if (buf == nullptr || len <= 0)
+            {
+                return 0;
+            }
+
+            try
+            {
+                return _sampleBuffers.Read(len, buf);
+            }
+            catch (...)
+            {
+                LogTrace(L"AllocationSampler: exception draining sample buffer");
+            }
+
+            return 0;
+        }
+
+        // Handle one AllocationTick. Runs ON THE ALLOCATING APP THREAD inside the runtime's EventPipe
+        // dispatch (see the class comment). Callers must have already filtered the event with
+        // IsAllocationTickEvent. Never throws, never blocks.
+        void OnAllocationTick(ULONG dataLen, LPCBYTE data) noexcept
+        {
+            if (!_sessionActive.load())
+            {
+                return;
+            }
+
+            try
+            {
+                // Serialize tick handling across app threads (see the class comment). try_lock, never
+                // lock: a concurrent tick is dropped, not queued behind another thread's stack walk.
+                std::unique_lock<std::mutex> tickLock(_tickMutex, std::try_to_lock);
+                if (!tickLock.owns_lock())
+                {
+                    return;
+                }
+
+                // Rate limit BEFORE any stack walk (AllocationSubSampler's documented contract). Ticks
+                // dropped by the try_lock above are not counted here, so the sub-sampler's estimate of
+                // per-cycle tick volume is a slight undercount on heavily-parallel workloads -- it paces
+                // conservatively as a result, which is the harmless direction.
+                if (!_subSampler || !_subSampler->ShouldSample())
+                {
+                    return;
+                }
+
+                uint64_t allocatedSize = 0;
+                xstring_t typeName;
+                if (!ParseAllocationTickPayload(dataLen, data, allocatedSize, typeName))
+                {
+                    return; // malformed / unexpected-version payload -- drop it, never guess
+                }
+
+                // Back-pressure before the expensive part: if the managed reader has not drained, this
+                // sample has nowhere to go, so skip the walk/resolve/encode instead of throwing the result
+                // away at publish time. Safe as a gate because _tickMutex makes this the single producer.
+                if (!_sampleBuffers.HasFreeSlot())
+                {
+                    LogTrace(L"AllocationSampler: sample buffers full; skipping tick (reader has not drained)");
+                    return;
+                }
+
+                // Own-thread trace-context read: unlike ContinuousProfiler's cross-thread read, there is no
+                // concurrent writer to race -- the only writer of this slot is this very thread. (Even in
+                // the impossible case of a tick landing inside that thread's own seqlock write, TryGet is
+                // wait-free and simply reports "no context".)
+                ThreadID currentThreadId = 0;
+                _corProfilerInfo->GetCurrentThreadID(&currentThreadId);
+                TraceContext context{};
+                if (_traceContexts != nullptr)
+                {
+                    _traceContexts->TryGet(currentThreadId, context);
+                }
+
+                std::vector<FunctionID> functionIds;
+                functionIds.reserve(MaxStackFramesSupported);
+                StackWalkContext walkContext{ &functionIds, false };
+
+                {
+                    // Serialize with ContinuousProfiler/ThreadProfiler: DoStackSnapshot must not run against
+                    // a thread that another walk is already targeting, and the periodic sampler walks EVERY
+                    // managed thread -- including this one. try_lock, so a tick that collides with a
+                    // periodic sample is dropped rather than parking an app thread for a whole suspend
+                    // window. Released before the (much longer) resolve/encode phase, which needs no
+                    // serialization of its own.
+                    std::unique_lock<NewRelic::Profiler::SuspendMutex> suspendLock(
+                        NewRelic::Profiler::SuspendMutex::Shared(), std::try_to_lock);
+                    if (!suspendLock.owns_lock())
+                    {
+                        LogTrace(L"AllocationSampler: skipping tick, the periodic sampler holds the suspend mutex");
+                        return;
+                    }
+
+                    // NULL target thread == walk the CURRENT thread synchronously; no thread is suspended
+                    // by this call. That is also why the callback below may allocate, unlike
+                    // ContinuousProfiler's strictly zero-alloc one.
+                    const HRESULT walkResult = _corProfilerInfo->DoStackSnapshot(static_cast<ThreadID>(0),
+                        &StaticAllocationStackFrameCallback, COR_PRF_SNAPSHOT_INFO::COR_PRF_SNAPSHOT_DEFAULT,
+                        &walkContext, nullptr, 0);
+
+                    // A stack deeper than the frame cap reports failure (CORPROF_E_STACKSNAPSHOT_ABORTED)
+                    // because the callback deliberately aborted the walk; those leaf-most frames are good,
+                    // so keep the sample -- exactly ContinuousProfiler's truncation handling.
+                    if (FAILED(walkResult) && !walkContext.Truncated)
+                    {
+                        LogTrace(L"AllocationSampler: DoStackSnapshot failed for allocation sample");
+                        return;
+                    }
+                }
+
+                EncodeAndPublish(currentThreadId, context, allocatedSize, typeName, functionIds);
+            }
+            catch (...)
+            {
+                // A COM callback boundary: swallow everything. Logging is safe here (no runtime suspend is
+                // in progress on this path) but is kept to Finest -- this can fire per allocation tick.
+                LogTrace(L"AllocationSampler: exception handling allocation tick");
+            }
+        }
+
+        // Parse the AllocationTick **v4** payload. Ported field-for-field from OpenTelemetry's
+        // opentelemetry-dotnet-instrumentation continuous_profiler.cpp (ContinuousProfiler::AllocationTick),
+        // which is the authoritative description of this ETW-shaped blob:
+        //
+        //   AllocationAmount   int32
+        //   AllocationKind     int32
+        //   InstanceId         int16
+        //   AllocationAmount64 int64
+        //   TypeId             pointer-sized
+        //   TypeName           UTF-16, NUL-terminated, VARIABLE length
+        //   HeapIndex          int32
+        //   Address            pointer-sized
+        //   AllocatedSize      int64   <- LAST field (appended in v4 after the v3 fields)
+        //
+        // Only AllocatedSize and TypeName are consumed downstream, and because TypeName is variable-length
+        // they are read from OPPOSITE ends: TypeName from the fixed front offset, AllocatedSize from the
+        // last 8 bytes. Pointer-sized fields use sizeof(void*) -- the payload is emitted by the runtime
+        // hosting us, so its pointer width is ours (correct for both x64 and x86).
+        //
+        // Static + stateless so it is directly unit-testable without a CLR. Never throws.
+        static bool ParseAllocationTickPayload(ULONG dataLen, LPCBYTE data, uint64_t& allocatedSize, xstring_t& typeName) noexcept
+        {
+            allocatedSize = 0;
+            typeName.clear();
+
+            if (data == nullptr)
+            {
+                return false;
+            }
+
+            const size_t len = static_cast<size_t>(dataLen);
+
+            // OTel's own guard against a buffer under-read, ported as-is: the payload must be long enough
+            // for every fixed field plus at least the NUL terminator of TypeName, and whatever remains
+            // beyond the fixed fields must be a whole number of UTF-16 code units. Anything else is a
+            // truncated or differently-shaped payload -- reject it without reading a single byte.
+            if (len < AllocationTickV4SizeWithoutTypeName + sizeof(xchar_t) ||
+                (len - AllocationTickV4SizeWithoutTypeName) % sizeof(xchar_t) != 0)
+            {
+                return false;
+            }
+
+            // memcpy rather than a reinterpret_cast dereference: the field is not guaranteed to be aligned
+            // for a uint64_t, and this is also strict-aliasing clean.
+            uint64_t size = 0;
+            std::memcpy(&size, data + (len - sizeof(uint64_t)), sizeof(uint64_t));
+
+            // Character count EXCLUDING the NUL terminator. Constructed with an explicit length: the
+            // terminator is not assumed to be reachable, so no NUL-scanning constructor is used.
+            const size_t typeNameCharLen = (len - AllocationTickV4SizeWithoutTypeName) / sizeof(xchar_t) - 1;
+
+            try
+            {
+                // UTF-16LE in the payload; xchar_t is the platform's 2-byte UTF-16 code unit (wchar_t on
+                // Windows, char16_t under the PAL), so this is a straight copy on both.
+                typeName.assign(reinterpret_cast<const xchar_t*>(data + AllocationTickV4TypeNameStartByteIndex), typeNameCharLen);
+            }
+            catch (...)
+            {
+                return false; // only an allocation failure can land here
+            }
+
+            allocatedSize = size;
+            return true;
+        }
+
+        // NOTE: intentionally NOT `noexcept = default` -- see the identical note on ContinuousProfiler's
+        // constructor (clang computes the implicit spec from members that allocate, MSVC does not).
+        AllocationSampler() = default;
+
+        // Safety net for the case where managed code never calls Shutdown() explicitly: leaving an
+        // EventPipe session open costs the process the runtime's verbose GC event traffic forever.
+        // Shutdown() is idempotent (it zeroes _sessionId), so this is safe after an explicit call.
+        ~AllocationSampler() noexcept
+        {
+            Shutdown();
+        }
+
+        AllocationSampler(const AllocationSampler&) = delete;
+        AllocationSampler(AllocationSampler&&) = delete;
+        AllocationSampler& operator=(const AllocationSampler&) = delete;
+        AllocationSampler& operator=(AllocationSampler&&) = delete;
+
+    private:
+        using NameCache = NewRelic::Profiler::ThreadProfiler::NameCache;
+
+        // Pointer width of the process emitting the payload -- which is this process (see
+        // ParseAllocationTickPayload), so our own pointer size is the right one on x64 and x86 alike.
+        static constexpr size_t EtwPointerSize = sizeof(void*);
+
+        // Byte offset of the variable-length TypeName field: AllocationAmount(4) + AllocationKind(4) +
+        // InstanceId(2) + AllocationAmount64(8) + TypeId(ptr).
+        static constexpr size_t AllocationTickV4TypeNameStartByteIndex = 4 + 4 + 2 + 8 + EtwPointerSize;
+
+        // Total size of every FIXED field, i.e. the whole payload minus TypeName's bytes: the fields above
+        // plus HeapIndex(4) + Address(ptr) + AllocatedSize(8).
+        static constexpr size_t AllocationTickV4SizeWithoutTypeName = 4 + 4 + 2 + 8 + EtwPointerSize + 4 + EtwPointerSize + 8;
+
+        // Per-thread frame cap, mirroring ContinuousProfiler::MaxStackFramesSupported: the CLR walks
+        // leaf-first, so the frames captured before the cap are the leaf-most ones -- where the allocation
+        // actually happened. Bounds the walk on pathological/runaway recursion.
+        static constexpr size_t MaxStackFramesSupported = 128;
+
+        // Hard ceiling on one encoded allocation sample. Far smaller than ContinuousProfiler's per-tick
+        // all-threads batch because this is a single sample.
+        static constexpr size_t MaxAllocationBufferBytes = 64 * 1024;
+
+        // The sub-sampler's cycle length. maxSamplesPerMinute is a per-MINUTE budget, hence 60.
+        static constexpr uint32_t SubSampleCycleSeconds = 60;
+
+        // Bound on how long Shutdown() waits for EventPipeStopSession before abandoning it.
+        static constexpr uint32_t StopSessionTimeoutSeconds = 5;
+
+        // Rendezvous between Shutdown() and the detached thread that calls EventPipeStopSession. Held by
+        // shared_ptr on BOTH sides so an abandoned (timed-out) stop can still complete and signal without
+        // touching freed memory.
+        struct StopSessionSignal
+        {
+            std::mutex Mtx;
+            std::condition_variable Cv;
+            bool Done{ false };
+        };
+
+        // Context for the stack-walk callback: where to append FunctionIDs, and whether the walk was
+        // deliberately aborted at the frame cap (vs. having genuinely failed).
+        struct StackWalkContext
+        {
+            std::vector<FunctionID>* Ids;
+            bool Truncated;
+        };
+
+        // Per-frame snapshot callback for the CURRENT thread's walk. NOT running under a runtime suspend
+        // (nothing suspends anything on this path), so an ordinary vector push_back is safe here -- the
+        // zero-allocation discipline that is mandatory in ContinuousProfiler's callback is not load-bearing
+        // here, and this path fires orders of magnitude less often (sub-sampled) than the periodic one.
+        //
+        // Returning non-S_OK makes the CLR abort the walk (DoStackSnapshot then reports
+        // CORPROF_E_STACKSNAPSHOT_ABORTED); frames already recorded survive the abort.
+        static HRESULT __stdcall StaticAllocationStackFrameCallback(uintptr_t functionId, uintptr_t /* instructionPointer */,
+            uintptr_t /* frameInfo */, uint32_t /* contextSize */, uint8_t[] /* context */, void* clientData)
+        {
+            const HRESULT StackTooDeep = S_FALSE;
+
+            try
+            {
+                auto* walkContext = static_cast<StackWalkContext*>(clientData);
+                if (walkContext == nullptr || walkContext->Ids == nullptr)
+                {
+                    return StackTooDeep; // nothing to write into; stop walking rather than spin
+                }
+
+                if (walkContext->Ids->size() >= MaxStackFramesSupported)
+                {
+                    walkContext->Truncated = true;
+                    return StackTooDeep;
+                }
+
+                walkContext->Ids->push_back(static_cast<FunctionID>(functionId));
+            }
+            catch (...)
+            {
+                // Never let an exception cross back into the CLR's stack walker.
+            }
+
+            return S_OK;
+        }
+
+        // Resolve names and encode this ONE sample into its own batch, then publish it. Runs on the
+        // allocating thread with no lock held beyond _tickMutex: metadata calls, string building and
+        // allocation are all fine here (nothing is suspended). Never throws.
+        void EncodeAndPublish(ThreadID managedThreadId, const TraceContext& context, uint64_t allocatedSize,
+            const xstring_t& typeName, const std::vector<FunctionID>& functionIds) noexcept
+        {
+            try
+            {
+                // Not error-checked, exactly as in ContinuousProfiler::EnrichCapturedThreads: on failure
+                // the id stays 0 and ResolveOsThreadName treats that as "no name".
+                DWORD osThreadId = 0;
+                _corProfilerInfo->GetThreadInfo(managedThreadId, &osThreadId);
+
+                const auto nowNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count();
+
+                SampleBufferWriter writer(_encodeScratch, MaxAllocationBufferBytes);
+                writer.BeginBatch();
+                writer.WriteStartBatch(nowNanos);
+                writer.WriteStartAllocationSample();
+                writer.WriteThreadName(ResolveOsThreadName(osThreadId));
+                writer.WriteInt64Field(static_cast<int64_t>(osThreadId));
+                writer.WriteInt64Field(context.TraceIdHigh);
+                writer.WriteInt64Field(context.TraceIdLow);
+                writer.WriteInt64Field(context.SpanId);
+                writer.WriteInt64Field(nowNanos / 1000000); // sample timestamp, milliseconds
+                writer.WriteUInt64Field(allocatedSize);
+                writer.WriteStringField(typeName);
+
+                for (const auto functionId : functionIds)
+                {
+                    const xstring_t frame = _frameNames ? _frameNames->ResolveFrameName(functionId) : xstring_t();
+
+                    // Keep the encoded sample inside the fixed buffer instead of growing it without bound.
+                    // The reservation covers this frame's worst case (a fresh, uninterned definition) plus
+                    // the list terminator, so there is always room to close the frame list.
+                    const size_t chars = frame.size() < SampleBufferWriter::MaxStringChars
+                        ? frame.size() : SampleBufferWriter::MaxStringChars;
+                    if (!writer.WillFit(2 + 2 + (chars * 2) + 2))
+                    {
+                        LogTrace(L"AllocationSampler: sample buffer full mid-sample; truncating the frame list");
+                        break;
+                    }
+
+                    writer.WriteCodedFrameString(frame);
+                }
+
+                writer.WriteFrameListTerminator();
+                writer.WriteEndBatch();
+
+                // The OnAllocationTick gate normally catches saturation before any of the above is paid
+                // for, so reaching this drop means the queue filled while this sample was being built.
+                if (!_sampleBuffers.TryPublish(_encodeScratch))
+                {
+                    LogTrace(L"AllocationSampler: sample buffers full; dropping allocation sample");
+                }
+                _encodeScratch.clear();
+            }
+            catch (...)
+            {
+                LogTrace(L"AllocationSampler: exception encoding allocation sample");
+            }
+        }
+
+        // Interface to the CLR execution engine and metadata services, provided during profiler Initialize.
+        CComPtr<ICorProfilerInfo4> _corProfilerInfo;
+
+        // EventPipe session control. Null on .NET Framework and pre-.NET 5 CoreCLR, which is exactly the
+        // "allocation sampling unavailable" signal (see IsAvailable).
+        CComPtr<ICorProfilerInfo12> _corProfilerInfo12;
+
+        // Per-thread active trace context. NOT owned -- it is ContinuousProfiler's map, shared so that the
+        // single managed trace-context export feeds both samplers (see Init).
+        TraceContextMap* _traceContexts{ nullptr };
+
+        // Serializes the whole tick handler across app threads; every state member below it is
+        // single-threaded-only and protected by it. Only ever try_lock'd on the tick path.
+        std::mutex _tickMutex;
+
+        // Rate limiter. Created by Start() (so a restart re-paces from zero) under _tickMutex.
+        std::unique_ptr<AllocationSubSampler> _subSampler;
+
+        // Whether the handler should produce samples. Toggled by Start()/Stop()/Shutdown() and read on
+        // every tick, so it is the one member that is deliberately atomic rather than _tickMutex-guarded.
+        std::atomic<bool> _sessionActive{ false };
+
+        // The open EventPipe session, or 0 when none is open. Written only by Start()/Shutdown().
+        EVENTPIPE_SESSION _sessionId{ 0 };
+
+        // Type/method name cache. Declared BEFORE _frameNames, which borrows it, so reverse-order
+        // destruction tears the resolver down first.
+        NameCache _nameCache;
+
+        // Frame-name resolution over _nameCache. This sampler's own instance -- see the note in Init().
+        std::unique_ptr<FrameNameResolver> _frameNames;
+
+        // Scratch buffer the encoder writes into before the bytes are swapped into a filled queue slot.
+        std::vector<uint8_t> _encodeScratch;
+
+        // Two-slot FIFO hand-off to the managed reader (its own lock -- see SampleBufferQueue.h). Separate
+        // from ContinuousProfiler's queue so allocation samples and thread samples cannot starve each
+        // other, and so each is drained by its own managed reader.
+        SampleBufferQueue _sampleBuffers;
+    };
+}}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
@@ -18,6 +18,7 @@
 
 #include "../Logging/Logger.h"
 #include "../ThreadProfiler/namecache.h"
+#include "AllocationBatchAccumulator.h"
 #include "AllocationSubSampler.h"
 #include "FrameNameResolver.h"
 #include "OsThreadName.h"
@@ -52,6 +53,12 @@
 // immediately. That also makes this class the single producer SampleBufferQueue::HasFreeSlot assumes,
 // and -- because nothing is ever QUEUED on a try_lock -- it is what lets Shutdown() drain in-flight
 // handlers deterministically before the owner destroys this object.
+//
+// ONE CONSEQUENCE OF THAT WORTH SPELLING OUT: the managed drain thread also publishes, via the
+// pending-batch flush in ReadAllocationSamples. SampleBufferQueue's "check HasFreeSlot, then TryPublish
+// later" gating is only sound with a single producer, so that flush takes _tickMutex (try_lock) too.
+// Every publish in this class -- from a tick handler or from the drain -- happens under _tickMutex, and
+// anything added later that publishes must do the same.
 //
 // Lifecycle contract for the owner (Task 4): call Init() once, Start()/Stop() as configuration dictates,
 // and Shutdown() EXPLICITLY while the process is still healthy. The destructor is only a diagnostic
@@ -299,6 +306,25 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // teardown lives in Shutdown(). The runtime keeps raising AllocationTick, but the handler returns
         // on its first branch.
         //
+        // SEALS AND PUBLISHES a pending (still-accumulating) batch on the way out, so the samples a tick
+        // added since the last managed read are handed over instead of sitting in a buffer nothing will look
+        // at again until some later Start(). Doing that needs _tickMutex, taken here with a BLOCKING lock
+        // exactly as Start() and Shutdown() already take it -- the real constraint is not "lifecycle calls
+        // never take _tickMutex" (they do) but the LOCK ORDER: _lifecycleMutex then _tickMutex, never the
+        // reverse, and never a blocking _tickMutex acquisition from the tick or read paths (they try_lock,
+        // which is what keeps Shutdown()'s drain deterministic -- nothing can be QUEUED ahead of it there).
+        // Since every lifecycle call holds _lifecycleMutex first, they serialize with each other before ever
+        // reaching _tickMutex, so this cannot queue behind another lifecycle call's hold of it either.
+        //
+        // COST, WHICH IS NEW AND NO LONGER SHUTDOWN-ONLY: acquiring _tickMutex can wait out one in-flight
+        // tick's full walk + name resolution + encode (the same bounded wait Shutdown()'s drain has always
+        // paid, described there). Stop() is not only called at teardown -- the managed side calls it on a
+        // config-driven disable, a heap stop command, and on a send-failure backoff trip, and that last one
+        // runs on the DRAIN thread while holding the managed service's own lifecycle lock. So a backoff trip
+        // can now block the drain thread for about one sample's work. That is a millisecond-scale wait on a
+        // path that is already doing I/O, and the alternative is stranding the accumulated batch, but it is
+        // worth knowing before adding anything heavier to the tick path.
+        //
         // Takes _lifecycleMutex for the same reason Shutdown() does: a bare store racing an in-progress
         // Start() can be overwritten by that Start()'s own arm, so Stop() would return having silently not
         // stopped. No use-after-free risk in that case (just a stale-enabled sampler), but "Stop() stops"
@@ -310,6 +336,23 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             {
                 std::lock_guard<std::mutex> lifecycleLock(_lifecycleMutex);
                 _sessionActive.store(false);
+
+                // Disarmed first, so this runs with no further ticks able to append: take _tickMutex (which
+                // also waits out the one tick that may be in flight) and hand over whatever accumulated.
+                // Publishes only if the queue has room; if it does not, the batch simply stays pending, which
+                // is no worse than before.
+                std::lock_guard<std::mutex> tickLock(_tickMutex);
+                try
+                {
+                    _pendingBatch.FlushIfPending();
+                }
+                catch (...)
+                {
+                    // Sealing writes to the buffer, so a throw can leave a partial tail that must never be
+                    // published (see EncodeAndPublish's phase-2 catch).
+                    _pendingBatch.AbandonBatch();
+                    LogTrace(L"AllocationSampler: exception flushing the pending allocation batch on stop; discarded it");
+                }
             }
             catch (const std::exception&)
             {
@@ -334,7 +377,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         //
         // 2. USE-AFTER-FREE. Clearing _sessionActive does not evict a handler that already passed that
         //    gate: it may be mid stack-walk, holding _tickMutex, using _frameNames / _nameCache /
-        //    _encodeScratch / _sampleBuffers. If the owner destroys this object right after Shutdown()
+        //    _pendingBatch / _sampleBuffers. If the owner destroys this object right after Shutdown()
         //    returns, those members would vanish underneath that thread. So Shutdown() ends by taking
         //    _tickMutex with a BLOCKING lock: since the handler only ever try_locks, nothing can be queued
         //    behind it, and acquiring it means the last in-flight handler has finished. This matters most
@@ -396,6 +439,10 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // Drain the oldest filled sample buffer into the caller's array; the allocation-sample counterpart
         // of ContinuousProfiler::ReadThreadSamples, decoded by the same managed BufferParser. Returns the
         // number of bytes written (0 when nothing is ready or the args are invalid). Never throws.
+        //
+        // The managed drain calls this REPEATEDLY until it returns 0, so one drain collects every batch
+        // the sampler is holding -- which is what makes multi-batch accumulation useful rather than just
+        // deferred.
         int32_t ReadAllocationSamples(int32_t len, unsigned char* buf) noexcept
         {
             if (buf == nullptr || len <= 0)
@@ -405,6 +452,35 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 
             try
             {
+                // Hand over a batch still accumulating under back-pressure before reading, so a drain
+                // picks it up in THIS sweep. Without this it would sit unsealed until the next allocation
+                // tick noticed a free slot -- i.e. indefinitely once the workload stops allocating, losing
+                // the tail of every burst.
+                //
+                // try_lock, never lock: _tickMutex is held by tick handlers on customer threads, and
+                // Shutdown()'s drain depends on nothing ever QUEUEING on it. A lost race just defers the
+                // flush to the next read. The latch re-check under the lock keeps this off an object
+                // Shutdown() has already declared finished (and whose owner may be about to destroy it).
+                {
+                    std::unique_lock<std::mutex> flushLock(_tickMutex, std::try_to_lock);
+                    if (flushLock.owns_lock() && !_shutdownComplete.load())
+                    {
+                        // Caught HERE, not by the outer handler, for two reasons: a failed flush must not
+                        // cost the caller the batch that is already sitting in the queue (the read below
+                        // still has to happen), and sealing a batch is a write -- a throw mid-seal leaves a
+                        // partial tail that must never be published, so the batch is abandoned.
+                        try
+                        {
+                            _pendingBatch.FlushIfPending();
+                        }
+                        catch (...)
+                        {
+                            _pendingBatch.AbandonBatch();
+                            LogTrace(L"AllocationSampler: exception flushing the pending allocation batch; discarded it");
+                        }
+                    }
+                }
+
                 return _sampleBuffers.Read(len, buf);
             }
             catch (...)
@@ -471,12 +547,18 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
                     return; // malformed / unexpected-version payload -- drop it, never guess
                 }
 
-                // Back-pressure before the expensive part: if the managed reader has not drained, this
-                // sample has nowhere to go, so skip the walk/resolve/encode instead of throwing the result
-                // away at publish time. Safe as a gate because _tickMutex makes this the single producer.
-                if (!_sampleBuffers.HasFreeSlot())
+                // Back-pressure before the expensive part -- but note what this gate does NOT test any
+                // more. "Both queue slots are full" is no longer a reason to drop a tick: the sample joins
+                // the PENDING batch instead, and that batch is published as soon as the reader frees a
+                // slot (see AllocationBatchAccumulator, which exists because dropping here capped delivery
+                // at one sample per drain interval regardless of the configured budget). Only the
+                // genuinely saturated state -- no free slot AND a pending batch with no room left -- is
+                // still dropped before the walk, because there is then nowhere for the result to go.
+                // Safe as a gate because _tickMutex makes this the single producer.
+                if (!_pendingBatch.CanAcceptSample())
                 {
-                    LogTrace(L"AllocationSampler: sample buffers full; skipping tick (reader has not drained)");
+                    _pendingBatch.RecordDroppedSample();
+                    LogTrace(L"AllocationSampler: sample buffers and pending batch both full; skipping tick (reader has not drained)");
                     return;
                 }
 
@@ -681,9 +763,34 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // actually happened. Bounds the walk on pathological/runaway recursion.
         static constexpr size_t MaxStackFramesSupported = 128;
 
-        // Hard ceiling on one encoded allocation sample. Far smaller than ContinuousProfiler's per-tick
-        // all-threads batch because this is a single sample.
-        static constexpr size_t MaxAllocationBufferBytes = 64 * 1024;
+        // Hard ceiling on one encoded allocation BATCH -- which, since a batch can now accumulate many
+        // samples under back-pressure, is also what bounds how many samples one drain interval can deliver
+        // (the sampler holds at most three batches between drains: two SampleBufferQueue slots plus the
+        // pending one). So it is a throughput knob, not just a safety cap, and the per-sample cost that
+        // divides into it is the MARGINAL cost of appending sample N to an ALREADY-OPEN batch -- NOT the size
+        // of a standalone one-sample batch, and not the size of the OTLP profile built from it. Two regimes,
+        // because the per-batch frame-interning table makes the difference enormous:
+        //
+        //   * REPEATED stacks (one allocating loop -- the common shape, and what the integration test
+        //     exercises): every frame after its first sight is a 2-byte back-reference, so a sample costs
+        //     opcode(1) + threadName(2+) + 6 int64s(48) + typeName(~28) + 2 bytes/frame + terminator(2)
+        //     ~= 95-150 bytes. Enforced, not assumed: AllocationBatchAccumulatorTest's
+        //     MarginalBytesPerAppendedSample_StaysSmallForARepeatedStack asserts it. 64 KB would already
+        //     hold ~500 such samples.
+        //   * DISTINCT stacks (a service allocating from many call sites): each new frame costs a full inline
+        //     definition, 4 + 2*chars bytes, so ~20 fresh 60-char frames put a sample at ~2.5 KB. THIS is the
+        //     regime that sizes the cap: the shipped defaults (200 samples/minute at a 10 s drain) demand
+        //     ~33 samples per interval, which at 2.5 KB is ~83 KB -- more than 64 KB, i.e. the old value
+        //     could not deliver the DEFAULT budget for a diverse workload even with batching. 128 KB covers
+        //     ~50 such samples, and ~1300 in the repeated-stack regime.
+        //
+        // Cost of the headroom is bounded and only paid under load: the buffers are std::vectors that grow to
+        // what is actually written, so the worst case (3 x this) only materializes while genuinely
+        // backpressured on a diverse workload; steady state stays at a few KB. Still far below
+        // ContinuousProfiler's 4 MB per-tick all-threads batch, and well inside the managed drain buffer
+        // (DrainBufferSize, 4 MB). A budget large enough to exceed this cap is now visible rather than silent
+        // (Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped).
+        static constexpr size_t MaxAllocationBufferBytes = 128 * 1024;
 
         // The sub-sampler's cycle length. maxSamplesPerMinute is a per-MINUTE budget, hence 60.
         static constexpr uint32_t SubSampleCycleSeconds = 60;
@@ -795,67 +902,136 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             return S_OK;
         }
 
-        // Resolve names and encode this ONE sample into its own batch, then publish it. Runs on the
-        // allocating thread with no lock held beyond _tickMutex: metadata calls, string building and
-        // allocation are all fine here (nothing is suspended). Never throws.
+        // Encoded size of a length-prefixed string field: the big-endian int16 char count plus the
+        // UTF-16LE code units, with the encoder's own 512-char cap applied (see WriteString).
+        static size_t EncodedStringBytes(const xstring_t& value) noexcept
+        {
+            const size_t chars = value.size() < SampleBufferWriter::MaxStringChars
+                ? value.size() : SampleBufferWriter::MaxStringChars;
+            return 2 + (chars * 2);
+        }
+
+        // Encoded size of one frame-list entry at its WORST case: a 2-byte code plus a full inline string
+        // definition (what a frame not yet interned in this batch costs).
+        static size_t EncodedFrameBytes(const xstring_t& frame) noexcept
+        {
+            return 2 + EncodedStringBytes(frame);
+        }
+
+        // Encoded size of everything in an allocation sample except its frame list: the 0x08 opcode, the
+        // thread name, six int64 fields (os thread id, traceIdHigh, traceIdLow, spanId, timestamp,
+        // allocated size), the type name, and the frame-list terminator.
+        static size_t AllocationSampleFixedBytes(const xstring_t& threadName, const xstring_t& typeName) noexcept
+        {
+            return 1 + EncodedStringBytes(threadName) + (6 * 8) + EncodedStringBytes(typeName) + 2;
+        }
+
+        // Resolve names and encode this sample into the pending batch, publishing that batch when there is
+        // a queue slot for it (see AllocationBatchAccumulator for why a batch can span several ticks).
+        // Runs on the allocating thread with no lock held beyond _tickMutex: metadata calls, string
+        // building and allocation are all fine here (nothing is suspended). Never throws.
         void EncodeAndPublish(ThreadID managedThreadId, const TraceContext& context, uint64_t allocatedSize,
             const xstring_t& typeName, const std::vector<FunctionID>& functionIds) noexcept
         {
+            // PHASE 1 -- resolve, in its own try/catch, because NOTHING here touches the pending batch and
+            // this is where nearly all of this function's allocation happens (thread-name lookup, frame-name
+            // building, NameCache inserts, the scratch vector's growth). A bad_alloc here must cost ONE
+            // sample, exactly as it did before batching existed. Sharing the catch below would instead
+            // discard an accumulated batch of up to hundreds of already-encoded, perfectly good samples --
+            // the fix would have multiplied the blast radius of an allocation failure by the batch size.
+            DWORD osThreadId = 0;
+            int64_t nowNanos = 0;
+            xstring_t threadName;
             try
             {
                 // Not error-checked, exactly as in ContinuousProfiler::EnrichCapturedThreads: on failure
                 // the id stays 0 and ResolveOsThreadName treats that as "no name".
-                DWORD osThreadId = 0;
                 _corProfilerInfo->GetThreadInfo(managedThreadId, &osThreadId);
 
-                const auto nowNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count();
+                nowNanos = static_cast<int64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
 
-                SampleBufferWriter writer(_encodeScratch, MaxAllocationBufferBytes);
-                writer.BeginBatch();
-                writer.WriteStartBatch(nowNanos);
-                writer.WriteStartAllocationSample();
-                writer.WriteThreadName(ResolveOsThreadName(osThreadId));
-                writer.WriteInt64Field(static_cast<int64_t>(osThreadId));
-                writer.WriteInt64Field(context.TraceIdHigh);
-                writer.WriteInt64Field(context.TraceIdLow);
-                writer.WriteInt64Field(context.SpanId);
-                writer.WriteInt64Field(nowNanos / 1000000); // sample timestamp, milliseconds
-                writer.WriteUInt64Field(allocatedSize);
-                writer.WriteStringField(typeName);
+                threadName = ResolveOsThreadName(osThreadId);
 
+                // Resolve every frame name BEFORE touching the batch, into a reused scratch vector. That
+                // makes this sample's exact worst-case encoded size known up front, which is what lets the
+                // accumulator decide at a SAMPLE boundary whether the sample fits the open batch -- rather
+                // than starting to write it and truncating its frame list at the buffer's edge.
+                _frameScratch.clear();
                 for (const auto functionId : functionIds)
                 {
-                    const xstring_t frame = _frameNames ? _frameNames->ResolveFrameName(functionId) : xstring_t();
+                    _frameScratch.push_back(_frameNames ? _frameNames->ResolveFrameName(functionId) : xstring_t());
+                }
+            }
+            catch (...)
+            {
+                // One sample lost, the open batch untouched and still deliverable.
+                _pendingBatch.RecordDroppedSample();
+                LogTrace(L"AllocationSampler: exception resolving allocation sample names; dropping this sample only");
+                return;
+            }
 
-                    // Keep the encoded sample inside the fixed buffer instead of growing it without bound.
-                    // The reservation covers this frame's worst case (a fresh, uninterned definition) plus
-                    // the list terminator, so there is always room to close the frame list.
-                    const size_t chars = frame.size() < SampleBufferWriter::MaxStringChars
-                        ? frame.size() : SampleBufferWriter::MaxStringChars;
-                    if (!writer.WillFit(2 + 2 + (chars * 2) + 2))
+            // PHASE 2 -- encode into the batch. Every statement below either touches the batch or is
+            // arithmetic that cannot throw, so this catch can abandon unconditionally: there is no way to
+            // reach it without having been inside the encoder. (That is precisely why the resolve work was
+            // lifted out above rather than guarded by a "did we start writing?" flag -- the split makes the
+            // distinction structural instead of something a later edit could get wrong.)
+            try
+            {
+                size_t requiredBytes = AllocationSampleFixedBytes(threadName, typeName);
+                for (const auto& frame : _frameScratch)
+                {
+                    requiredBytes += EncodedFrameBytes(frame);
+                }
+
+                SampleBufferWriter* writer = _pendingBatch.BeginSample(requiredBytes, nowNanos);
+                if (writer == nullptr)
+                {
+                    // Saturated: no slot to publish into and no room left in the pending batch. Already
+                    // counted as a drop by the accumulator.
+                    LogTrace(L"AllocationSampler: sample buffers and pending batch both full; dropping allocation sample");
+                    return;
+                }
+
+                writer->WriteStartAllocationSample();
+                writer->WriteThreadName(threadName);
+                writer->WriteInt64Field(static_cast<int64_t>(osThreadId));
+                writer->WriteInt64Field(context.TraceIdHigh);
+                writer->WriteInt64Field(context.TraceIdLow);
+                writer->WriteInt64Field(context.SpanId);
+                writer->WriteInt64Field(nowNanos / 1000000); // sample timestamp, milliseconds
+                writer->WriteUInt64Field(allocatedSize);
+                writer->WriteStringField(typeName);
+
+                for (const auto& frame : _frameScratch)
+                {
+                    // Only reachable for a sample whose frames alone exceed the whole buffer cap -- the
+                    // accumulator has already guaranteed room for every other sample. The reservation
+                    // covers this frame's worst case (a fresh, uninterned definition), the list
+                    // terminator, and the batch's own closing records, so the batch can always be sealed.
+                    if (!writer->WillFit(EncodedFrameBytes(frame) + 2 + AllocationBatchAccumulator::BatchTailBytes))
                     {
                         LogTrace(L"AllocationSampler: sample buffer full mid-sample; truncating the frame list");
                         break;
                     }
 
-                    writer.WriteCodedFrameString(frame);
+                    writer->WriteCodedFrameString(frame);
                 }
 
-                writer.WriteFrameListTerminator();
-                writer.WriteEndBatch();
+                writer->WriteFrameListTerminator();
 
-                // The OnAllocationTick gate normally catches saturation before any of the above is paid
-                // for, so reaching this drop means the queue filled while this sample was being built.
-                if (!_sampleBuffers.TryPublish(_encodeScratch))
-                {
-                    LogTrace(L"AllocationSampler: sample buffers full; dropping allocation sample");
-                }
-                _encodeScratch.clear();
+                // Publishes now if a slot is free (the common case, byte-identical to the old
+                // one-sample-per-batch behavior); otherwise the batch stays open and the next tick appends
+                // to it instead of being dropped.
+                _pendingBatch.EndSample();
             }
             catch (...)
             {
-                LogTrace(L"AllocationSampler: exception encoding allocation sample");
+                // A throw can leave a HALF-WRITTEN record in the open batch, and the encoder cannot roll
+                // one back -- a partial record desynchronizes the managed decoder for every sample after
+                // it. Discarding the whole pending batch (counted as dropped) is the only safe response.
+                _pendingBatch.AbandonBatch();
+                LogTrace(L"AllocationSampler: exception encoding allocation sample; discarded the pending batch");
             }
         }
 
@@ -913,12 +1089,20 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // Frame-name resolution over _nameCache. This sampler's own instance -- see the note in Init().
         std::unique_ptr<FrameNameResolver> _frameNames;
 
-        // Scratch buffer the encoder writes into before the bytes are swapped into a filled queue slot.
-        std::vector<uint8_t> _encodeScratch;
+        // Resolved frame names for the sample being encoded. A member so the vector's storage is reused
+        // across ticks; resolution happens up front so the sample's exact encoded size is known before the
+        // batch is touched (see EncodeAndPublish).
+        std::vector<xstring_t> _frameScratch;
 
         // Two-slot FIFO hand-off to the managed reader (its own lock -- see SampleBufferQueue.h). Separate
         // from ContinuousProfiler's queue so allocation samples and thread samples cannot starve each
-        // other, and so each is drained by its own managed reader.
+        // other, and so each is drained by its own managed reader. Declared BEFORE _pendingBatch, which
+        // holds a reference to it.
         SampleBufferQueue _sampleBuffers;
+
+        // Owns the encode buffer, the batch's writer (one instance, so frame interning stays consistent
+        // across a multi-tick batch) and the accumulate/flush decision. Guarded by _tickMutex like every
+        // other state member here, including on the FlushIfPending call the drain path makes.
+        AllocationBatchAccumulator _pendingBatch{ _sampleBuffers, MaxAllocationBufferBytes };
     };
 }}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
@@ -88,6 +88,43 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // the correct failure mode for telemetry.
         static constexpr DWORD AllocationTickSupportedVersion = 4;
 
+        // Upper bound on an accepted sample budget, 300x the shipped default of 200/minute. Not a tuned
+        // performance limit -- it is the point past which the number stops meaning anything: each sample
+        // costs a stack walk plus frame-name resolution ON THE ALLOCATING APPLICATION THREAD, and the
+        // two-slot SampleBufferQueue plus the managed drain interval, not this cap, become the binding
+        // constraint well below 1000/second. Anything larger is indistinguishable from "unbounded".
+        static constexpr int32_t MaxSupportedSamplesPerMinute = 60000;
+
+        // Validates a sample budget as it arrives from managed code -- SIGNED, because that is how it
+        // crosses the P/Invoke boundary -- and converts it to the unsigned value Start() takes. Returns
+        // false when sampling must not be started at all.
+        //
+        // This exists because a blind static_cast<uint32_t> of a non-positive value is NOT a harmless
+        // no-op: -1 becomes 4294967295, AllocationSubSampler does not clamp its target, and its odds
+        // computation then saturates to >= 1 -- so every single AllocationTick (~10^5/second in an
+        // allocation-heavy app) would take the tick mutex, walk the stack, resolve frame names and encode,
+        // on customer threads. A configuration mistake would become a performance incident. Zero is
+        // rejected rather than treated as "sample nothing", because a session opened for a zero budget
+        // still makes the CLR generate every AllocationTick for no benefit.
+        //
+        // Lives here, next to the sub-sampler it protects, so the rule is unit-testable and cannot drift
+        // from the state it guards; the export layer only logs and forwards.
+        static bool TryNormalizeMaxSamplesPerMinute(int32_t requested, uint32_t& normalized) noexcept
+        {
+            if (requested <= 0)
+            {
+                normalized = 0;
+                return false;
+            }
+
+            // Local copy, same reason as StopSessionWithBoundedWait's: a conditional expression whose
+            // operands are both lvalues yields an lvalue, which risks odr-using this static constexpr
+            // member -- and C++11/14 (the Linux build) has no way to define one in a header-only class.
+            const int32_t ceiling = MaxSupportedSamplesPerMinute;
+            normalized = static_cast<uint32_t>(requested < ceiling ? requested : ceiling);
+            return true;
+        }
+
         // Dispatch predicate for CorProfilerCallbackImpl::EventPipeEventDelivered. Provider identity is
         // the caller's business (it holds the EVENTPIPE_PROVIDER handle for the session it created); this
         // only answers "is this the event we can parse?".
@@ -106,7 +143,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // allocation samples can only be correlated by reading the same instance.
         void Init(ICorProfilerInfo4* corProfilerInfo, TraceContextMap* sharedTraceContexts) noexcept
         {
-            LogInfo(L"Initializing AllocationSampler");
+            LogDebug(L"Initializing AllocationSampler");
 
             _corProfilerInfo = corProfilerInfo;
             _traceContexts = sharedTraceContexts;
@@ -117,13 +154,16 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             }
 
             HRESULT hr = corProfilerInfo->QueryInterface(__uuidof(ICorProfilerInfo12), (void**)&_corProfilerInfo12);
+            // Debug, not Info: every .NET Framework process would otherwise log two lines at Info about a
+            // feature it can never use. The lines still exist for diagnosing "why no allocation samples?",
+            // which is a debug-level question by then.
             if (SUCCEEDED(hr))
             {
-                LogInfo(L"AllocationSampler: ICorProfilerInfo12 available");
+                LogDebug(L"AllocationSampler: ICorProfilerInfo12 available");
             }
             else
             {
-                LogInfo(L"AllocationSampler: ICorProfilerInfo12 unavailable (.NET Framework or old CoreCLR) -- allocation sampling disabled");
+                LogDebug(L"AllocationSampler: ICorProfilerInfo12 unavailable (.NET Framework or old CoreCLR) -- allocation sampling disabled");
             }
 
             try
@@ -141,12 +181,32 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             }
         }
 
-        // Whether allocation sampling can work in this process at all (i.e. the runtime is new enough to
-        // expose the EventPipe profiling API). Lets the caller skip setting COR_PRF_HIGH_MONITOR_EVENT_PIPE
-        // and skip Start() entirely on .NET Framework.
+        // Whether allocation sampling can work in this process at all. Two independent preconditions:
+        //   1. the runtime exposes the EventPipe profiling API (ICorProfilerInfo12) -- absent on .NET
+        //      Framework and pre-.NET 5 CoreCLR; and
+        //   2. the profiler actually holds COR_PRF_HIGH_MONITOR_EVENT_PIPE, without which the runtime
+        //      never delivers EventPipeEventDelivered (see MarkUnavailable).
+        // The owner checks this before setting the mask bit and before calling Start().
         bool IsAvailable() const noexcept
         {
-            return _corProfilerInfo12 != nullptr;
+            return _corProfilerInfo12 != nullptr && !_eventDeliveryUnavailable.load();
+        }
+
+        // Called by the owner when it could NOT enable COR_PRF_HIGH_MONITOR_EVENT_PIPE (SetEventMask2
+        // rejected it, so the mask was re-applied without it). Without this, the sampler would have no way
+        // to know, and Start() would happily open an EventPipe session that makes the CLR generate
+        // AllocationTick events at full cost while EventPipeEventDelivered is never invoked for them --
+        // paying the entire overhead of the feature for exactly zero samples, which is strictly worse than
+        // not having it. Disarms permanently: it describes a fact about this process, fixed at startup.
+        //
+        // Deliberately does NOT clear _corProfilerInfo12: Stop()/Shutdown() still need that interface if a
+        // session somehow exists, and conflating "the interface is missing" with "the mask bit is missing"
+        // would make the two failure modes indistinguishable in the logs.
+        void MarkUnavailable() noexcept
+        {
+            _eventDeliveryUnavailable.store(true);
+            LogWarn(L"AllocationSampler: EventPipe event delivery is unavailable in this process; "
+                L"allocation sampling is disabled and Start() will be ignored");
         }
 
         // Open the AllocationTick EventPipe session and arm the handler. No-op (logged) when
@@ -166,9 +226,14 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // and resuming; Shutdown() is one-way.
         void Start(uint32_t maxSamplesPerMinute) noexcept
         {
-            if (!_corProfilerInfo12)
+            // Both preconditions, not just the interface: opening a session the runtime will never deliver
+            // events for costs the full AllocationTick generation overhead and yields nothing (see
+            // MarkUnavailable).
+            if (!IsAvailable())
             {
-                LogDebug(L"AllocationSampler: Start ignored; the EventPipe profiling API is unavailable in this runtime");
+                LogDebug(L"AllocationSampler: Start ignored; allocation sampling is unavailable in this process ",
+                    L"(either the runtime has no EventPipe profiling API, or the profiler could not subscribe "
+                    L"to EventPipe events -- see the startup logs for which)");
                 return;
             }
 
@@ -829,6 +894,12 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // that has been shut down stays shut down; Stop()/Start() is the pause/resume pair. Atomic because
         // it is also read on the (unlocked) destructor path.
         std::atomic<bool> _shutdownComplete{ false };
+
+        // Set once, at startup, by MarkUnavailable() when the owner could not enable
+        // COR_PRF_HIGH_MONITOR_EVENT_PIPE. Distinct from _shutdownComplete: that one means "this sampler
+        // is finished", this one means "this process can never deliver events to it". Atomic only because
+        // IsAvailable() is called from lifecycle threads other than the one that set it.
+        std::atomic<bool> _eventDeliveryUnavailable{ false };
 
         // The open EventPipe session, or 0 when none is open. Atomic, and claimed via exchange(0) on the
         // teardown paths, so two lifecycle callers can never both believe they own the same session (a

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSampler.h
@@ -35,17 +35,40 @@
 //   * The CLR raises AllocationTick roughly every 100 KB allocated -- ~10^5/second in an allocation-heavy
 //     app -- so the handler bails as early and as cheaply as possible. Order: session gate -> tick
 //     try-lock -> sub-sample -> payload parse -> back-pressure -> stack walk -> encode.
-//   * It NEVER blocks the app thread. Every lock it takes is a try_lock; a lost race costs one allocation
-//     sample, which is statistically irrelevant to a subsampled profile and is never a correctness issue.
+//   * The TICK PATH never blocks an app thread. Every lock it takes there is a try_lock; a lost race
+//     costs one allocation sample, which is statistically irrelevant to a subsampled profile and is never
+//     a correctness issue. (The LIFECYCLE calls -- Start/Stop/Shutdown -- do block, by design; they run
+//     on the agent's own threads. See Shutdown() for exactly how long it can wait and why.)
 //   * It NEVER throws. This is a COM callback boundary; an escaping exception would propagate into the
 //     runtime's EventPipe dispatch.
-//   * Session teardown must NEVER block agent shutdown -- see the Shutdown() comment.
+//   * Session teardown must never block agent shutdown INDEFINITELY -- the stop call is bounded by a
+//     timeout and then abandoned. It is not instantaneous, though: see the Shutdown() comment for the
+//     one in-flight sample it may still wait out.
 //
 // Concurrency model: allocation ticks arrive on MANY app threads at once, but almost all of this class's
 // state (the sub-sampler's RNG, the name cache, the frame resolver's scratch frame, the encode buffer)
 // is single-threaded-only. Rather than sprinkling locks over each, one try_lock'd _tickMutex makes the
 // whole handler mutually exclusive: exactly one thread handles a tick at a time and the rest return
-// immediately. That also makes this class the single producer SampleBufferQueue::HasFreeSlot assumes.
+// immediately. That also makes this class the single producer SampleBufferQueue::HasFreeSlot assumes,
+// and -- because nothing is ever QUEUED on a try_lock -- it is what lets Shutdown() drain in-flight
+// handlers deterministically before the owner destroys this object.
+//
+// Lifecycle contract for the owner (Task 4): call Init() once, Start()/Stop() as configuration dictates,
+// and Shutdown() EXPLICITLY while the process is still healthy. The destructor is only a diagnostic
+// safety net -- it cannot stop the session, because it may run under process/DLL teardown (see there).
+// Two guarantees, and they are different things:
+//   * MUTUAL EXCLUSION between concurrent Start/Stop/Shutdown calls -- they serialize internally on
+//     _lifecycleMutex, so the owner needs no lock of its own.
+//   * Shutdown() is TERMINAL. A Start() arriving after Shutdown() has returned (not just racing it) is
+//     refused rather than opening a fresh session on a torn-down object. Together with the in-flight drain
+//     Shutdown() performs, that is what makes "Shutdown() then destroy" safe without the owner having to
+//     prove no Start() is still in flight anywhere.
+// Note the deliberate divergence from ContinuousProfiler::Shutdown, which is restartable (it resets its
+// flags so a later Start() spins up a fresh worker thread). Here Shutdown() is one-way: pausing and
+// resuming is Stop()/Start(), and a genuine restart-after-shutdown would need a new AllocationSampler.
+// The asymmetry is intentional -- an EventPipe session cannot be reopened as cheaply or as safely as a
+// worker thread can be respawned -- but Task 4 should wire the managed enable/disable path to Stop()/
+// Start(), NOT to Shutdown()/Start().
 namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 {
     class AllocationSampler
@@ -130,6 +153,17 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // ICorProfilerInfo12 is unavailable. Idempotent: a second Start() after a Stop() re-arms the
         // handler and resets the sub-sampler WITHOUT opening a second session -- overwriting _sessionId
         // would orphan the first session (nothing could ever stop it) and double the runtime's event cost.
+        //
+        // Serialized against Shutdown() (and against another Start()) by _lifecycleMutex, so the
+        // check-then-open of the session below cannot interleave with a claim-then-stop. Lifecycle callers
+        // may block on that mutex; the tick path never touches it.
+        //
+        // REFUSES to arm once Shutdown() has completed. Mutual exclusion alone is not enough: a Start()
+        // that runs strictly AFTER Shutdown() returned would open a brand-new session and re-arm an object
+        // the owner considers dead and is about to destroy -- and no further Shutdown() is coming to close
+        // that session. The _shutdownComplete latch makes Shutdown() terminal, which is what lets the owner
+        // shut down without first proving that no Start() can still arrive. Use Stop()/Start() for pausing
+        // and resuming; Shutdown() is one-way.
         void Start(uint32_t maxSamplesPerMinute) noexcept
         {
             if (!_corProfilerInfo12)
@@ -140,6 +174,15 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 
             try
             {
+                std::lock_guard<std::mutex> lifecycleLock(_lifecycleMutex);
+
+                if (_shutdownComplete.load())
+                {
+                    LogDebug(L"AllocationSampler: Start ignored; Shutdown() has already run and is terminal "
+                        L"(use Stop()/Start() to pause and resume instead)");
+                    return;
+                }
+
                 {
                     // Held so a tick in flight can never observe a half-replaced sub-sampler. Start() runs
                     // on the agent's own thread, where a brief wait is fine (unlike the tick path, which
@@ -148,7 +191,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
                     _subSampler.reset(new AllocationSubSampler(maxSamplesPerMinute, SubSampleCycleSeconds));
                 }
 
-                if (_sessionId != 0)
+                if (_sessionId.load() != 0)
                 {
                     _sessionActive.store(true);
                     LogTrace(L"AllocationSampler: re-armed the existing EventPipe session");
@@ -175,7 +218,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 
                 // Publish the id BEFORE arming the handler so Shutdown() can always find a session that
                 // ticks may already be arriving on.
-                _sessionId = sessionId;
+                _sessionId.store(sessionId);
                 _sessionActive.store(true);
                 LogInfo(L"AllocationSampler: EventPipe session started");
             }
@@ -190,65 +233,98 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // semantics (which parks its worker thread rather than destroying it): the expensive/risky
         // teardown lives in Shutdown(). The runtime keeps raising AllocationTick, but the handler returns
         // on its first branch.
+        //
+        // Takes _lifecycleMutex for the same reason Shutdown() does: a bare store racing an in-progress
+        // Start() can be overwritten by that Start()'s own arm, so Stop() would return having silently not
+        // stopped. No use-after-free risk in that case (just a stale-enabled sampler), but "Stop() stops"
+        // is worth making true rather than documenting an exception to. Blocking here is fine -- this is a
+        // lifecycle call off any hot path -- though it does mean Stop() waits out a concurrent Shutdown().
         void Stop() noexcept
         {
-            _sessionActive.store(false);
-        }
-
-        // Close the EventPipe session. NEVER blocks agent shutdown indefinitely: EventPipeStopSession has
-        // to rendezvous with the runtime's own EventPipe machinery, so it is run on a DETACHED thread with
-        // a bounded wait. On timeout the call is abandoned (the detached thread keeps its own references
-        // alive, so nothing dangles) instead of hanging the agent's shutdown path behind the runtime.
-        //
-        // std::async is deliberately NOT used here: the std::future it returns has a BLOCKING destructor,
-        // so the "bounded wait" would be silently undone by the future going out of scope -- the exact
-        // hang this is written to avoid.
-        void Shutdown() noexcept
-        {
-            _sessionActive.store(false);
-
-            if (!_corProfilerInfo12 || _sessionId == 0)
-            {
-                return;
-            }
-
-            // Claim the session so a second Shutdown() (the destructor always calls it as a safety net)
-            // cannot stop the same session twice.
-            const EVENTPIPE_SESSION sessionId = _sessionId;
-            _sessionId = 0;
-
             try
             {
-                auto signal = std::make_shared<StopSessionSignal>();
-                CComPtr<ICorProfilerInfo12> info12 = _corProfilerInfo12; // keeps the interface alive for the detached thread
-
-                std::thread stopper([info12, sessionId, signal]() {
-                    info12->EventPipeStopSession(sessionId);
-                    {
-                        std::lock_guard<std::mutex> l(signal->Mtx);
-                        signal->Done = true;
-                    }
-                    signal->Cv.notify_all();
-                });
-                stopper.detach();
-
-                std::unique_lock<std::mutex> l(signal->Mtx);
-                const bool stopped = signal->Cv.wait_for(l, std::chrono::seconds(StopSessionTimeoutSeconds),
-                    [signal]() { return signal->Done; });
-
-                if (stopped)
-                {
-                    LogTrace(L"AllocationSampler: EventPipe session stopped");
-                }
-                else
-                {
-                    LogError(L"AllocationSampler: EventPipeStopSession did not return within ",
-                        static_cast<uint32_t>(StopSessionTimeoutSeconds), L"s; abandoning it rather than blocking shutdown");
-                }
+                std::lock_guard<std::mutex> lifecycleLock(_lifecycleMutex);
+                _sessionActive.store(false);
             }
             catch (const std::exception&)
             {
-                LogError(L"AllocationSampler: exception stopping the EventPipe session");
+                // A lock_guard on a valid mutex does not throw in practice; if it somehow did, fall back to
+                // the unsynchronized store so Stop() still disarms in the common (uncontended) case.
+                _sessionActive.store(false);
+            }
+        }
+
+        // Close the EventPipe session and DRAIN any tick handler still in flight. Must be called
+        // explicitly (the destructor cannot do this job -- see ~AllocationSampler) and only from a thread
+        // that is allowed to block for a bounded time, i.e. the agent's own shutdown path -- never from a
+        // tick handler.
+        //
+        // Two distinct hazards are handled here:
+        //
+        // 1. HANG. EventPipeStopSession has to rendezvous with the runtime's own EventPipe machinery, so it
+        //    runs on a DETACHED thread under a bounded wait. On timeout the call is abandoned (the detached
+        //    thread holds its own references, so nothing dangles) instead of hanging agent shutdown behind
+        //    the runtime. std::async is deliberately NOT used: the std::future it returns has a BLOCKING
+        //    destructor, which would silently undo the bounded wait -- the exact hang this avoids.
+        //
+        // 2. USE-AFTER-FREE. Clearing _sessionActive does not evict a handler that already passed that
+        //    gate: it may be mid stack-walk, holding _tickMutex, using _frameNames / _nameCache /
+        //    _encodeScratch / _sampleBuffers. If the owner destroys this object right after Shutdown()
+        //    returns, those members would vanish underneath that thread. So Shutdown() ends by taking
+        //    _tickMutex with a BLOCKING lock: since the handler only ever try_locks, nothing can be queued
+        //    behind it, and acquiring it means the last in-flight handler has finished. This matters most
+        //    in the timeout case above, where the session is still OPEN and ticks keep arriving -- they
+        //    then bounce off the _sessionActive gate (and off the re-check inside the lock) without
+        //    touching any member.
+        //
+        // The disarm below MUST happen under _lifecycleMutex, not before taking it. Clearing
+        // _sessionActive first and then blocking on the mutex lets a concurrent Start() win the lock,
+        // re-arm the handler, and return -- so this method would drain once and then hand back an object
+        // that is still armed, with ticks free to run a full walk/encode against members the owner is now
+        // entitled to destroy. That is hazard 2 all over again, entered through the lifecycle door.
+        void Shutdown() noexcept
+        {
+            try
+            {
+                std::lock_guard<std::mutex> lifecycleLock(_lifecycleMutex);
+
+                // Authoritative disarm + terminal latch, both set before anything else in the critical
+                // section. Any Start() racing this is either queued on this same mutex (and will then
+                // observe _shutdownComplete and refuse to arm) or already finished before we got here, so
+                // _sessionActive cannot be resurrected between this store and the drain below -- and no
+                // LATER Start() can resurrect it either. Setting the latch first also means the degraded
+                // paths below (a stop that times out, or an exception) still leave the object terminal.
+                _sessionActive.store(false);
+                _shutdownComplete.store(true);
+
+                // Claim the session so a concurrent/second Shutdown() cannot stop the same session twice.
+                const EVENTPIPE_SESSION sessionId = _sessionId.exchange(0);
+                if (_corProfilerInfo12 && sessionId != 0)
+                {
+                    StopSessionWithBoundedWait(sessionId);
+                }
+
+                // Drain: see hazard 2 above. This is NOT instantaneous and is not hard-bounded by a
+                // timeout: it can wait for one in-flight tick's full stack walk + name resolution +
+                // encode, and if the periodic sampler suspends the runtime while that handler is in its
+                // (unserialized) resolve/encode phase, for that suspend window too. It is bounded in
+                // practice -- one sample's work -- and is the price of handing back an object the owner can
+                // safely destroy.
+                std::lock_guard<std::mutex> drainLock(_tickMutex);
+            }
+            catch (const std::exception&)
+            {
+                // Reachable only if locking itself fails (a pathological std::system_error), i.e. before
+                // the stores above ran. Disarm and latch anyway: this is the path where the owner is about
+                // to destroy the object, so returning with the sampler still armed -- and still re-armable
+                // by a later Start() -- is the worst possible outcome. Mirrors Stop()'s fallback. NOTE: no
+                // drain happens on this path (the mutex that failed is the one guarding it), so a handler
+                // in flight at that instant is not waited for; nothing better is available if the runtime
+                // can no longer lock a mutex.
+                _sessionActive.store(false);
+                _shutdownComplete.store(true);
+                LogError(L"AllocationSampler: exception stopping the EventPipe session; the sampler is disarmed "
+                    L"but its EventPipe session (if any) could not be closed");
             }
         }
 
@@ -275,10 +351,21 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         }
 
         // Handle one AllocationTick. Runs ON THE ALLOCATING APP THREAD inside the runtime's EventPipe
-        // dispatch (see the class comment). Callers must have already filtered the event with
-        // IsAllocationTickEvent. Never throws, never blocks.
-        void OnAllocationTick(ULONG dataLen, LPCBYTE data) noexcept
+        // dispatch (see the class comment). Never throws, never blocks.
+        //
+        // Takes eventId/eventVersion and re-checks them itself rather than trusting the caller's filter.
+        // The check is two integer comparisons, and this is the ONE place in the feature where getting it
+        // wrong produces silently WRONG telemetry instead of none: ParseAllocationTickPayload reads
+        // AllocatedSize from the END of the buffer, so a v2/v3 payload parses "successfully" into a slice
+        // of the Address field. Defense in depth against a future caller or refactor that forgets to
+        // pre-filter.
+        void OnAllocationTick(DWORD eventId, DWORD eventVersion, ULONG dataLen, LPCBYTE data) noexcept
         {
+            if (!IsAllocationTickEvent(eventId, eventVersion))
+            {
+                return;
+            }
+
             if (!_sessionActive.load())
             {
                 return;
@@ -287,9 +374,18 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             try
             {
                 // Serialize tick handling across app threads (see the class comment). try_lock, never
-                // lock: a concurrent tick is dropped, not queued behind another thread's stack walk.
+                // lock: a concurrent tick is dropped, not queued behind another thread's stack walk. It is
+                // also what lets Shutdown() drain safely -- nothing is ever queued on this mutex.
                 std::unique_lock<std::mutex> tickLock(_tickMutex, std::try_to_lock);
                 if (!tickLock.owns_lock())
+                {
+                    return;
+                }
+
+                // Re-check under the lock: Stop()/Shutdown() may have fired between the gate above and
+                // acquiring the mutex, and past this point the handler touches shared state that Shutdown()
+                // is entitled to consider quiesced.
+                if (!_sessionActive.load())
                 {
                     return;
                 }
@@ -447,12 +543,52 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         // constructor (clang computes the implicit spec from members that allocate, MSVC does not).
         AllocationSampler() = default;
 
-        // Safety net for the case where managed code never calls Shutdown() explicitly: leaving an
-        // EventPipe session open costs the process the runtime's verbose GC event traffic forever.
-        // Shutdown() is idempotent (it zeroes _sessionId), so this is safe after an explicit call.
+        // TEARDOWN-SAFE, and deliberately NOT a call to Shutdown().
+        //
+        // This destructor can run while the CLR/loader is tearing the process down (DLL_PROCESS_DETACH, or
+        // after ExitProcess has already terminated every other thread), where Shutdown()'s machinery is not
+        // merely slow but wrong:
+        //   * Creating a thread under the loader lock is illegal, and a thread created during
+        //     DLL_PROCESS_DETACH cannot even begin to run until DllMain returns -- so the stopper thread
+        //     could never reach EventPipeStopSession and the bounded wait would be GUARANTEED to burn its
+        //     full timeout. Same outcome after ExitProcess: the other threads are already gone.
+        //   * Calling EventPipeStopSession inline is no better -- it rendezvouses with runtime threads that
+        //     may no longer exist.
+        //   * Blocking on _tickMutex is unsafe too: a thread terminated by ExitProcess while holding it
+        //     would never release it, deadlocking process exit.
+        // So this path is INSTANT: no thread, no timed wait, no blocking lock. The session (if any) is
+        // simply abandoned -- it dies with the process, which is the only scenario this path can be in.
+        //
+        // Consequence: Task 4's owner MUST call Shutdown() explicitly while the process is still healthy.
+        // Reaching the log line below means that did not happen.
+        //
+        // Residual, knowingly accepted: the LogError calls below take the global logger's mutex, which is
+        // the same class of hazard this path avoids elsewhere (a thread killed mid-teardown while holding
+        // that mutex would hang us here). They are kept because this is the only signal that Shutdown()
+        // was skipped, and because ContinuousProfiler's own destructor already logs on this same path --
+        // so it is pre-existing precedent, not a new risk. It is NOT fully solved; if teardown hangs are
+        // ever observed here, dropping these two lines is the fix.
         ~AllocationSampler() noexcept
         {
-            Shutdown();
+            // Disarm and latch (no lock -- see above; a Start() racing destruction is already unrecoverable,
+            // but the latch means one that merely queued behind us cannot arm a half-destroyed object).
+            _sessionActive.store(false);
+            _shutdownComplete.store(true);
+
+            if (_sessionId.exchange(0) != 0)
+            {
+                LogError(L"AllocationSampler: destroyed with an EventPipe session still open -- Shutdown() was never "
+                    L"called. Abandoning the session instead of stopping it, because this path may be running under "
+                    L"process/DLL teardown where stopping it cannot succeed and would hang.");
+            }
+
+            // Best-effort drain only (try_lock, never block -- see above). Under normal teardown no tick
+            // can be in flight; if one somehow is, there is nothing safe left to do about it here.
+            std::unique_lock<std::mutex> drainLock(_tickMutex, std::try_to_lock);
+            if (!drainLock.owns_lock())
+            {
+                LogError(L"AllocationSampler: destroyed while an allocation tick was still in flight");
+            }
         }
 
         AllocationSampler(const AllocationSampler&) = delete;
@@ -499,6 +635,56 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             std::condition_variable Cv;
             bool Done{ false };
         };
+
+        // Run EventPipeStopSession on a detached thread and wait a bounded time for it. Called only from
+        // the explicit Shutdown() path (never the destructor -- see ~AllocationSampler for why). The
+        // detached thread holds its own CComPtr + shared signal, so abandoning it on timeout dangles
+        // nothing.
+        void StopSessionWithBoundedWait(EVENTPIPE_SESSION sessionId) noexcept
+        {
+            try
+            {
+                auto signal = std::make_shared<StopSessionSignal>();
+                CComPtr<ICorProfilerInfo12> info12 = _corProfilerInfo12; // keeps the interface alive for the detached thread
+
+                std::thread stopper([info12, sessionId, signal]() {
+                    info12->EventPipeStopSession(sessionId);
+                    {
+                        std::lock_guard<std::mutex> l(signal->Mtx);
+                        signal->Done = true;
+                    }
+                    signal->Cv.notify_all();
+                });
+                stopper.detach();
+
+                std::unique_lock<std::mutex> l(signal->Mtx);
+                // Copied into a local on purpose. std::chrono::duration's converting constructor takes its
+                // argument by CONST REFERENCE, which odr-uses StopSessionTimeoutSeconds -- and the Linux
+                // build is C++11/14, where a static constexpr member that is odr-used needs an out-of-line
+                // definition no header-only class can provide (there are no inline variables before C++17).
+                // Passing a local avoids that: MSVC elides it either way, clang would otherwise leave an
+                // undefined symbol in libNewRelicProfiler.so that only surfaces at load time.
+                const uint32_t stopTimeoutSeconds = StopSessionTimeoutSeconds;
+                const bool stopped = signal->Cv.wait_for(l, std::chrono::seconds(stopTimeoutSeconds),
+                    [signal]() { return signal->Done; });
+
+                if (stopped)
+                {
+                    LogTrace(L"AllocationSampler: EventPipe session stopped");
+                }
+                else
+                {
+                    LogError(L"AllocationSampler: EventPipeStopSession did not return within ",
+                        static_cast<uint32_t>(StopSessionTimeoutSeconds), L"s; abandoning it rather than blocking "
+                        L"shutdown. The session stays open, so ticks may keep arriving -- they are gated off by "
+                        L"_sessionActive and cannot touch sampler state.");
+                }
+            }
+            catch (const std::exception&)
+            {
+                LogError(L"AllocationSampler: exception stopping the EventPipe session");
+            }
+        }
 
         // Context for the stack-walk callback: where to append FunctionIDs, and whether the walk was
         // deliberately aborted at the frame cap (vs. having genuinely failed).
@@ -620,18 +806,34 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         TraceContextMap* _traceContexts{ nullptr };
 
         // Serializes the whole tick handler across app threads; every state member below it is
-        // single-threaded-only and protected by it. Only ever try_lock'd on the tick path.
+        // single-threaded-only and protected by it. Only ever try_lock'd on the tick path (which is what
+        // both keeps app threads unblocked and lets Shutdown() drain deterministically).
         std::mutex _tickMutex;
+
+        // Serializes session lifecycle (Start/Shutdown) so a check-then-open can never interleave with a
+        // claim-then-stop. Taken ONLY by lifecycle callers, which are allowed to block; never by the tick
+        // path, and never by the destructor (blocking there could deadlock process exit).
+        std::mutex _lifecycleMutex;
 
         // Rate limiter. Created by Start() (so a restart re-paces from zero) under _tickMutex.
         std::unique_ptr<AllocationSubSampler> _subSampler;
 
         // Whether the handler should produce samples. Toggled by Start()/Stop()/Shutdown() and read on
-        // every tick, so it is the one member that is deliberately atomic rather than _tickMutex-guarded.
+        // every tick before any lock is taken, so it is atomic rather than _tickMutex-guarded. It is the
+        // gate that makes a post-Shutdown tick harmless (it returns before touching any other member).
         std::atomic<bool> _sessionActive{ false };
 
-        // The open EventPipe session, or 0 when none is open. Written only by Start()/Shutdown().
-        EVENTPIPE_SESSION _sessionId{ 0 };
+        // One-way latch set by Shutdown() (and the destructor) under _lifecycleMutex. Once true, Start()
+        // refuses to arm, so Shutdown() is TERMINAL rather than merely momentary: no later Start() can
+        // open a fresh session on an object its owner has already torn down. Never cleared -- a sampler
+        // that has been shut down stays shut down; Stop()/Start() is the pause/resume pair. Atomic because
+        // it is also read on the (unlocked) destructor path.
+        std::atomic<bool> _shutdownComplete{ false };
+
+        // The open EventPipe session, or 0 when none is open. Atomic, and claimed via exchange(0) on the
+        // teardown paths, so two lifecycle callers can never both believe they own the same session (a
+        // double EventPipeStopSession) nor both open one (an orphaned session nothing can ever stop).
+        std::atomic<EVENTPIPE_SESSION> _sessionId{ 0 };
 
         // Type/method name cache. Declared BEFORE _frameNames, which borrows it, so reverse-order
         // destruction tears the resolver down first.

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSubSampler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/AllocationSubSampler.h
@@ -1,0 +1,120 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <random>
+
+// Ports OTel's cycle-based allocation-tick sub-sampler: instead of true reservoir sampling (which
+// needs to know N in advance), each tick rolls a "die" whose odds are derived from how many samples
+// are still wanted this cycle vs. how many ticks the PREVIOUS cycle saw. Startup pacing (the first
+// few cycles) spaces samples out rather than letting them cluster at the very start of cycle 1.
+namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
+{
+    class AllocationSubSampler
+    {
+    private:
+        using Clock = std::chrono::steady_clock;
+
+    public:
+        AllocationSubSampler(uint32_t targetPerCycle, uint32_t cycleSeconds) noexcept
+            : _targetPerCycle(targetPerCycle), _cycleSeconds(cycleSeconds),
+              _cycleStart(Clock::now()), _rng(InitializeRng()),
+              _clockFunc([]() { return Clock::now(); })
+        {
+        }
+
+        // Allows tests to inject a custom clock function for deterministic cycle-boundary testing.
+        void SetClockFunction(std::function<std::chrono::steady_clock::time_point()> clockFunc) noexcept
+        {
+            _clockFunc = clockFunc;
+        }
+
+        // Call once per AllocationTick, BEFORE any stack walk. Returns true if this tick should be
+        // captured. Never throws, never blocks, never allocates on the heap (uses a stack-local
+        // uniform_real_distribution -- no dynamic state beyond the member RNG).
+        bool ShouldSample() noexcept
+        {
+            MaybeRollCycle();
+
+            ++_ticksThisCycle;
+
+            if (_targetPerCycle == 0)
+            {
+                return false;
+            }
+
+            if (_sampledThisCycle >= _targetPerCycle)
+            {
+                return false;
+            }
+
+            // Odds based on the LAST cycle's total tick count (0 on the very first cycle -> pace
+            // conservatively instead of sampling everything until the first real estimate exists).
+            const uint64_t estimatedTotal = _lastCycleTicks > 0 ? _lastCycleTicks : StartupPacedEstimate();
+            const uint32_t remaining = _targetPerCycle - _sampledThisCycle;
+            const double odds = estimatedTotal > 0
+                ? (static_cast<double>(remaining) / static_cast<double>(estimatedTotal))
+                : 1.0;
+
+            std::uniform_real_distribution<double> dist(0.0, 1.0);
+            if (dist(_rng) <= odds)
+            {
+                ++_sampledThisCycle;
+                return true;
+            }
+            return false;
+        }
+
+    private:
+        // Safely initialize the RNG, falling back to a deterministic seed if std::random_device
+        // throws (which can happen in restricted/sandboxed environments).
+        static std::mt19937 InitializeRng() noexcept
+        {
+            try
+            {
+                std::random_device rd;
+                return std::mt19937(rd());
+            }
+            catch (...)
+            {
+                // Fallback: use steady_clock ticks as seed for deterministic initialization.
+                // This ensures the constructor is truly noexcept and never crashes the app,
+                // even in entropy-starved or sandboxed environments.
+                return std::mt19937(static_cast<uint32_t>(
+                    std::chrono::steady_clock::now().time_since_epoch().count() & 0xFFFFFFFFULL));
+            }
+        }
+
+        // First few cycles have no _lastCycleTicks history yet; assume a large-ish tick volume so we
+        // don't accidentally sample everything in cycle 1 (matches OTel's startup-pacing intent).
+        uint64_t StartupPacedEstimate() const noexcept
+        {
+            return static_cast<uint64_t>(_targetPerCycle) * 1000;
+        }
+
+        void MaybeRollCycle() noexcept
+        {
+            const auto now = _clockFunc();
+            if (std::chrono::duration_cast<std::chrono::seconds>(now - _cycleStart).count() >= _cycleSeconds)
+            {
+                _lastCycleTicks = _ticksThisCycle;
+                _ticksThisCycle = 0;
+                _sampledThisCycle = 0;
+                _cycleStart = now;
+            }
+        }
+
+        uint32_t _targetPerCycle;
+        uint32_t _cycleSeconds;
+        Clock::time_point _cycleStart;
+        uint64_t _ticksThisCycle{ 0 };
+        uint64_t _lastCycleTicks{ 0 };
+        uint32_t _sampledThisCycle{ 0 };
+        std::mt19937 _rng;
+        std::function<Clock::time_point()> _clockFunc;
+    };
+}}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/ContinuousProfiler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/ContinuousProfiler.h
@@ -32,9 +32,8 @@
 
 #include "../Logging/Logger.h"
 #include "../ThreadProfiler/namecache.h"
-#include "../SignatureParser/SignatureParser.h"
-#include "../SignatureParser/SignatureFormatting.h"
-#include "../Profiler/CorTokenResolver.h"
+#include "FrameNameResolver.h"
+#include "OsThreadName.h"
 #include "SampleBufferQueue.h"
 #include "SampleBufferWriter.h"
 #include "SuspendMutex.h"
@@ -84,6 +83,19 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             HRESULT corProfilerInfoInitResult = corProfilerInfo->QueryInterface(__uuidof(ICorProfilerInfo10), (void**)&_corProfilerInfo10);
             if (SUCCEEDED(corProfilerInfoInitResult)) {
                 LogInfo(L"CP: ICorProfilerInfo10 available");
+            }
+
+            // The name resolver needs the (now-known) ICorProfilerInfo4, so it is created here rather than
+            // at construction. It borrows _nameCache, which is declared ahead of it and therefore outlives
+            // it. Created before any thread exists, so no lock is needed around this store; the sampling
+            // thread only reads it, and only from Start() onwards.
+            try
+            {
+                _frameNames.reset(new FrameNameResolver(_nameCache, corProfilerInfo));
+            }
+            catch (const std::exception&)
+            {
+                LogError(L"CP: failed to create the frame name resolver; sampling will be skipped");
             }
         }
 
@@ -243,11 +255,13 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 
     private:
         // Reuse the ThreadProfiler's preallocated name-cache machinery verbatim (same suspend-safe
-        // constraints apply): NameCache, the prealloc name buffers, and the type/method name holder.
+        // constraints apply). The prealloc name buffers, the type/method name holder and the frame struct
+        // that holds them now live with the name resolution they exist for -- see FrameNameResolver.h.
         using NameCache = NewRelic::Profiler::ThreadProfiler::NameCache;
-        using TypeAndMethodNames = NewRelic::Profiler::ThreadProfiler::TypeAndMethodNames;
-        using PreallocTypeName = NewRelic::Profiler::ThreadProfiler::PreallocTypeName;
-        using PreallocMethodName = NewRelic::Profiler::ThreadProfiler::PreallocMethodName;
+
+        // The preallocated per-frame walk slot. Owned by FrameNameResolver (it is that class's scratch
+        // type); the walk buffer below is an array of them.
+        using StackFrame = FrameNameResolver::StackFrame;
 
         // How many stack frames we support per thread. Walking stops (keeping the leaf-most frames) beyond
         // this; see StaticStackFrameCallback. Deliberately NOT ThreadProfiler's 1337 -- that value was
@@ -260,38 +274,6 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
 
         // A guess at how many threads we will see; used to reserve the per-tick capture vector.
         static constexpr size_t ThreadCountForReservation = 100;
-
-        // Upper bound on a captured method-signature blob. Signatures larger than this fall back to a
-        // name-only frame (no parameter list) rather than allocating in the snapshot callback.
-        static constexpr size_t MaxSigBlobBytes = 256;
-
-        // Defensive bound on the nested-type enclosing-chain walk in QualifyNestedTypeName. Real nesting is
-        // shallow (a handful of levels at most); this only stops a pathological or corrupt-metadata loop.
-        static constexpr size_t MaxTypeNestingDepth = 16;
-
-        // One preallocated stack frame. All name storage is preallocated so the snapshot callback never
-        // allocates. Mirrors ThreadProfiler::StackFrame (ThreadProfiler.h:290-302).
-        struct StackFrame
-        {
-            FunctionID functionId{};
-            // Defining module of functionId. Half of the type-name cache key: an mdTypeDef token is only
-            // unique within its own module (see namecache.h).
-            ModuleID moduleId{};
-            mdTypeDef typeDef{};
-            PreallocTypeName typeName{};
-            PreallocMethodName methodName{};
-
-            // Raw COR method-signature blob captured under suspend (zero-alloc memcpy); parsed + formatted
-            // into the method name during the post-walk fold. sigBlobLength == 0 means "no signature".
-            std::array<uint8_t, MaxSigBlobBytes> sigBlob{};
-            uint32_t sigBlobLength{};
-
-            StackFrame() = default;
-            StackFrame(const StackFrame&) = delete;
-            StackFrame(StackFrame&&) = delete;
-            StackFrame& operator=(const StackFrame&) = delete;
-            StackFrame& operator=(StackFrame&&) = delete;
-        };
 
         // Preallocated array of frames -- avoids dynamic allocation during the walk
         // (mirror ThreadProfiler.h:305).
@@ -758,7 +740,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
                 _corProfilerInfo->GetThreadInfo(thread.ManagedThreadId, &osThreadId);
                 thread.OsThreadId = osThreadId;
 
-                thread.ThreadName = ResolveThreadName(thread.OsThreadId);
+                thread.ThreadName = ResolveOsThreadName(thread.OsThreadId);
 
                 // On-CPU classification: a thread is on-CPU this tick if its cumulative CPU time grew
                 // since the last tick's baseline. No baseline yet (first tick this thread was seen, or
@@ -776,67 +758,8 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             return withContext;
         }
 
-        // Resolve an OS thread's name (empty string when it has none). Windows: GetThreadDescription on a
-        // handle opened for the OS thread id. Linux: read /proc/self/task/<tid>/comm (comm caps names at
-        // ~15 chars). Both paths run AFTER ResumeRuntime (they allocate / do syscalls) and never throw.
-        static xstring_t ResolveThreadName(DWORD osThreadId) noexcept
-        {
-            try
-            {
-#ifdef PAL_STDCPP_COMPAT
-                // Linux: pthread_getname_np needs a pthread_t we do not have for an arbitrary sampled OS
-                // thread id, so read the kernel-exposed comm file keyed directly by tid.
-                char path[64] = { 0 };
-                std::snprintf(path, sizeof(path), "/proc/self/task/%u/comm", static_cast<unsigned>(osThreadId));
-
-                std::FILE* f = std::fopen(path, "r");
-                if (f == nullptr)
-                {
-                    return xstring_t(); // thread gone or comm unreadable -> "".
-                }
-
-                char name[64] = { 0 };
-                const size_t read = std::fread(name, 1, sizeof(name) - 1, f);
-                std::fclose(f);
-
-                // comm is newline-terminated; trim the trailing '\n' and any tail.
-                size_t len = read;
-                while (len > 0 && (name[len - 1] == '\n' || name[len - 1] == '\r'))
-                {
-                    --len;
-                }
-                name[len] = '\0';
-
-                return ToWideString(name);
-#else
-                // Windows: GetThreadDescription (Win 10+). THREAD_QUERY_LIMITED_INFORMATION is the minimal
-                // right needed and succeeds for threads in our own process.
-                xstring_t result;
-                HANDLE hThread = ::OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, osThreadId);
-                if (hThread == nullptr)
-                {
-                    return xstring_t();
-                }
-
-                PWSTR description = nullptr;
-                const HRESULT hr = ::GetThreadDescription(hThread, &description);
-                if (SUCCEEDED(hr) && description != nullptr)
-                {
-                    result.assign(description);
-                    ::LocalFree(description);
-                }
-                ::CloseHandle(hThread);
-                return result;
-#endif
-            }
-            catch (...)
-            {
-                return xstring_t();
-            }
-        }
-
         // Cumulative CPU time (user+kernel) for an OS thread, in microseconds; -1 if unavailable (thread
-        // gone, or the read failed). Runs POST-resume only, same as ResolveThreadName -- both allocate /
+        // gone, or the read failed). Runs POST-resume only, same as ResolveOsThreadName -- both allocate /
         // do syscalls and are therefore not suspend-safe. Never throws.
         static int64_t ReadThreadCpuMicros(DWORD osThreadId) noexcept
         {
@@ -922,166 +845,17 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             }
         }
 
-        // POST-RESUME: resolve one FunctionID's type + method name (+ signature) into the name cache, if not
-        // already cached. Mirrors what the snapshot callback used to do under suspend, moved here so all
-        // metadata calls + allocation happen after ResumeRuntime. functionId==0 and unresolvable functions
-        // are left uncached (AssembleFrameName then emits "Native.Function Call" / "UnknownMethod(<id>)").
-        // Never throws.
-        void ResolveIntoCache(FunctionID functionId) noexcept
-        {
-            if (functionId == 0 || _nameCache.has_fid(functionId))
-                return;
-
-            try
-            {
-                CComPtr<IMetaDataImport2> metaData;
-                mdToken methodToken{};
-                if (FAILED(_corProfilerInfo->GetTokenAndMetaDataFromFunction(functionId, IID_IMetaDataImport2, (IUnknown**)&metaData, &methodToken)) || metaData == nullptr)
-                    return;
-
-                auto& scratch = _resolveScratch;
-                scratch.functionId = functionId;
-                scratch.moduleId = 0;
-                scratch.typeDef = 0;
-                scratch.sigBlobLength = 0;
-
-                auto& methodName = scratch.methodName;
-                PCCOR_SIGNATURE pSigBlob = nullptr;
-                ULONG sigBlobLength = 0;
-                if (FAILED(metaData->GetMethodProps(methodToken, &scratch.typeDef,
-                    &methodName.first.front(), (ULONG)methodName.first.size(), &methodName.second,
-                    nullptr, &pSigBlob, &sigBlobLength, nullptr, nullptr)))
-                    return;
-
-                if (scratch.typeDef == 0)
-                    return; // no owning type -> leave uncached (AssembleFrameName emits UnknownMethod(<id>))
-
-                // The defining module completes the type-name cache key -- an mdTypeDef token alone is only
-                // unique within its own module. One extra call per cache-missing function, not per frame.
-                ClassID classId = 0;
-                mdToken functionToken = 0;
-                if (FAILED(_corProfilerInfo->GetFunctionInfo(functionId, &classId, &scratch.moduleId, &functionToken)) || scratch.moduleId == 0)
-                    return;
-
-                if (pSigBlob != nullptr && sigBlobLength > 0 && sigBlobLength <= MaxSigBlobBytes)
-                {
-                    std::memcpy(scratch.sigBlob.data(), pSigBlob, sigBlobLength);
-                    scratch.sigBlobLength = sigBlobLength;
-                }
-
-                auto& typeName = scratch.typeName;
-                const auto cachedTypeName = _nameCache.typename_for(scratch.moduleId, scratch.typeDef);
-                if (cachedTypeName == TypeAndMethodNames::GetUnknownTypeName())
-                {
-                    DWORD typeFlags = 0;
-                    // Bail on failure rather than caching: typeName still holds the PREVIOUS resolve's name
-                    // (only functionId/moduleId/typeDef/sigBlobLength are reset per call), which would
-                    // otherwise be cached under this type's key. Uncached -> UnknownMethod(<id>).
-                    if (FAILED(metaData->GetTypeDefProps(scratch.typeDef, &typeName.first.front(), static_cast<ULONG>(typeName.first.size()), &typeName.second, &typeFlags, nullptr)))
-                        return;
-
-                    // GetTypeDefProps returns only the innermost name for a NESTED type (e.g. the compiler
-                    // closure "<>c"), dropping the declaring type -- unusable on its own since every type's
-                    // closures share that name. Walk the enclosing chain and rebuild "Outer+...+Inner" so the
-                    // frame is attributable. Cached per typeDef (below), so this runs once per type.
-                    if (IsTdNested(typeFlags))
-                    {
-                        QualifyNestedTypeName(metaData, scratch.typeDef, typeFlags, typeName);
-                    }
-                }
-                else
-                {
-                    wcscpy_s(typeName.first.data(), static_cast<ULONG>(typeName.first.size()), cachedTypeName->c_str());
-                }
-
-                AppendSignature(scratch); // fold the parameter list into the method name
-                _nameCache.insert(scratch.moduleId, scratch.functionId, scratch.typeDef, scratch.typeName, scratch.methodName);
-            }
-            catch (...)
-            {
-                // Leave uncached -> name-only / UnknownMethod(<id>). Never crash the sampler.
-            }
-        }
-
-        // POST-RESUME: rewrite a nested type's prealloc name from the bare innermost name GetTypeDefProps
-        // returns (e.g. the compiler closure "<>c") to the fully-qualified "Outer+...+Inner", walking the
-        // enclosing chain via GetNestedClassProps and prepending each encloser with '+' (the CLR nested-type
-        // separator, matching Function.h). Uses IsTdNested -- ALL nested visibilities -- so tdNestedPrivate/
-        // tdNestedAssembly compiler closures are qualified too (a tdNestedPublic|tdNestedFamily mask misses
-        // them). Bounded and never throws; on any failure the bare innermost name is left as-is.
-        void QualifyNestedTypeName(IMetaDataImport2* metaData, mdTypeDef typeDef, DWORD typeFlags, PreallocTypeName& out) noexcept
-        {
-            try
-            {
-                xstring_t qualified(out.first.data()); // innermost name GetTypeDefProps just wrote
-                mdTypeDef current = typeDef;
-                DWORD flags = typeFlags;
-
-                for (size_t depth = 0; IsTdNested(flags) && depth < MaxTypeNestingDepth; ++depth)
-                {
-                    mdTypeDef enclosing = 0;
-                    if (FAILED(metaData->GetNestedClassProps(current, &enclosing)) || enclosing == 0)
-                        break;
-
-                    ULONG nameLen = 0;
-                    metaData->GetTypeDefProps(enclosing, nullptr, 0, &nameLen, nullptr, nullptr);
-                    if (nameLen == 0)
-                        break;
-
-                    std::vector<xchar_t> buffer(nameLen);
-                    DWORD enclosingFlags = 0;
-                    if (FAILED(metaData->GetTypeDefProps(enclosing, buffer.data(), nameLen, &nameLen, &enclosingFlags, nullptr)))
-                        break;
-
-                    qualified = xstring_t(buffer.data()) + _X("+") + qualified;
-                    current = enclosing;
-                    flags = enclosingFlags;
-                }
-
-                // Copy back into the prealloc buffer, truncating to capacity. PreallocTypeName.second is the
-                // length INCLUDING the null terminator (NameCache::insert stores .second - 1 chars).
-                const size_t maxChars = out.first.size() - 1;
-                const size_t n = qualified.size() < maxChars ? qualified.size() : maxChars;
-                std::copy_n(qualified.c_str(), n, out.first.data());
-                out.first[n] = 0;
-                out.second = static_cast<ULONG>(n + 1);
-            }
-            catch (...)
-            {
-                // Leave the bare innermost name as-is; never crash the sampler.
-            }
-        }
-
-        // POST-RESUME: assemble one frame's fully-qualified name from the (now-populated) cache, mirroring
-        // the thread profiler's three-case handling: functionId==0 -> "Native.Function Call"; resolved ->
-        // "Type.Method(params)"; real-but-unresolvable -> "UnknownClass.UnknownMethod(<id>)".
-        xstring_t AssembleFrameName(FunctionID functionId)
-        {
-            if (functionId == 0)
-            {
-                // NOTE: the managed PprofProfileBuilder.NativeFrameName constant MUST match this exact
-                // string -- it keys profile.frame.type = "native" off it. Change both together.
-                return _X("Native.Function Call");
-            }
-            if (!_nameCache.has_fid(functionId))
-            {
-                xstring_t frameName(_X("UnknownClass.UnknownMethod("));
-                frameName.append(to_xstring((unsigned long)functionId));
-                frameName.append(_X(")"));
-                return frameName;
-            }
-            const auto& names = _nameCache[functionId];
-            xstring_t frameName(names.TypeName());
-            frameName.append(_X("."));
-            frameName.append(names.MethodName());
-            return frameName;
-        }
-
         // POST-RESUME: resolve every captured thread's FunctionID sequence into fully-qualified frame names.
-        // All metadata + signature + string work happens here, out of the suspend window. Runs on the
-        // sampling thread after ResumeRuntime.
+        // All metadata + signature + string work happens here, out of the suspend window (it is done by
+        // FrameNameResolver -- see that header for why none of it is suspend-safe). Runs on the sampling
+        // thread after ResumeRuntime.
         void ResolveCapturedFrames()
         {
+            if (!_frameNames)
+            {
+                return; // Init() failed to create the resolver; leave the frames empty rather than crash.
+            }
+
             for (size_t i = 0; i < _capturedCount; ++i)
             {
                 auto& thread = _capture[i];
@@ -1090,51 +864,8 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
                 // though this runs post-resume.
                 for (const auto functionId : thread.FunctionIds)
                 {
-                    ResolveIntoCache(functionId);
-                    thread.Frames.emplace_back(AssembleFrameName(functionId));
+                    thread.Frames.emplace_back(_frameNames->ResolveFrameName(functionId));
                 }
-            }
-        }
-
-        // Format the frame's captured method signature and append its parameter list to the method name,
-        // turning "Type.Method" into "Type.Method(System.Object, System.Int32)" -- OTel-shaped, so a
-        // customer migrating OTel->NR sees identical frames and overloads are distinguishable. Runs during
-        // post-resume resolution (ResolveIntoCache), once per newly-resolved functionId. Any failure (parse
-        // error, unresolvable token, would-overflow the name buffer) leaves the name-only method name --
-        // never throws, never crashes the sampler.
-        void AppendSignature(StackFrame& frame) noexcept
-        {
-            if (frame.sigBlobLength == 0)
-                return;
-
-            try
-            {
-                // Re-fetch the defining module's metadata reader so signature type tokens resolve in the
-                // correct scope. Cheap: this runs only for frames being inserted fresh into the cache.
-                CComPtr<IMetaDataImport2> metaData;
-                mdToken methodToken{};
-                if (FAILED(_corProfilerInfo->GetTokenAndMetaDataFromFunction(frame.functionId, IID_IMetaDataImport2, (IUnknown**)&metaData, &methodToken)) || metaData == nullptr)
-                    return;
-
-                ByteVector bytes(frame.sigBlob.begin(), frame.sigBlob.begin() + frame.sigBlobLength);
-                auto iterator = bytes.cbegin();
-                auto methodSignature = SignatureParser::SignatureParser::ParseMethodSignature(iterator, bytes.cend());
-                auto resolver = std::make_shared<CorTokenResolver>(metaData);
-                const auto params = SignatureParser::FormatParameterList(methodSignature, resolver); // "(...)"
-
-                // methodName.second is the current length INCLUDING the null terminator (NameCache convention).
-                auto& buffer = frame.methodName.first;
-                const size_t nameLength = frame.methodName.second == 0 ? 0 : frame.methodName.second - 1;
-                if (nameLength + params.size() + 1 <= buffer.size())
-                {
-                    std::copy(params.begin(), params.end(), buffer.begin() + nameLength);
-                    buffer[nameLength + params.size()] = _X('\0');
-                    frame.methodName.second = static_cast<ULONG>(nameLength + params.size() + 1);
-                }
-            }
-            catch (...)
-            {
-                // Keep the name-only method name.
             }
         }
 
@@ -1449,13 +1180,16 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         std::vector<ThreadID> _threadList;
 
         // Type/method name cache, reused across ticks. Populated post-resume in ResolveCapturedFrames
-        // (never touched inside the snapshot callback, which now only records FunctionIDs).
+        // (never touched inside the snapshot callback, which now only records FunctionIDs). Declared
+        // BEFORE _frameNames, which borrows it: reverse-order destruction then guarantees the resolver
+        // dies first.
         NameCache _nameCache;
 
-        // Reusable scratch frame for post-resume name/signature resolution (prealloc name + sig buffers),
-        // so ResolveIntoCache does not allocate ~4 KB per resolved function. Touched only by the sampling
-        // thread, after resume.
-        StackFrame _resolveScratch;
+        // Post-resume frame-name resolution (metadata + signature formatting into _nameCache). Created in
+        // Init() once ICorProfilerInfo4 is known. Touched only by the sampling thread, only after resume --
+        // it is not thread safe, which is also why AllocationSampler owns its own instance rather than
+        // sharing this one (see FrameNameResolver.h).
+        std::unique_ptr<FrameNameResolver> _frameNames;
 
         // Per-thread active trace context, written by app threads via Set/ResetTraceContext and read by
         // the sampler (by CLR ManagedThreadId) while the runtime is suspended. Lock-free + wait-free

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/ContinuousProfiler.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/ContinuousProfiler.h
@@ -230,6 +230,18 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             _agentWork.Decrement(CurrentManagedThreadId());
         }
 
+        // The per-thread trace-context map this sampler owns, for OTHER samplers to read from.
+        // AllocationSampler MUST use this instance rather than one of its own: there is a single managed
+        // trace-context export, and it writes here (via SetTraceContext above), so an allocation sample can
+        // only be correlated by reading the same map. Safe to share -- unlike the name cache, TraceContextMap
+        // is lock-free and wait-free by design (see its header), so concurrent readers on app threads and
+        // the sampling thread are exactly what it is built for. Never null; owned by this object, so it
+        // outlives any sampler the profiler callback holds alongside it.
+        TraceContextMap* SharedTraceContexts() noexcept
+        {
+            return &_traceContexts;
+        }
+
         // NOTE: intentionally NOT declared `noexcept = default`. clang/libstdc++ computes the implicit
         // default ctor's exception spec from the members (some -- e.g. the reused NameCache / vector
         // buffers -- allocate and are therefore not noexcept), so `noexcept = default` is a hard compile

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/FrameNameResolver.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/FrameNameResolver.h
@@ -1,0 +1,314 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <cor.h>
+#include <corprof.h>
+
+#include "../ThreadProfiler/namecache.h"
+#include "../SignatureParser/SignatureParser.h"
+#include "../SignatureParser/SignatureFormatting.h"
+#include "../Profiler/CorTokenResolver.h"
+
+// FrameNameResolver turns a captured FunctionID into the fully-qualified frame name the managed side
+// consumes ("Namespace.Type.Method(System.Int32)"), caching type/method names in a caller-owned
+// NameCache. It was extracted verbatim from ContinuousProfiler so BOTH samplers -- the timer-driven
+// thread sampler and the event-driven AllocationSampler -- share one implementation instead of two
+// copies of the same ~120 lines of metadata/signature handling.
+//
+// EVERYTHING HERE IS POST-RESUME ONLY. Every method allocates, takes metadata locks and/or makes
+// ICorProfilerInfo calls, so none of it may run while the runtime (or any app thread) is suspended --
+// that is the whole reason ContinuousProfiler defers name resolution until after ResumeRuntime.
+//
+// NOT THREAD SAFE, deliberately. It owns a ~4 KB reusable scratch frame and writes into a NameCache
+// that is itself documented as single-threaded (namecache.h: "even Get mutates"). Each sampler
+// therefore owns its OWN FrameNameResolver + NameCache and touches it from one thread at a time; they
+// are NOT shared across the sampling thread and app threads. Sharing one instance would mean two
+// threads mutating the same unordered_map/LRU list concurrently -- heap corruption, not just a stale
+// name -- and the alternative (a mutex) would let an app thread block behind the sampler thread
+// resolving a hundred threads' stacks. Duplicated cache entries are bounded (namecache.h caps each
+// map at 5000 LRU entries), which is a far cheaper price than either of those.
+namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
+{
+    class FrameNameResolver
+    {
+    public:
+        // Reuse the ThreadProfiler's preallocated name-cache machinery verbatim (same suspend-safe
+        // constraints apply): NameCache, the prealloc name buffers, and the type/method name holder.
+        using NameCache = NewRelic::Profiler::ThreadProfiler::NameCache;
+        using TypeAndMethodNames = NewRelic::Profiler::ThreadProfiler::TypeAndMethodNames;
+        using PreallocTypeName = NewRelic::Profiler::ThreadProfiler::PreallocTypeName;
+        using PreallocMethodName = NewRelic::Profiler::ThreadProfiler::PreallocMethodName;
+
+        // Upper bound on a captured method-signature blob. Signatures larger than this fall back to a
+        // name-only frame (no parameter list) rather than allocating in the snapshot callback.
+        static constexpr size_t MaxSigBlobBytes = 256;
+
+        // Defensive bound on the nested-type enclosing-chain walk in QualifyNestedTypeName. Real nesting is
+        // shallow (a handful of levels at most); this only stops a pathological or corrupt-metadata loop.
+        static constexpr size_t MaxTypeNestingDepth = 16;
+
+        // One preallocated stack frame. All name storage is preallocated so the snapshot callback never
+        // allocates. Mirrors ThreadProfiler::StackFrame (ThreadProfiler.h:290-302).
+        struct StackFrame
+        {
+            FunctionID functionId{};
+            // Defining module of functionId. Half of the type-name cache key: an mdTypeDef token is only
+            // unique within its own module (see namecache.h).
+            ModuleID moduleId{};
+            mdTypeDef typeDef{};
+            PreallocTypeName typeName{};
+            PreallocMethodName methodName{};
+
+            // Raw COR method-signature blob captured under suspend (zero-alloc memcpy); parsed + formatted
+            // into the method name during the post-walk fold. sigBlobLength == 0 means "no signature".
+            std::array<uint8_t, MaxSigBlobBytes> sigBlob{};
+            uint32_t sigBlobLength{};
+
+            StackFrame() = default;
+            StackFrame(const StackFrame&) = delete;
+            StackFrame(StackFrame&&) = delete;
+            StackFrame& operator=(const StackFrame&) = delete;
+            StackFrame& operator=(StackFrame&&) = delete;
+        };
+
+        // `nameCache` is borrowed, NOT owned -- it must outlive this resolver (both samplers declare it
+        // as a member ahead of the resolver, so destruction order guarantees that).
+        FrameNameResolver(NameCache& nameCache, ICorProfilerInfo4* corProfilerInfo)
+            : _nameCache(nameCache), _corProfilerInfo(corProfilerInfo)
+        {
+        }
+
+        // POST-RESUME: resolve (and cache) one FunctionID's fully-qualified frame name. The two-step
+        // resolve-then-assemble split is an implementation detail: a cache miss populates the cache, then
+        // the name is assembled from it. Never throws for a resolution failure -- an unresolvable function
+        // yields "Native.Function Call" / "UnknownClass.UnknownMethod(<id>)" instead.
+        xstring_t ResolveFrameName(FunctionID functionId)
+        {
+            ResolveIntoCache(functionId);
+            return AssembleFrameName(functionId);
+        }
+
+        FrameNameResolver(const FrameNameResolver&) = delete;
+        FrameNameResolver(FrameNameResolver&&) = delete;
+        FrameNameResolver& operator=(const FrameNameResolver&) = delete;
+        FrameNameResolver& operator=(FrameNameResolver&&) = delete;
+
+    private:
+        // POST-RESUME: resolve one FunctionID's type + method name (+ signature) into the name cache, if not
+        // already cached. Mirrors what the snapshot callback used to do under suspend, moved here so all
+        // metadata calls + allocation happen after ResumeRuntime. functionId==0 and unresolvable functions
+        // are left uncached (AssembleFrameName then emits "Native.Function Call" / "UnknownMethod(<id>)").
+        // Never throws.
+        void ResolveIntoCache(FunctionID functionId) noexcept
+        {
+            if (functionId == 0 || _nameCache.has_fid(functionId))
+                return;
+
+            try
+            {
+                CComPtr<IMetaDataImport2> metaData;
+                mdToken methodToken{};
+                if (FAILED(_corProfilerInfo->GetTokenAndMetaDataFromFunction(functionId, IID_IMetaDataImport2, (IUnknown**)&metaData, &methodToken)) || metaData == nullptr)
+                    return;
+
+                auto& scratch = _resolveScratch;
+                scratch.functionId = functionId;
+                scratch.moduleId = 0;
+                scratch.typeDef = 0;
+                scratch.sigBlobLength = 0;
+
+                auto& methodName = scratch.methodName;
+                PCCOR_SIGNATURE pSigBlob = nullptr;
+                ULONG sigBlobLength = 0;
+                if (FAILED(metaData->GetMethodProps(methodToken, &scratch.typeDef,
+                    &methodName.first.front(), (ULONG)methodName.first.size(), &methodName.second,
+                    nullptr, &pSigBlob, &sigBlobLength, nullptr, nullptr)))
+                    return;
+
+                if (scratch.typeDef == 0)
+                    return; // no owning type -> leave uncached (AssembleFrameName emits UnknownMethod(<id>))
+
+                // The defining module completes the type-name cache key -- an mdTypeDef token alone is only
+                // unique within its own module. One extra call per cache-missing function, not per frame.
+                ClassID classId = 0;
+                mdToken functionToken = 0;
+                if (FAILED(_corProfilerInfo->GetFunctionInfo(functionId, &classId, &scratch.moduleId, &functionToken)) || scratch.moduleId == 0)
+                    return;
+
+                if (pSigBlob != nullptr && sigBlobLength > 0 && sigBlobLength <= MaxSigBlobBytes)
+                {
+                    std::memcpy(scratch.sigBlob.data(), pSigBlob, sigBlobLength);
+                    scratch.sigBlobLength = sigBlobLength;
+                }
+
+                auto& typeName = scratch.typeName;
+                const auto cachedTypeName = _nameCache.typename_for(scratch.moduleId, scratch.typeDef);
+                if (cachedTypeName == TypeAndMethodNames::GetUnknownTypeName())
+                {
+                    DWORD typeFlags = 0;
+                    // Bail on failure rather than caching: typeName still holds the PREVIOUS resolve's name
+                    // (only functionId/moduleId/typeDef/sigBlobLength are reset per call), which would
+                    // otherwise be cached under this type's key. Uncached -> UnknownMethod(<id>).
+                    if (FAILED(metaData->GetTypeDefProps(scratch.typeDef, &typeName.first.front(), static_cast<ULONG>(typeName.first.size()), &typeName.second, &typeFlags, nullptr)))
+                        return;
+
+                    // GetTypeDefProps returns only the innermost name for a NESTED type (e.g. the compiler
+                    // closure "<>c"), dropping the declaring type -- unusable on its own since every type's
+                    // closures share that name. Walk the enclosing chain and rebuild "Outer+...+Inner" so the
+                    // frame is attributable. Cached per typeDef (below), so this runs once per type.
+                    if (IsTdNested(typeFlags))
+                    {
+                        QualifyNestedTypeName(metaData, scratch.typeDef, typeFlags, typeName);
+                    }
+                }
+                else
+                {
+                    wcscpy_s(typeName.first.data(), static_cast<ULONG>(typeName.first.size()), cachedTypeName->c_str());
+                }
+
+                AppendSignature(scratch); // fold the parameter list into the method name
+                _nameCache.insert(scratch.moduleId, scratch.functionId, scratch.typeDef, scratch.typeName, scratch.methodName);
+            }
+            catch (...)
+            {
+                // Leave uncached -> name-only / UnknownMethod(<id>). Never crash the sampler.
+            }
+        }
+
+        // POST-RESUME: rewrite a nested type's prealloc name from the bare innermost name GetTypeDefProps
+        // returns (e.g. the compiler closure "<>c") to the fully-qualified "Outer+...+Inner", walking the
+        // enclosing chain via GetNestedClassProps and prepending each encloser with '+' (the CLR nested-type
+        // separator, matching Function.h). Uses IsTdNested -- ALL nested visibilities -- so tdNestedPrivate/
+        // tdNestedAssembly compiler closures are qualified too (a tdNestedPublic|tdNestedFamily mask misses
+        // them). Bounded and never throws; on any failure the bare innermost name is left as-is.
+        void QualifyNestedTypeName(IMetaDataImport2* metaData, mdTypeDef typeDef, DWORD typeFlags, PreallocTypeName& out) noexcept
+        {
+            try
+            {
+                xstring_t qualified(out.first.data()); // innermost name GetTypeDefProps just wrote
+                mdTypeDef current = typeDef;
+                DWORD flags = typeFlags;
+
+                for (size_t depth = 0; IsTdNested(flags) && depth < MaxTypeNestingDepth; ++depth)
+                {
+                    mdTypeDef enclosing = 0;
+                    if (FAILED(metaData->GetNestedClassProps(current, &enclosing)) || enclosing == 0)
+                        break;
+
+                    ULONG nameLen = 0;
+                    metaData->GetTypeDefProps(enclosing, nullptr, 0, &nameLen, nullptr, nullptr);
+                    if (nameLen == 0)
+                        break;
+
+                    std::vector<xchar_t> buffer(nameLen);
+                    DWORD enclosingFlags = 0;
+                    if (FAILED(metaData->GetTypeDefProps(enclosing, buffer.data(), nameLen, &nameLen, &enclosingFlags, nullptr)))
+                        break;
+
+                    qualified = xstring_t(buffer.data()) + _X("+") + qualified;
+                    current = enclosing;
+                    flags = enclosingFlags;
+                }
+
+                // Copy back into the prealloc buffer, truncating to capacity. PreallocTypeName.second is the
+                // length INCLUDING the null terminator (NameCache::insert stores .second - 1 chars).
+                const size_t maxChars = out.first.size() - 1;
+                const size_t n = qualified.size() < maxChars ? qualified.size() : maxChars;
+                std::copy_n(qualified.c_str(), n, out.first.data());
+                out.first[n] = 0;
+                out.second = static_cast<ULONG>(n + 1);
+            }
+            catch (...)
+            {
+                // Leave the bare innermost name as-is; never crash the sampler.
+            }
+        }
+
+        // POST-RESUME: assemble one frame's fully-qualified name from the (now-populated) cache, mirroring
+        // the thread profiler's three-case handling: functionId==0 -> "Native.Function Call"; resolved ->
+        // "Type.Method(params)"; real-but-unresolvable -> "UnknownClass.UnknownMethod(<id>)".
+        xstring_t AssembleFrameName(FunctionID functionId)
+        {
+            if (functionId == 0)
+            {
+                // NOTE: the managed PprofProfileBuilder.NativeFrameName constant MUST match this exact
+                // string -- it keys profile.frame.type = "native" off it. Change both together.
+                return _X("Native.Function Call");
+            }
+            if (!_nameCache.has_fid(functionId))
+            {
+                xstring_t frameName(_X("UnknownClass.UnknownMethod("));
+                frameName.append(to_xstring((unsigned long)functionId));
+                frameName.append(_X(")"));
+                return frameName;
+            }
+            const auto& names = _nameCache[functionId];
+            xstring_t frameName(names.TypeName());
+            frameName.append(_X("."));
+            frameName.append(names.MethodName());
+            return frameName;
+        }
+
+        // Format the frame's captured method signature and append its parameter list to the method name,
+        // turning "Type.Method" into "Type.Method(System.Object, System.Int32)" -- OTel-shaped, so a
+        // customer migrating OTel->NR sees identical frames and overloads are distinguishable. Runs during
+        // post-resume resolution (ResolveIntoCache), once per newly-resolved functionId. Any failure (parse
+        // error, unresolvable token, would-overflow the name buffer) leaves the name-only method name --
+        // never throws, never crashes the sampler.
+        void AppendSignature(StackFrame& frame) noexcept
+        {
+            if (frame.sigBlobLength == 0)
+                return;
+
+            try
+            {
+                // Re-fetch the defining module's metadata reader so signature type tokens resolve in the
+                // correct scope. Cheap: this runs only for frames being inserted fresh into the cache.
+                CComPtr<IMetaDataImport2> metaData;
+                mdToken methodToken{};
+                if (FAILED(_corProfilerInfo->GetTokenAndMetaDataFromFunction(frame.functionId, IID_IMetaDataImport2, (IUnknown**)&metaData, &methodToken)) || metaData == nullptr)
+                    return;
+
+                ByteVector bytes(frame.sigBlob.begin(), frame.sigBlob.begin() + frame.sigBlobLength);
+                auto iterator = bytes.cbegin();
+                auto methodSignature = SignatureParser::SignatureParser::ParseMethodSignature(iterator, bytes.cend());
+                auto resolver = std::make_shared<CorTokenResolver>(metaData);
+                const auto params = SignatureParser::FormatParameterList(methodSignature, resolver); // "(...)"
+
+                // methodName.second is the current length INCLUDING the null terminator (NameCache convention).
+                auto& buffer = frame.methodName.first;
+                const size_t nameLength = frame.methodName.second == 0 ? 0 : frame.methodName.second - 1;
+                if (nameLength + params.size() + 1 <= buffer.size())
+                {
+                    std::copy(params.begin(), params.end(), buffer.begin() + nameLength);
+                    buffer[nameLength + params.size()] = _X('\0');
+                    frame.methodName.second = static_cast<ULONG>(nameLength + params.size() + 1);
+                }
+            }
+            catch (...)
+            {
+                // Keep the name-only method name.
+            }
+        }
+
+        // Type/method name cache, owned by the SAMPLER (not this resolver) and reused across samples.
+        NameCache& _nameCache;
+
+        // Interface to the CLR metadata services. Provided during profiler Initialize.
+        CComPtr<ICorProfilerInfo4> _corProfilerInfo;
+
+        // Reusable scratch frame for post-resume name/signature resolution (prealloc name + sig buffers),
+        // so ResolveIntoCache does not allocate ~4 KB per resolved function. Touched only by the owning
+        // sampler's thread (see the not-thread-safe note on this class).
+        StackFrame _resolveScratch;
+    };
+}}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/OsThreadName.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/OsThreadName.h
@@ -1,0 +1,83 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+
+#ifdef PAL_STDCPP_COMPAT
+// Linux: /proc/self/task/<tid>/comm is the OS-tid-keyed source of a thread's name (pthread_getname_np
+// needs a pthread_t, which we do not have for an arbitrary sampled OS thread id). Read AFTER resume.
+#include <cstdio>
+#include <unistd.h>
+#endif
+
+#include <cor.h>
+#include <corprof.h>
+
+#include "../Common/xplat.h"
+
+// Shared OS-thread-name lookup for the sampling paths. Extracted from ContinuousProfiler so the
+// event-driven AllocationSampler stamps thread names with the SAME platform code instead of a second
+// copy of it.
+namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
+{
+    // Resolve an OS thread's name (empty string when it has none). Windows: GetThreadDescription on a
+    // handle opened for the OS thread id. Linux: read /proc/self/task/<tid>/comm (comm caps names at
+    // ~15 chars). Both paths ALLOCATE and make syscalls, so callers must only run this OUTSIDE a runtime
+    // suspend window (ContinuousProfiler calls it after ResumeRuntime). Never throws.
+    inline xstring_t ResolveOsThreadName(DWORD osThreadId) noexcept
+    {
+        try
+        {
+#ifdef PAL_STDCPP_COMPAT
+            // Linux: pthread_getname_np needs a pthread_t we do not have for an arbitrary sampled OS
+            // thread id, so read the kernel-exposed comm file keyed directly by tid.
+            char path[64] = { 0 };
+            std::snprintf(path, sizeof(path), "/proc/self/task/%u/comm", static_cast<unsigned>(osThreadId));
+
+            std::FILE* f = std::fopen(path, "r");
+            if (f == nullptr)
+            {
+                return xstring_t(); // thread gone or comm unreadable -> "".
+            }
+
+            char name[64] = { 0 };
+            const size_t read = std::fread(name, 1, sizeof(name) - 1, f);
+            std::fclose(f);
+
+            // comm is newline-terminated; trim the trailing '\n' and any tail.
+            size_t len = read;
+            while (len > 0 && (name[len - 1] == '\n' || name[len - 1] == '\r'))
+            {
+                --len;
+            }
+            name[len] = '\0';
+
+            return ToWideString(name);
+#else
+            // Windows: GetThreadDescription (Win 10+). THREAD_QUERY_LIMITED_INFORMATION is the minimal
+            // right needed and succeeds for threads in our own process.
+            xstring_t result;
+            HANDLE hThread = ::OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, osThreadId);
+            if (hThread == nullptr)
+            {
+                return xstring_t();
+            }
+
+            PWSTR description = nullptr;
+            const HRESULT hr = ::GetThreadDescription(hThread, &description);
+            if (SUCCEEDED(hr) && description != nullptr)
+            {
+                result.assign(description);
+                ::LocalFree(description);
+            }
+            ::CloseHandle(hThread);
+            return result;
+#endif
+        }
+        catch (...)
+        {
+            return xstring_t();
+        }
+    }
+}}}

--- a/src/Agent/NewRelic/Profiler/ContinuousProfiler/SampleBufferWriter.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfiler/SampleBufferWriter.h
@@ -22,12 +22,17 @@
 //   * Strings are a BIG-ENDIAN int16 CHAR count (capped at 512), followed by that many UTF-16LE code
 //     units (2 bytes each, low byte first). This matches BufferParser.ReadString: a big-endian short
 //     prefix then Encoding.Unicode (== UTF-16LE) over charCount*2 bytes.
-//   * Opcodes: StartBatch 0x01, StartSample 0x02, EndBatch 0x06, BatchStats 0x07.
+//   * Opcodes: StartBatch 0x01, StartSample 0x02, EndBatch 0x06, BatchStats 0x07, AllocationSample 0x08.
 //   * StartBatch payload: 1 version byte + int64 timestamp.
 //   * BatchStats payload: int64 microsSuspended + int32 threadCount + int32 frameCount + int32 skipped.
 //   * Per-sample payload (after StartSample): thread name (string) -> OS thread id (int64) ->
 //     traceIdHigh (int64) -> traceIdLow (int64) -> spanId (int64) -> [v2+] onCpu (1 byte 0/1) ->
 //     [v3+] isAgentWork (1 byte 0/1) -> frame list -> terminator short 0.
+//   * AllocationSample payload (after opcode 0x08): thread name (string) -> OS thread id (int64) ->
+//     traceIdHigh (int64) -> traceIdLow (int64) -> spanId (int64) -> timestampMillis (int64) ->
+//     allocatedSize (uint64 written via the int64 writer -- both sides agree on the bit pattern, not
+//     the signed value) -> typeName (string) -> frame list -> terminator short 0. Uses the SAME
+//     per-batch frame-interning table as thread samples (shares _frameCodes/_nextFrameIndex).
 //   * Frame list: 2-byte big-endian short codes terminated by 0. FIRST sight of a frame string writes
 //     a NEGATIVE short (-index, index starting at 1) then the UTF-16 string, and remembers the index;
 //     a SUBSEQUENT sight writes the POSITIVE index (a back-reference). This is the inverse of
@@ -46,6 +51,7 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         StartSample = 0x02,
         EndBatch = 0x06,
         BatchStats = 0x07,
+        AllocationSample = 0x08,
     };
 
     class SampleBufferWriter
@@ -133,6 +139,15 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
             WriteOpcode(BufferOpcode::EndBatch);
         }
 
+        // AllocationSample 0x08. Field order matches BufferParser.ReadAllocationSample exactly: thread name,
+        // OS thread id, traceIdHigh, traceIdLow, spanId, timestampMillis, allocatedSize (uint64 reinterpreted
+        // as int64 -- both sides agree on the bit pattern, not the signed value), typeName, then a frame list
+        // using the SAME per-batch interning table as thread samples (shares _frameCodes/_nextFrameIndex).
+        void WriteStartAllocationSample()
+        {
+            WriteOpcode(BufferOpcode::AllocationSample);
+        }
+
         //
         // Per-sample field writers (call between WriteStartSample and WriteFrameListTerminator, in the
         // order BufferParser.ReadSample reads them).
@@ -148,6 +163,20 @@ namespace NewRelic { namespace Profiler { namespace ContinuousProfiler
         void WriteInt64Field(int64_t value)
         {
             WriteLong(value);
+        }
+
+        // allocatedSize is a uint64 on the producer side; reinterpret its bit pattern as an int64 so it
+        // round-trips through BufferParser.ReadAllocationSample's `unchecked((ulong)ReadLong(...))`.
+        void WriteUInt64Field(uint64_t value)
+        {
+            WriteLong(static_cast<int64_t>(value));
+        }
+
+        // Same-body alias of WriteThreadName -- used for allocation-sample fields that are a plain
+        // length-prefixed string but aren't a thread name (e.g. typeName), so the call site reads naturally.
+        void WriteStringField(const xstring_t& value)
+        {
+            WriteString(value);
         }
 
         // Per-sample on-CPU flag (v2+): a single 0/1 byte. Inverse of BufferParser.ReadBool.

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationBatchAccumulatorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationBatchAccumulatorTest.cpp
@@ -1,0 +1,571 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CppUnitTest.h"
+#include <string>
+#include <vector>
+#include "../ContinuousProfiler/AllocationBatchAccumulator.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace NewRelic::Profiler::ContinuousProfiler;
+
+// Exercises the accumulate/flush decisions that fix allocation sampling's delivery ceiling: with a
+// two-slot queue and one managed read per drain, one-batch-per-sample capped delivery at ~1 sample per
+// drain interval and dropped every other sub-sampled tick. These tests drive the accumulator against a
+// REAL SampleBufferQueue (it has no CLR or logging dependencies either) and decode the published bytes,
+// so they assert on the actual wire output rather than on internal counters alone.
+namespace
+{
+    // DELIBERATELY SMALLER than production's cap (AllocationSampler::MaxAllocationBufferBytes, 128 KB): the
+    // saturation and cap-driven-flush paths have to be reachable without encoding thousands of samples, and
+    // the accumulator takes the cap as a constructor argument precisely so a test can shrink it. Nothing here
+    // asserts anything about the production value -- that constant's own comment carries its derivation, and
+    // MarginalBytesPerAppendedSample_StaysSmallForARepeatedStack pins the per-sample cost it is divided by.
+    constexpr size_t MaxBatchBytes = 64 * 1024;
+
+    // Write one allocation sample of a controllable size through the accumulator. Mirrors
+    // AllocationSampler::EncodeAndPublish's field order exactly, which is what makes the decoded
+    // assertions below meaningful. Returns false when the accumulator refused the sample (a drop).
+    // Mirrors AllocationSampler::EncodedStringBytes, INCLUDING its MaxStringChars clamp: without the clamp
+    // this helper's size model would silently disagree with production's for any string over 512 chars, and
+    // the oversized-sample tests below would only work by accident of the encoder truncating anyway.
+    size_t EncodedStringBytes(const std::wstring& value)
+    {
+        const size_t chars = value.size() < SampleBufferWriter::MaxStringChars
+            ? value.size() : SampleBufferWriter::MaxStringChars;
+        return 2 + (chars * 2);
+    }
+
+    bool AppendSample(AllocationBatchAccumulator& accumulator, int64_t timestampNanos,
+        const std::wstring& threadName, uint64_t allocatedSize, const std::wstring& typeName,
+        const std::vector<std::wstring>& frames)
+    {
+        size_t required = 1 + EncodedStringBytes(threadName) + (6 * 8) + EncodedStringBytes(typeName) + 2;
+        for (const auto& frame : frames)
+        {
+            required += 2 + EncodedStringBytes(frame);
+        }
+
+        auto* writer = accumulator.BeginSample(required, timestampNanos);
+        if (writer == nullptr)
+        {
+            return false;
+        }
+
+        writer->WriteStartAllocationSample();
+        writer->WriteThreadName(threadName);
+        writer->WriteInt64Field(1234);            // os thread id
+        writer->WriteInt64Field(0x11);            // traceIdHigh
+        writer->WriteInt64Field(0x22);            // traceIdLow
+        writer->WriteInt64Field(0x33);            // spanId
+        writer->WriteInt64Field(timestampNanos / 1000000);
+        writer->WriteUInt64Field(allocatedSize);
+        writer->WriteStringField(typeName);
+        for (const auto& frame : frames)
+        {
+            writer->WriteCodedFrameString(frame);
+        }
+        writer->WriteFrameListTerminator();
+
+        accumulator.EndSample();
+        return true;
+    }
+
+    bool AppendSimpleSample(AllocationBatchAccumulator& accumulator, uint64_t allocatedSize)
+    {
+        return AppendSample(accumulator, 1000000000LL, L"worker", allocatedSize, L"System.Byte[]",
+            { L"MyApp.Alloc()", L"MyApp.Caller()" });
+    }
+
+    // A frame-name string big enough that a handful of samples fill a 64 KB batch, so the saturation
+    // path is reachable without writing thousands of samples.
+    std::wstring BigFrame(wchar_t fill)
+    {
+        return std::wstring(SampleBufferWriter::MaxStringChars, fill);
+    }
+
+    bool AppendBigSample(AllocationBatchAccumulator& accumulator, wchar_t fill)
+    {
+        std::vector<std::wstring> frames;
+        for (int i = 0; i < 12; ++i)
+        {
+            // Distinct per frame so nothing interns to a 2-byte back-reference: each costs its full
+            // ~1 KB definition, i.e. ~12 KB per sample.
+            auto frame = BigFrame(fill);
+            frame.push_back(static_cast<wchar_t>(L'0' + i));
+            frames.push_back(frame);
+        }
+        return AppendSample(accumulator, 1000000000LL, L"worker", 4096, L"System.Byte[]", frames);
+    }
+
+    // Minimal decoder for the published bytes -- the inverse of SampleBufferWriter, and deliberately
+    // independent of the managed BufferParser so a wire-format regression cannot hide behind a shared
+    // implementation. Counts 0x08 records, resolves interned frame codes, and captures BatchStats.skipped.
+    struct DecodedBatch
+    {
+        int Samples{ 0 };
+        int Skipped{ 0 };
+        bool SawEndBatch{ false };
+        bool Malformed{ false };
+        // Frame-code POLARITY, which is the only thing that can actually detect an interning table reset
+        // mid-batch. A negative code is a self-contained definition; a positive one is a back-reference to a
+        // definition earlier in the SAME batch. A writer whose table were rebuilt per tick would emit a fresh
+        // definition for every sample's every frame -- decoding correctly (each definition simply overwrites
+        // the identical dictionary entry) but producing a far less dense batch. Counting the two kinds is
+        // what makes that visible; sample counts and frame strings alone cannot see it.
+        int NegativeDefinitions{ 0 };
+        int PositiveLookups{ 0 };
+        int TotalBytes{ 0 };
+        std::vector<std::wstring> FirstSampleFrames;
+        std::vector<std::wstring> LastSampleFrames;
+        std::vector<uint64_t> AllocatedSizes;
+    };
+
+    class Reader
+    {
+    public:
+        Reader(const unsigned char* bytes, size_t length) : _bytes(bytes), _length(length) {}
+
+        bool Done() const { return _pos >= _length; }
+        bool Overrun(size_t size) const { return _pos + size > _length; }
+
+        uint8_t Byte() { return _bytes[_pos++]; }
+
+        int16_t Short()
+        {
+            const int16_t value = static_cast<int16_t>((_bytes[_pos] << 8) | _bytes[_pos + 1]);
+            _pos += 2;
+            return value;
+        }
+
+        int32_t Int()
+        {
+            int32_t value = 0;
+            for (int i = 0; i < 4; ++i) { value = (value << 8) | _bytes[_pos + i]; }
+            _pos += 4;
+            return value;
+        }
+
+        int64_t Long()
+        {
+            int64_t value = 0;
+            for (int i = 0; i < 8; ++i) { value = (value << 8) | _bytes[_pos + i]; }
+            _pos += 8;
+            return value;
+        }
+
+        std::wstring String()
+        {
+            const int16_t chars = Short();
+            std::wstring value;
+            value.reserve(static_cast<size_t>(chars));
+            for (int16_t i = 0; i < chars; ++i)
+            {
+                const uint16_t codeUnit = static_cast<uint16_t>(_bytes[_pos] | (_bytes[_pos + 1] << 8));
+                value.push_back(static_cast<wchar_t>(codeUnit));
+                _pos += 2;
+            }
+            return value;
+        }
+
+    private:
+        const unsigned char* _bytes;
+        size_t _length;
+        size_t _pos{ 0 };
+    };
+
+    DecodedBatch Decode(const unsigned char* bytes, int32_t length)
+    {
+        DecodedBatch decoded;
+        Reader reader(bytes, static_cast<size_t>(length));
+        std::vector<std::wstring> frameDictionary(1); // index 0 is the terminator, never a real frame
+
+        while (!reader.Done())
+        {
+            const uint8_t opcode = reader.Byte();
+            if (opcode == 0x01) // StartBatch
+            {
+                reader.Byte(); // version
+                reader.Long(); // timestamp
+            }
+            else if (opcode == 0x08) // AllocationSample
+            {
+                reader.String();                        // thread name
+                reader.Long();                          // os thread id
+                reader.Long(); reader.Long(); reader.Long(); // trace context
+                reader.Long();                          // timestamp millis
+                decoded.AllocatedSizes.push_back(static_cast<uint64_t>(reader.Long()));
+                reader.String();                        // type name
+
+                std::vector<std::wstring> frames;
+                for (;;)
+                {
+                    const int16_t code = reader.Short();
+                    if (code == 0)
+                    {
+                        break;
+                    }
+
+                    if (code < 0)
+                    {
+                        ++decoded.NegativeDefinitions;
+                        const auto value = reader.String();
+                        const size_t index = static_cast<size_t>(-code);
+                        if (frameDictionary.size() <= index)
+                        {
+                            frameDictionary.resize(index + 1);
+                        }
+                        frameDictionary[index] = value;
+                        frames.push_back(value);
+                    }
+                    else
+                    {
+                        ++decoded.PositiveLookups;
+                        // A positive code that was never defined is precisely the corruption a
+                        // reconstructed-per-tick interning table would produce.
+                        if (static_cast<size_t>(code) >= frameDictionary.size() || frameDictionary[code].empty())
+                        {
+                            decoded.Malformed = true;
+                            return decoded;
+                        }
+                        frames.push_back(frameDictionary[code]);
+                    }
+                }
+
+                if (decoded.Samples == 0)
+                {
+                    decoded.FirstSampleFrames = frames;
+                }
+                decoded.LastSampleFrames = frames;
+                ++decoded.Samples;
+            }
+            else if (opcode == 0x07) // BatchStats
+            {
+                reader.Long(); reader.Int(); reader.Int();
+                decoded.Skipped = reader.Int();
+            }
+            else if (opcode == 0x06) // EndBatch
+            {
+                decoded.SawEndBatch = true;
+                return decoded;
+            }
+            else
+            {
+                decoded.Malformed = true;
+                return decoded;
+            }
+        }
+
+        return decoded;
+    }
+
+    DecodedBatch ReadAndDecode(SampleBufferQueue& queue, int32_t& bytesRead)
+    {
+        std::vector<unsigned char> buffer(MaxBatchBytes * 2, 0);
+        bytesRead = queue.Read(static_cast<int32_t>(buffer.size()), buffer.data());
+        auto decoded = Decode(buffer.data(), bytesRead);
+        decoded.TotalBytes = bytesRead;
+        return decoded;
+    }
+}
+
+TEST_CLASS(AllocationBatchAccumulatorTest)
+{
+public:
+    TEST_METHOD(EndSample_WithAFreeSlot_PublishesOneSamplePerBatch)
+    {
+        // The common, non-backpressured case must behave exactly as it did before batching existed:
+        // publish on the spot, one sample per batch, no added latency.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        Assert::IsTrue(AppendSimpleSample(accumulator, 1024));
+
+        Assert::IsFalse(accumulator.HasOpenBatch(), L"a sample must not be held back while a slot is free");
+
+        int32_t bytesRead = 0;
+        const auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::IsTrue(bytesRead > 0);
+        Assert::AreEqual(1, decoded.Samples);
+        Assert::IsTrue(decoded.SawEndBatch);
+        Assert::IsFalse(decoded.Malformed);
+        Assert::AreEqual(0ULL, accumulator.DroppedTotal());
+    }
+
+    TEST_METHOD(SamplesTakenWhileBothSlotsAreFull_AreDeliveredAsOneBatch_NotDropped)
+    {
+        // THE REGRESSION THIS TASK FIXES. Both slots stay full for the whole burst, which used to drop
+        // every tick in it. They must instead accumulate into one pending batch and be delivered intact
+        // once a slot frees.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        // Fill both slots (published immediately, one sample each) so the queue is saturated.
+        Assert::IsTrue(AppendSimpleSample(accumulator, 1));
+        Assert::IsTrue(AppendSimpleSample(accumulator, 2));
+        Assert::IsFalse(queue.HasFreeSlot(), L"both slots must be full for this test to mean anything");
+
+        // The burst that used to be dropped in its entirety.
+        const int burst = 20;
+        for (int i = 0; i < burst; ++i)
+        {
+            Assert::IsTrue(AppendSimpleSample(accumulator, static_cast<uint64_t>(100 + i)),
+                L"a sample taken under back-pressure must be accumulated, not refused");
+        }
+
+        Assert::AreEqual(0ULL, accumulator.DroppedTotal(), L"nothing may be dropped while the pending batch has room");
+        Assert::IsTrue(accumulator.HasOpenBatch());
+        Assert::AreEqual(static_cast<uint32_t>(burst), accumulator.SamplesInPendingBatch());
+
+        // Drain the first published batch: that frees a slot, and the pending batch goes out on the next
+        // flush (which is what AllocationSampler::ReadAllocationSamples performs before every read).
+        int32_t bytesRead = 0;
+        auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(1, decoded.Samples);
+
+        Assert::IsTrue(accumulator.FlushIfPending());
+        Assert::IsFalse(accumulator.HasOpenBatch());
+
+        // Reads are FIFO, so the second single-sample batch comes out before the accumulated one.
+        decoded = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(1, decoded.Samples);
+
+        decoded = ReadAndDecode(queue, bytesRead);
+        Assert::IsFalse(decoded.Malformed, L"the accumulated batch must decode cleanly");
+        Assert::IsTrue(decoded.SawEndBatch);
+        Assert::AreEqual(burst, decoded.Samples, L"every accumulated sample must be delivered");
+        Assert::AreEqual(0ULL, accumulator.DroppedTotal());
+
+        // And the samples are the real ones, in order -- not a repeat of the same bytes.
+        Assert::AreEqual(static_cast<size_t>(burst), decoded.AllocatedSizes.size());
+        Assert::AreEqual(100ULL, decoded.AllocatedSizes.front());
+        Assert::AreEqual(static_cast<uint64_t>(100 + burst - 1), decoded.AllocatedSizes.back());
+    }
+
+    TEST_METHOD(AccumulatedBatch_InternsEachFrameOnceForTheWholeBatch)
+    {
+        // THE INTERNING REGRESSION GUARD, and it has to be written in terms of code POLARITY to be one.
+        // If the writer's frame table were rebuilt per tick (i.e. a fresh SampleBufferWriter wrapped around a
+        // persistent buffer -- the mistake this design exists to avoid), the batch would still DECODE
+        // correctly: every frame would arrive as a self-contained negative definition, each overwriting the
+        // identical dictionary entry. Frame strings, sample counts and a "malformed?" check therefore all
+        // pass either way. What changes is density: 5 samples x 2 frames would emit 10 definitions and 0
+        // back-references instead of 2 definitions and 8 back-references.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        AppendSimpleSample(accumulator, 1);
+        AppendSimpleSample(accumulator, 2);
+        Assert::IsFalse(queue.HasFreeSlot());
+
+        // 5 samples sharing exactly 2 distinct frames.
+        for (int i = 0; i < 5; ++i)
+        {
+            Assert::IsTrue(AppendSimpleSample(accumulator, static_cast<uint64_t>(i)));
+        }
+
+        int32_t bytesRead = 0;
+        ReadAndDecode(queue, bytesRead); // drain one slot
+        ReadAndDecode(queue, bytesRead); // and the other, so the flush below has room
+        Assert::IsTrue(accumulator.FlushIfPending());
+
+        const auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::IsFalse(decoded.Malformed);
+        Assert::AreEqual(5, decoded.Samples);
+        Assert::AreEqual(2, decoded.NegativeDefinitions,
+            L"each distinct frame must be DEFINED exactly once for the whole batch -- 10 definitions means the interning table was reset per sample");
+        Assert::AreEqual(8, decoded.PositiveLookups,
+            L"every repeat must be a back-reference into this batch's table -- 0 lookups means the table was reset per sample");
+
+        // And the back-references still resolve to the right strings (density without correctness would be
+        // worse than the bug).
+        Assert::AreEqual(static_cast<size_t>(2), decoded.FirstSampleFrames.size());
+        Assert::AreEqual(std::wstring(L"MyApp.Alloc()"), decoded.FirstSampleFrames[0]);
+        Assert::IsTrue(decoded.LastSampleFrames == decoded.FirstSampleFrames,
+            L"the last sample's back-referenced frames must resolve to the first sample's definitions");
+    }
+
+    TEST_METHOD(MarginalBytesPerAppendedSample_StaysSmallForARepeatedStack)
+    {
+        // Pins the number MaxAllocationBufferBytes is sized against. Appending sample N to an open batch
+        // whose stack is already interned costs only the fixed fields plus 2 bytes per frame -- roughly 100
+        // bytes, NOT the ~2 KB of a standalone one-sample OTLP profile. Sizing the cap off the wrong figure
+        // (as the first cut of this change did) either wastes memory or, in the other direction, silently
+        // caps delivery. If interning regressed, this number would jump by the full definition cost of every
+        // frame, so this doubles as a second, quantitative guard on the test above.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        AppendSimpleSample(accumulator, 1);
+        AppendSimpleSample(accumulator, 2);
+        Assert::IsFalse(queue.HasFreeSlot());
+
+        const int samples = 50;
+        for (int i = 0; i < samples; ++i)
+        {
+            Assert::IsTrue(AppendSimpleSample(accumulator, static_cast<uint64_t>(i)));
+        }
+
+        int32_t bytesRead = 0;
+        ReadAndDecode(queue, bytesRead);
+        ReadAndDecode(queue, bytesRead);
+        Assert::IsTrue(accumulator.FlushIfPending());
+
+        const auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(samples, decoded.Samples);
+
+        const int bytesPerSample = decoded.TotalBytes / samples;
+        Assert::IsTrue(bytesPerSample < 200,
+            L"a sample appended to a batch that already interned its stack must cost ~100 bytes, not kilobytes");
+        Assert::IsTrue(bytesPerSample > 50, L"sanity: the fixed fields alone are ~85 bytes");
+    }
+
+    TEST_METHOD(AFullPendingBatch_IsFlushedAtASampleBoundaryWhenASlotFrees)
+    {
+        // Cap-driven flush: an open batch that cannot fit the next sample is published (not truncated,
+        // not dropped) and a fresh batch is started for that sample.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        // Fill exactly one slot, leaving the other free so the cap-driven flush has somewhere to go.
+        Assert::IsTrue(AppendSimpleSample(accumulator, 1));
+        Assert::IsTrue(queue.HasFreeSlot());
+
+        int32_t bytesRead = 0;
+        ReadAndDecode(queue, bytesRead); // drain it; both slots free again
+
+        // Fill both slots to force accumulation, then pile on big samples until the batch overflows.
+        AppendSimpleSample(accumulator, 2);
+        AppendSimpleSample(accumulator, 3);
+        Assert::IsFalse(queue.HasFreeSlot());
+
+        int accepted = 0;
+        for (int i = 0; i < 6 && accumulator.DroppedTotal() == 0; ++i)
+        {
+            if (AppendBigSample(accumulator, static_cast<wchar_t>(L'a' + i))) { ++accepted; }
+        }
+
+        // ~12 KB per sample against a 64 KB cap: the batch must have filled and refused at least one.
+        Assert::IsTrue(accepted >= 4, L"the 64 KB batch should hold at least four ~12 KB samples");
+        Assert::AreEqual(1ULL, accumulator.DroppedTotal(), L"a saturated accumulator drops exactly the sample it cannot take");
+
+        // Free a slot: the next oversized sample now triggers a cap-driven flush of the full batch
+        // instead of a drop, and lands in a fresh batch of its own.
+        ReadAndDecode(queue, bytesRead);
+        Assert::IsTrue(AppendBigSample(accumulator, L'z'), L"with a slot free, an over-cap sample must flush the batch rather than be dropped");
+        Assert::IsTrue(accumulator.HasOpenBatch(), L"the flushed-into fresh batch stays open while the queue is full again");
+        Assert::AreEqual(static_cast<uint32_t>(1), accumulator.SamplesInPendingBatch());
+
+        // Reads are FIFO, so the other single-sample batch still queued from before comes out first.
+        auto leftover = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(1, leftover.Samples);
+
+        // Then the flushed batch, which decodes cleanly and carries the drop count from before it.
+        const auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::IsFalse(decoded.Malformed);
+        Assert::IsTrue(decoded.SawEndBatch);
+        Assert::AreEqual(accepted, decoded.Samples, L"every sample accepted into the batch must survive the flush");
+        Assert::AreEqual(1, decoded.Skipped, L"the drop must be reported in band on the next published batch");
+    }
+
+    TEST_METHOD(DropCount_IsReportedInBandAndOnlyOnce)
+    {
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        accumulator.RecordDroppedSample();
+        accumulator.RecordDroppedSample();
+        accumulator.RecordDroppedSample();
+        Assert::AreEqual(3ULL, accumulator.DroppedPending());
+
+        Assert::IsTrue(AppendSimpleSample(accumulator, 1));
+
+        int32_t bytesRead = 0;
+        auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(3, decoded.Skipped, L"the pending drop delta must ride out on the next batch");
+        Assert::AreEqual(0ULL, accumulator.DroppedPending(), L"a reported delta must be retired");
+
+        // The delta is a delta: a second batch with no further drops reports zero rather than repeating.
+        Assert::IsTrue(AppendSimpleSample(accumulator, 2));
+        decoded = ReadAndDecode(queue, bytesRead);
+        Assert::AreEqual(0, decoded.Skipped);
+        Assert::AreEqual(3ULL, accumulator.DroppedTotal(), L"the cumulative total still remembers them");
+    }
+
+    TEST_METHOD(AbandonBatch_DiscardsThePartialBatchAndCountsItsSamples)
+    {
+        // What the owner does when encoding throws: the half-written record cannot be rolled back, so the
+        // whole batch is discarded rather than shipped as a stream the decoder would desynchronize on.
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        AppendSimpleSample(accumulator, 1);
+        AppendSimpleSample(accumulator, 2);
+        Assert::IsFalse(queue.HasFreeSlot());
+
+        AppendSimpleSample(accumulator, 3);
+        AppendSimpleSample(accumulator, 4);
+        Assert::AreEqual(static_cast<uint32_t>(2), accumulator.SamplesInPendingBatch());
+
+        accumulator.AbandonBatch();
+
+        Assert::IsFalse(accumulator.HasOpenBatch());
+        Assert::AreEqual(0u, accumulator.SamplesInPendingBatch());
+        Assert::AreEqual(2ULL, accumulator.DroppedTotal(), L"an abandoned batch's samples are dropped samples");
+
+        // And the accumulator is still usable: the next sample starts a clean batch. Both queued batches
+        // are drained first so that FIFO ordering puts the new one at the head of the queue.
+        int32_t bytesRead = 0;
+        ReadAndDecode(queue, bytesRead);
+        ReadAndDecode(queue, bytesRead);
+        Assert::IsTrue(AppendSimpleSample(accumulator, 5));
+        const auto decoded = ReadAndDecode(queue, bytesRead);
+        Assert::IsFalse(decoded.Malformed, L"a batch started after an abandon must decode cleanly");
+        Assert::AreEqual(1, decoded.Samples);
+        Assert::AreEqual(2, decoded.Skipped);
+    }
+
+    TEST_METHOD(FlushIfPending_IsANoOpWithNothingPendingOrNoRoom)
+    {
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        Assert::IsFalse(accumulator.FlushIfPending(), L"nothing is open, so there is nothing to flush");
+
+        AppendSimpleSample(accumulator, 1);
+        AppendSimpleSample(accumulator, 2);
+        AppendSimpleSample(accumulator, 3); // accumulates; both slots are full
+
+        Assert::IsTrue(accumulator.HasOpenBatch());
+        Assert::IsFalse(accumulator.FlushIfPending(), L"a full queue must leave the pending batch open");
+        Assert::IsTrue(accumulator.HasOpenBatch());
+        Assert::AreEqual(0ULL, accumulator.DroppedTotal(), L"a no-op flush must not count a drop");
+    }
+
+    TEST_METHOD(CanAcceptSample_IsFalseOnlyWhenSaturated)
+    {
+        SampleBufferQueue queue;
+        AllocationBatchAccumulator accumulator(queue, MaxBatchBytes);
+
+        Assert::IsTrue(accumulator.CanAcceptSample(), L"an empty queue can always take a sample");
+
+        AppendSimpleSample(accumulator, 1);
+        AppendSimpleSample(accumulator, 2);
+        Assert::IsFalse(queue.HasFreeSlot());
+        Assert::IsTrue(accumulator.CanAcceptSample(),
+            L"a full queue with no open batch must still accept -- this is the drop the fix removes");
+
+        // Fill the pending batch until the pre-walk gate closes.
+        for (int i = 0; i < 8 && accumulator.CanAcceptSample(); ++i)
+        {
+            AppendBigSample(accumulator, static_cast<wchar_t>(L'a' + i));
+        }
+
+        Assert::IsFalse(accumulator.CanAcceptSample(), L"a full queue AND a full pending batch is genuinely saturated");
+
+        // Freeing a slot reopens the gate: the batch can be flushed into it.
+        int32_t bytesRead = 0;
+        ReadAndDecode(queue, bytesRead);
+        Assert::IsTrue(accumulator.CanAcceptSample());
+    }
+};

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationSubSamplerTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationSubSamplerTest.cpp
@@ -1,0 +1,83 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CppUnitTest.h"
+#include "../ContinuousProfiler/AllocationSubSampler.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace NewRelic::Profiler::ContinuousProfiler;
+
+TEST_CLASS(AllocationSubSamplerTest)
+{
+public:
+    TEST_METHOD(ShouldSample_NeverExceedsTargetPerCycle_UnderHeavyLoad)
+    {
+        AllocationSubSampler sampler(/*targetPerCycle*/ 10, /*cycleSeconds*/ 60);
+        int sampled = 0;
+        for (int i = 0; i < 100000; ++i)
+        {
+            if (sampler.ShouldSample()) { ++sampled; }
+        }
+        // A single unbounded cycle (no time advance) must never sample dramatically more than the
+        // target, even under a huge burst of ticks.
+        Assert::IsTrue(sampled <= 10 * 3, L"sampled count grossly exceeded target under burst");
+    }
+
+    TEST_METHOD(ShouldSample_ZeroTarget_NeverSamples)
+    {
+        AllocationSubSampler sampler(0, 60);
+        for (int i = 0; i < 1000; ++i)
+        {
+            Assert::IsFalse(sampler.ShouldSample());
+        }
+    }
+
+    TEST_METHOD(ShouldSample_CycleRollover_ResetsCountersAndUsesHistoricalTicks)
+    {
+        // Test multi-cycle behavior: counters must reset at boundaries.
+        // Key proof: cycle 1 exhausts its sampling cap, then cycle 2 resumes sampling
+        // immediately after rollover (proving _sampledThisCycle was actually reset to 0).
+        const uint32_t target = 5;
+
+        // Capture the current time BEFORE construction so the fake clock is synchronized
+        // with _cycleStart set in the constructor.
+        auto now = std::chrono::steady_clock::now();
+        AllocationSubSampler sampler(target, 1);  // 1-second cycles
+
+        // Set fake clock to the captured time (approximately when _cycleStart was set).
+        // This ensures _cycleStart ≈ fake_now, so we can control cycle boundaries.
+        sampler.SetClockFunction([&now]() { return now; });
+
+        // === Cycle 1: Run enough ticks to exhaust the sampling cap ===
+        // With startup-paced estimate (target * 1000 = 5000), we expect approximately
+        // (target / 5000) * 50000 = 50 samples from 50000 ticks.
+        // This guarantees we hit the cap of 5 and trigger the "already sampled >= target" early-exit.
+        int sampledCycle1 = 0;
+        for (int i = 0; i < 50000; ++i)
+        {
+            if (sampler.ShouldSample()) { ++sampledCycle1; }
+        }
+
+        // Prove cycle 1 actually hit its cap (sampling stopped due to _sampledThisCycle >= target).
+        Assert::AreEqual(target, static_cast<uint32_t>(sampledCycle1),
+                         L"cycle 1 must sample exactly to target, then stop due to cap");
+
+        // === Advance clock past cycle boundary (>= 1 second) ===
+        now += std::chrono::seconds(2);
+
+        // === Cycle 2: Verify counters were reset by immediately sampling again ===
+        // With _lastCycleTicks = 50,000 now known from cycle 1, cycle 2's odds are (5 - 0) / 50,000 = 0.0001.
+        // Run enough ticks to guarantee at least one sample: with expected value ~2.5 for 50,000 ticks,
+        // we have > 99% confidence of at least one sample (proving counters reset).
+        // If _sampledThisCycle wasn't reset, all calls would return false (stuck at >= target from carry-over).
+        int sampledCycle2 = 0;
+        for (int i = 0; i < 50000; ++i)
+        {
+            if (sampler.ShouldSample()) { ++sampledCycle2; }
+            if (sampledCycle2 > 0) break;  // Exit as soon as we prove sampling works again
+        }
+
+        Assert::IsTrue(sampledCycle2 > 0,
+                       L"cycle 2 must resume sampling immediately after rollover; if _sampledThisCycle wasn't reset, this would be 0");
+    }
+};

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationSubSamplerTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationSubSamplerTest.cpp
@@ -80,4 +80,38 @@ public:
         Assert::IsTrue(sampledCycle2 > 0,
                        L"cycle 2 must resume sampling immediately after rollover; if _sampledThisCycle wasn't reset, this would be 0");
     }
+
+    // Documents WHY AllocationSampler::TryNormalizeMaxSamplesPerMinute must reject a non-positive budget
+    // instead of casting it. This class deliberately does not clamp _targetPerCycle, so the value a blind
+    // static_cast<uint32_t>(-1) produces is not "a very high cap" -- it makes the odds computation saturate
+    // and every single tick gets sampled, i.e. a full stack walk + name resolution on an application thread
+    // per AllocationTick. The first cycle hides it (startup pacing divides by target*1000); the damage
+    // starts at the first cycle boundary, which is why this test has to roll the clock.
+    TEST_METHOD(ShouldSample_UnclampedHugeTarget_SamplesEveryTickAfterFirstCycle)
+    {
+        const uint32_t castOfNegativeOne = static_cast<uint32_t>(-1); // 4294967295
+
+        auto now = std::chrono::steady_clock::now();
+        AllocationSubSampler sampler(castOfNegativeOne, 1);
+        sampler.SetClockFunction([&now]() { return now; });
+
+        // Cycle 1: establish a tick history so cycle 2 uses the real estimate.
+        for (int i = 0; i < 2000; ++i)
+        {
+            sampler.ShouldSample();
+        }
+
+        now += std::chrono::seconds(2);
+
+        int sampledCycle2 = 0;
+        for (int i = 0; i < 2000; ++i)
+        {
+            if (sampler.ShouldSample()) { ++sampledCycle2; }
+        }
+
+        // Not "more than the target" -- literally everything.
+        Assert::AreEqual(2000, sampledCycle2,
+            L"an unclamped huge target samples 100% of ticks, which is the incident the export-boundary "
+            L"guard exists to prevent");
+    }
 };

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationTickPayloadTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationTickPayloadTest.cpp
@@ -1,0 +1,144 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CppUnitTest.h"
+#include "../ContinuousProfiler/AllocationSampler.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace NewRelic::Profiler::ContinuousProfiler;
+
+// Exercises AllocationSampler's AllocationTick v4 payload parser. This is the one piece of the
+// allocation path that is pure, CLR-free logic -- and the one most easily got wrong, since the layout is
+// a byte blob whose last field must be read from the END of the buffer -- so it is unit tested directly.
+// Including this header here also keeps AllocationSampler.h under continuous compilation before the
+// profiler itself references it.
+namespace
+{
+    constexpr size_t PointerSize = sizeof(void*);
+    // AllocationAmount(4) + AllocationKind(4) + InstanceId(2) + AllocationAmount64(8) + TypeId(ptr)
+    constexpr size_t TypeNameOffset = 4 + 4 + 2 + 8 + PointerSize;
+    // ...plus HeapIndex(4) + Address(ptr) + AllocatedSize(8)
+    constexpr size_t FixedFieldBytes = TypeNameOffset + 4 + PointerSize + 8;
+
+    // Build a well-formed v4 payload for `typeName` (NUL-terminated in the buffer, as the runtime emits
+    // it) and `allocatedSize`, filling every field we do not consume with recognizable junk so a
+    // mis-offset read shows up as a wrong value rather than an accidental pass.
+    std::vector<uint8_t> BuildPayload(const std::wstring& typeName, uint64_t allocatedSize)
+    {
+        const size_t nameBytes = (typeName.size() + 1) * sizeof(wchar_t);
+        std::vector<uint8_t> payload(FixedFieldBytes + nameBytes, 0xAB);
+
+        std::memcpy(payload.data() + TypeNameOffset, typeName.c_str(), nameBytes);
+        std::memcpy(payload.data() + payload.size() - sizeof(uint64_t), &allocatedSize, sizeof(uint64_t));
+        return payload;
+    }
+}
+
+TEST_CLASS(AllocationTickPayloadTest)
+{
+public:
+    TEST_METHOD(Parse_WellFormedPayload_ReadsSizeAndTypeName)
+    {
+        const auto payload = BuildPayload(L"System.Collections.Generic.List`1[System.String]", 123456789ULL);
+
+        uint64_t allocatedSize = 0;
+        std::wstring typeName;
+        Assert::IsTrue(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(payload.size()), payload.data(), allocatedSize, typeName));
+
+        Assert::AreEqual(123456789ULL, allocatedSize);
+        Assert::AreEqual(std::wstring(L"System.Collections.Generic.List`1[System.String]"), typeName);
+    }
+
+    TEST_METHOD(Parse_EmptyTypeName_SucceedsWithEmptyString)
+    {
+        // The shortest legal payload: TypeName is just its NUL terminator.
+        const auto payload = BuildPayload(L"", 4096ULL);
+        Assert::AreEqual(FixedFieldBytes + sizeof(wchar_t), payload.size());
+
+        uint64_t allocatedSize = 0;
+        std::wstring typeName;
+        Assert::IsTrue(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(payload.size()), payload.data(), allocatedSize, typeName));
+
+        Assert::AreEqual(4096ULL, allocatedSize);
+        Assert::IsTrue(typeName.empty());
+    }
+
+    TEST_METHOD(Parse_NullData_Rejected)
+    {
+        uint64_t allocatedSize = 99;
+        std::wstring typeName(L"stale");
+        Assert::IsFalse(AllocationSampler::ParseAllocationTickPayload(1024, nullptr, allocatedSize, typeName));
+    }
+
+    TEST_METHOD(Parse_TooShortPayload_RejectedWithoutReading)
+    {
+        // One byte short of "all fixed fields + a NUL terminator" -- the under-read guard must reject it.
+        std::vector<uint8_t> payload(FixedFieldBytes + sizeof(wchar_t) - 1, 0xAB);
+
+        uint64_t allocatedSize = 99;
+        std::wstring typeName(L"stale");
+        Assert::IsFalse(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(payload.size()), payload.data(), allocatedSize, typeName));
+
+        // Out-params are cleared even on rejection, so a caller that ignores the result cannot publish a
+        // stale size/name from a previous sample.
+        Assert::AreEqual(0ULL, allocatedSize);
+        Assert::IsTrue(typeName.empty());
+    }
+
+    TEST_METHOD(Parse_OddTypeNameByteCount_Rejected)
+    {
+        // A trailing half code unit cannot be a UTF-16 string; the modulo guard must reject it.
+        auto payload = BuildPayload(L"Foo", 1ULL);
+        payload.push_back(0x00);
+
+        uint64_t allocatedSize = 0;
+        std::wstring typeName;
+        Assert::IsFalse(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(payload.size()), payload.data(), allocatedSize, typeName));
+    }
+
+    TEST_METHOD(Parse_TypeNameIsNotReadPastItsLength)
+    {
+        // The parser must use the computed length, not scan for a NUL: overwrite the terminator and the
+        // returned string must still stop at the right place (and must not include the terminator itself).
+        auto payload = BuildPayload(L"Foo", 8ULL);
+        std::memcpy(payload.data() + TypeNameOffset + (3 * sizeof(wchar_t)), L"X", sizeof(wchar_t));
+
+        uint64_t allocatedSize = 0;
+        std::wstring typeName;
+        Assert::IsTrue(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(payload.size()), payload.data(), allocatedSize, typeName));
+
+        Assert::AreEqual(static_cast<size_t>(3), typeName.size());
+        Assert::AreEqual(std::wstring(L"Foo"), typeName);
+    }
+
+    TEST_METHOD(Parse_AllocatedSizeComesFromTheEndOfTheBuffer)
+    {
+        // Two payloads whose ONLY difference is the type name's length must both report the same size --
+        // proving the size is read relative to the end, not from a fixed offset.
+        const auto shortName = BuildPayload(L"A", 0xDEADBEEFCAFEULL);
+        const auto longName = BuildPayload(L"A.Much.Longer.Type.Name.Here", 0xDEADBEEFCAFEULL);
+
+        uint64_t shortSize = 0, longSize = 0;
+        std::wstring ignored;
+        Assert::IsTrue(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(shortName.size()), shortName.data(), shortSize, ignored));
+        Assert::IsTrue(AllocationSampler::ParseAllocationTickPayload(
+            static_cast<ULONG>(longName.size()), longName.data(), longSize, ignored));
+
+        Assert::AreEqual(0xDEADBEEFCAFEULL, shortSize);
+        Assert::AreEqual(0xDEADBEEFCAFEULL, longSize);
+    }
+
+    TEST_METHOD(IsAllocationTickEvent_AcceptsOnlyEventTenVersionFour)
+    {
+        Assert::IsTrue(AllocationSampler::IsAllocationTickEvent(10, 4));
+        Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(10, 3));
+        Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(10, 5));
+        Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(9, 4));
+    }
+};

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationTickPayloadTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/AllocationTickPayloadTest.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CppUnitTest.h"
+#include <limits>
 #include "../ContinuousProfiler/AllocationSampler.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -140,5 +141,52 @@ public:
         Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(10, 3));
         Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(10, 5));
         Assert::IsFalse(AllocationSampler::IsAllocationTickEvent(9, 4));
+    }
+
+    // The budget arrives from managed code as a SIGNED int. A non-positive value must not be started at
+    // all: casting it would produce a huge unsigned target that AllocationSubSampler does not clamp,
+    // which degrades into sampling every single AllocationTick on application threads.
+    TEST_METHOD(TryNormalizeMaxSamplesPerMinute_RejectsNonPositiveInsteadOfWrappingToHuge)
+    {
+        uint32_t budget = 0xFFFFFFFFu;
+        Assert::IsFalse(AllocationSampler::TryNormalizeMaxSamplesPerMinute(-1, budget));
+        Assert::AreEqual(0u, budget, L"a rejected budget must not leave a usable value behind");
+
+        budget = 0xFFFFFFFFu;
+        Assert::IsFalse(AllocationSampler::TryNormalizeMaxSamplesPerMinute(0, budget));
+        Assert::AreEqual(0u, budget);
+
+        budget = 0xFFFFFFFFu;
+        Assert::IsFalse(AllocationSampler::TryNormalizeMaxSamplesPerMinute(
+            (std::numeric_limits<int32_t>::min)(), budget));
+        Assert::AreEqual(0u, budget);
+    }
+
+    TEST_METHOD(TryNormalizeMaxSamplesPerMinute_PassesSaneValuesThrough)
+    {
+        uint32_t budget = 0;
+        Assert::IsTrue(AllocationSampler::TryNormalizeMaxSamplesPerMinute(1, budget));
+        Assert::AreEqual(1u, budget);
+
+        Assert::IsTrue(AllocationSampler::TryNormalizeMaxSamplesPerMinute(200, budget));
+        Assert::AreEqual(200u, budget, L"the shipped default must survive unmodified");
+    }
+
+    TEST_METHOD(TryNormalizeMaxSamplesPerMinute_ClampsAboveTheCeiling)
+    {
+        // Copied to a local: the ceiling is a static constexpr member, and passing it straight to
+        // Assert::AreEqual (which takes a const reference) would odr-use it.
+        const int32_t ceiling = AllocationSampler::MaxSupportedSamplesPerMinute;
+
+        uint32_t budget = 0;
+        Assert::IsTrue(AllocationSampler::TryNormalizeMaxSamplesPerMinute(ceiling, budget));
+        Assert::AreEqual(static_cast<uint32_t>(ceiling), budget, L"the ceiling itself is accepted as-is");
+
+        Assert::IsTrue(AllocationSampler::TryNormalizeMaxSamplesPerMinute(ceiling + 1, budget));
+        Assert::AreEqual(static_cast<uint32_t>(ceiling), budget);
+
+        Assert::IsTrue(AllocationSampler::TryNormalizeMaxSamplesPerMinute(
+            (std::numeric_limits<int32_t>::max)(), budget));
+        Assert::AreEqual(static_cast<uint32_t>(ceiling), budget);
     }
 };

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
@@ -18,6 +18,11 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Same vendored CoreCLR profiling-API headers Profiler.vcxproj consumes, so the ContinuousProfiler
+         headers under test see the SAME corprof.h (ICorProfilerInfo12 etc.) as the real build. -->
+    <CoreClrVendoredHeaders>$(SolutionDir)externals\coreclr-headers</CoreClrVendoredHeaders>
+  </PropertyGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -75,21 +80,29 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(IncludePath)</IncludePath>
+    <ExternalIncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(IncludePath)</IncludePath>
+    <ExternalIncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(IncludePath)</IncludePath>
+    <ExternalIncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(IncludePath)</IncludePath>
+    <ExternalIncludePath>$(CoreClrVendoredHeaders)\src\pal\prebuilt\inc;$(CoreClrVendoredHeaders)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -116,16 +129,12 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <BrowseInformation>true</BrowseInformation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <Bscmake>
-      <PreserveSbr>true</PreserveSbr>
-    </Bscmake>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -178,6 +187,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="AllocationSubSamplerTest.cpp" />
+    <ClCompile Include="AllocationTickPayloadTest.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ContinuousProfilerTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(NativeToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <BrowseInformation>true</BrowseInformation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <Bscmake>
+      <PreserveSbr>true</PreserveSbr>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="AllocationSubSamplerTest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/ContinuousProfilerTest.vcxproj
@@ -186,6 +186,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="AllocationBatchAccumulatorTest.cpp" />
     <ClCompile Include="AllocationSubSamplerTest.cpp" />
     <ClCompile Include="AllocationTickPayloadTest.cpp" />
   </ItemGroup>

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.cpp
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.cpp
@@ -1,0 +1,12 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// stdafx.cpp : source file that includes just the standard includes
+// ContinuousProfilerTest.pch will be the pre-compiled header
+// stdafx.obj will contain the pre-compiled type information
+
+#include "stdafx.h"
+
+// Reference any additional headers you need in STDAFX.H
+// and not in this file

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.h
@@ -1,0 +1,8 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+// Headers for CppUnitTest
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <CppUnitTest.h>

--- a/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.h
+++ b/src/Agent/NewRelic/Profiler/ContinuousProfilerTest/stdafx.h
@@ -6,3 +6,11 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <CppUnitTest.h>
+
+// The ContinuousProfiler headers under test use CComPtr and the CLR profiling-API types without
+// including their providers themselves -- they rely on the profiler project's forced-include stdafx.h
+// for that. Mirror the Windows half of that header here so those types are equally available to the
+// tests. (The vendored corprof.h/cor.h come from the include paths this project sets, matching
+// Profiler.vcxproj, so ICorProfilerInfo12 resolves the same way it does in the real build.)
+#include <atlbase.h>
+#include <atlcomcli.h>

--- a/src/Agent/NewRelic/Profiler/NewRelic.Profiler.sln
+++ b/src/Agent/NewRelic/Profiler/NewRelic.Profiler.sln
@@ -21,6 +21,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SignatureParser", "Signatur
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SignatureParserTest", "SignatureParserTest\SignatureParserTest.vcxproj", "{C73C1AF5-E6F0-4632-9FD8-B67628B65DAF}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ContinuousProfilerTest", "ContinuousProfilerTest\ContinuousProfilerTest.vcxproj", "{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ModuleInjector", "ModuleInjector\ModuleInjector.vcxproj", "{56D5651F-A24B-4369-B9FC-1BD5B1959C0B}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Configuration", "Configuration\Configuration.vcxproj", "{E6F0388D-31E5-44A4-8144-162219474ED4}"
@@ -129,6 +131,14 @@ Global
 		{C73C1AF5-E6F0-4632-9FD8-B67628B65DAF}.Release|Win32.Build.0 = Release|Win32
 		{C73C1AF5-E6F0-4632-9FD8-B67628B65DAF}.Release|x64.ActiveCfg = Release|x64
 		{C73C1AF5-E6F0-4632-9FD8-B67628B65DAF}.Release|x64.Build.0 = Release|x64
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Debug|Win32.Build.0 = Debug|Win32
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Debug|x64.ActiveCfg = Debug|x64
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Debug|x64.Build.0 = Debug|x64
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Release|Win32.ActiveCfg = Release|Win32
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Release|Win32.Build.0 = Release|Win32
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Release|x64.ActiveCfg = Release|x64
+		{D8A5E4F2-92B1-4E3D-A6C5-9F3E8C2D1B0A}.Release|x64.Build.0 = Release|x64
 		{56D5651F-A24B-4369-B9FC-1BD5B1959C0B}.Debug|Win32.ActiveCfg = Debug|Win32
 		{56D5651F-A24B-4369-B9FC-1BD5B1959C0B}.Debug|Win32.Build.0 = Debug|Win32
 		{56D5651F-A24B-4369-B9FC-1BD5B1959C0B}.Debug|x64.ActiveCfg = Debug|x64

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <atomic>
+#include <cstdint>
 #include <cor.h>
 #include <corprof.h>
 
@@ -68,10 +69,11 @@ namespace NewRelic { namespace Profiler {
 
     typedef std::set<xstring_t> FilePaths;
 
-    class CorProfilerCallbackImpl : public ICorProfilerCallback4 {
+    class CorProfilerCallbackImpl : public ICorProfilerCallback10 {
 
     private:
         std::atomic<int> _referenceCount;
+        std::atomic<std::uint64_t> _eventPipeEventsDelivered;
 
 #ifndef PAL_STDCPP_COMPAT
         std::shared_ptr<ModuleInjector::ModuleInjector> _moduleInjector;
@@ -80,6 +82,7 @@ namespace NewRelic { namespace Profiler {
     public:
         CorProfilerCallbackImpl()
             : _referenceCount(0)
+            , _eventPipeEventsDelivered(0)
         {
             _systemCalls = std::make_shared<SystemCalls>();
             GetSingletonish() = this;
@@ -177,6 +180,59 @@ namespace NewRelic { namespace Profiler {
         virtual HRESULT __stdcall ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus) override { return S_OK; }
         virtual HRESULT __stdcall MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override { return S_OK; }
         virtual HRESULT __stdcall SurvivingReferences2(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback5
+        virtual HRESULT __stdcall ConditionalWeakTableElementReferences(ULONG cRootRefs, ObjectID keyRefIds[], ObjectID valueRefIds[], GCHandleID rootIds[]) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback6
+        virtual HRESULT __stdcall GetAssemblyReferences(const WCHAR* wszAssemblyPath, ICorProfilerAssemblyReferenceProvider* pAsmRefProvider) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback7
+        virtual HRESULT __stdcall ModuleInMemorySymbolsUpdated(ModuleID moduleId) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback8
+        virtual HRESULT __stdcall DynamicMethodJITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock, LPCBYTE pILHeader, ULONG cbILHeader) override { return S_OK; }
+        virtual HRESULT __stdcall DynamicMethodJITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback9
+        virtual HRESULT __stdcall DynamicMethodUnloaded(FunctionID functionId) override { return S_OK; }
+
+        // Unimplemented ICorProfilerCallback10
+        virtual HRESULT __stdcall EventPipeProviderCreated(EVENTPIPE_PROVIDER provider) override { return S_OK; }
+
+        // ICorProfilerCallback10
+        // Invoked by the CLR for every event delivered on an EventPipe session this profiler subscribes to.
+        // Nothing subscribes yet, so in practice this is never called today; it is implemented here so the
+        // class genuinely satisfies (and can advertise) ICorProfilerCallback10.
+        virtual HRESULT __stdcall EventPipeEventDelivered(
+            EVENTPIPE_PROVIDER provider,
+            DWORD eventId,
+            DWORD eventVersion,
+            ULONG cbMetadataBlob,
+            LPCBYTE metadataBlob,
+            ULONG cbEventData,
+            LPCBYTE eventData,
+            LPCGUID pActivityId,
+            LPCGUID pRelatedActivityId,
+            ThreadID eventThread,
+            ULONG numStackFrames,
+            UINT_PTR stackFrames[]) override
+        {
+            // Keep this method allocation-free, non-blocking and free of per-event logging: it runs on the
+            // thread that raised the event, inside the runtime's EventPipe dispatch, and a verbose
+            // AllocationTick subscription delivers events at ~10^5/second. Only the first delivery is
+            // logged, as a one-time "the CLR is calling us" diagnostic.
+            const auto deliveredCount = _eventPipeEventsDelivered.fetch_add(1, std::memory_order_relaxed) + 1;
+
+            if (deliveredCount == 1) {
+                LogDebug(L"First EventPipe event delivered to the profiler. eventId: ", eventId);
+            }
+
+            // TODO(Task 3): route Microsoft-Windows-DotNETRuntime AllocationTick events to AllocationSampler.
+            // Dispatch will key off the provider handle captured when the session is created plus eventId.
+
+            return S_OK;
+        }
 
         // Base profiler initialization method
         virtual HRESULT __stdcall Initialize(IUnknown* pICorProfilerInfoUnk) override
@@ -374,10 +430,10 @@ namespace NewRelic { namespace Profiler {
             {
                 // register for events that we are interested in getting callbacks for
 // SetEventMask2 requires ICorProfilerInfo5. It allows setting the high-order bits of the profiler event mask.
-// 0x8 = COR_PRF_HIGH_DISABLE_TIERED_COMPILATION <- this was introduced in ICorProfilerCallback9 which we're not currently implementing
+// 0x8 = COR_PRF_HIGH_DISABLE_TIERED_COMPILATION
 // see this PR: https://github.com/dotnet/coreclr/pull/14643/files#diff-e7d550d94de30cdf5e7f3a25647a2ae1R626
-// Just passing in the hardcoded 0x8 seems to actually disable tiered compilation,
-// but we should see about actually referencing and implementing ICorProfilerCallback9
+// The hardcoded 0x8 is retained deliberately rather than switched to the corprof.h enum value:
+// it is the shipped, proven behavior and this is not the place to change it.
 
                 CComPtr<ICorProfilerInfo5> _corProfilerInfo5;
                 const DWORD COR_PRF_HIGH_DISABLE_TIERED_COMPILATION = 0x8;
@@ -438,8 +494,12 @@ namespace NewRelic { namespace Profiler {
 
         virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override
         {
+            // ICorProfilerCallbackN is a single-inheritance chain, so one vtable satisfies every version
+            // in it -- returning `this` for any of these IIDs is correct. The CLR asks for the highest
+            // version it knows about and only invokes callbacks belonging to the version it gets back,
+            // so ICorProfilerCallback10 must be advertised here for EventPipeEventDelivered to ever fire.
             if (
-                riid == __uuidof(ICorProfilerCallback4) || riid == __uuidof(ICorProfilerCallback3) || riid == __uuidof(ICorProfilerCallback2) || riid == __uuidof(ICorProfilerCallback) || riid == IID_IUnknown) {
+                riid == __uuidof(ICorProfilerCallback10) || riid == __uuidof(ICorProfilerCallback9) || riid == __uuidof(ICorProfilerCallback8) || riid == __uuidof(ICorProfilerCallback7) || riid == __uuidof(ICorProfilerCallback6) || riid == __uuidof(ICorProfilerCallback5) || riid == __uuidof(ICorProfilerCallback4) || riid == __uuidof(ICorProfilerCallback3) || riid == __uuidof(ICorProfilerCallback2) || riid == __uuidof(ICorProfilerCallback) || riid == IID_IUnknown) {
                 *ppvObject = this;
                 this->AddRef();
                 return S_OK;

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -15,6 +15,7 @@
 #include "../SignatureParser/Exceptions.h"
 #include "../ThreadProfiler/ThreadProfiler.h"
 #include "../ContinuousProfiler/ContinuousProfiler.h"
+#include "../ContinuousProfiler/AllocationSampler.h"
 #include "../Common/FileUtils.h"
 #include "Function.h"
 #include "FunctionResolver.h"
@@ -201,9 +202,11 @@ namespace NewRelic { namespace Profiler {
         virtual HRESULT __stdcall EventPipeProviderCreated(EVENTPIPE_PROVIDER provider) override { return S_OK; }
 
         // ICorProfilerCallback10
-        // Invoked by the CLR for every event delivered on an EventPipe session this profiler subscribes to.
-        // Nothing subscribes yet, so in practice this is never called today; it is implemented here so the
-        // class genuinely satisfies (and can advertise) ICorProfilerCallback10.
+        // Invoked by the CLR for every event delivered on an EventPipe session THIS PROFILER started
+        // (via ICorProfilerInfo12::EventPipeStartSession -- the runtime does not forward other listeners'
+        // sessions here). Today the only such session is AllocationSampler's, which subscribes to the GC
+        // keyword of Microsoft-Windows-DotNETRuntime at verbose level, so every delivery lands on the
+        // dispatch below.
         virtual HRESULT __stdcall EventPipeEventDelivered(
             EVENTPIPE_PROVIDER provider,
             DWORD eventId,
@@ -228,8 +231,18 @@ namespace NewRelic { namespace Profiler {
                 LogDebug(L"First EventPipe event delivered to the profiler. eventId: ", eventId);
             }
 
-            // TODO(Task 3): route Microsoft-Windows-DotNETRuntime AllocationTick events to AllocationSampler.
-            // Dispatch will key off the provider handle captured when the session is created plus eventId.
+            // Route AllocationTick to the allocation sampler, filtered on event id + payload version.
+            // The `provider` handle is deliberately NOT part of the filter. It could be: EventPipeStartSession
+            // only returns a session id, but a handle could be resolved to a name via
+            // ICorProfilerInfo12::EventPipeGetProviderInfo from EventPipeProviderCreated and cached. That buys
+            // nothing today -- the runtime only delivers events for sessions THIS profiler started, and the
+            // only such session subscribes to exactly one provider -- while adding a metadata call plus cache
+            // on the startup path. The id+version pair is the real guard: it is exact (== 10, == v4),
+            // fail-closed, and AllocationSampler::OnAllocationTick re-checks it itself, so even a future
+            // second session could not silently feed the parser a foreign payload.
+            if (ContinuousProfiler::AllocationSampler::IsAllocationTickEvent(eventId, eventVersion)) {
+                _allocationSampler.OnAllocationTick(eventId, eventVersion, cbEventData, eventData);
+            }
 
             return S_OK;
         }
@@ -304,6 +317,11 @@ namespace NewRelic { namespace Profiler {
                 //_isCoreClr (set above by SetClrType) decides whether CP stops the world via
                 //SuspendRuntime/ResumeRuntime -- CoreCLR on every OS, matching OTel's ClrRuntimeCapture.
                 _continuousProfiler.Init(_corProfilerInfo4, _isCoreClr);
+                // Init opens no EventPipe session and starts no thread; it only probes for ICorProfilerInfo12
+                // and builds its frame-name resolver. The trace-context map is BORROWED from the continuous
+                // profiler (which owns it, and outlives this call): the single managed trace-context export
+                // writes that instance, so allocation samples can only be correlated by reading it too.
+                _allocationSampler.Init(_corProfilerInfo4, _continuousProfiler.SharedTraceContexts());
 
 
                 HRESULT corePathInitResult = InitializeAndSetAgentCoreDllPath(_productName);
@@ -443,8 +461,35 @@ namespace NewRelic { namespace Profiler {
                     ThrowOnError(_corProfilerInfo4->SetEventMask, _eventMask);
                 }
                 else {
-                    LogDebug(L"Calling SetEventMask2().");
-                    ThrowOnError(_corProfilerInfo5->SetEventMask2, _eventMask, COR_PRF_HIGH_DISABLE_TIERED_COMPILATION);
+                    // COR_PRF_HIGH_MONITOR_EVENT_PIPE (0x80) is what makes ICorProfilerCallback10::
+                    // EventPipeEventDelivered fire at all; without it the allocation sampler can open a
+                    // session but never receives a single event. It is only requested when the runtime
+                    // actually exposes the EventPipe profiling API (ICorProfilerInfo12, .NET 5+), which is
+                    // exactly the condition under which the sampler can be used.
+                    const DWORD highEventMask = COR_PRF_HIGH_DISABLE_TIERED_COMPILATION
+                        | (_allocationSampler.IsAvailable() ? (DWORD)COR_PRF_HIGH_MONITOR_EVENT_PIPE : 0u);
+
+                    LogDebug(L"Calling SetEventMask2(). High mask: ", std::hex, std::showbase, highEventMask,
+                        std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield));
+                    HRESULT setEventMaskResult = _corProfilerInfo5->SetEventMask2(_eventMask, highEventMask);
+
+                    // Allocation sampling is optional; profiler activation is not. If the runtime rejects the
+                    // high mask (e.g. it does not know the EventPipe bit), retry with only the bit this
+                    // profiler has always set, so an unusable allocation sampler cannot cost us the agent.
+                    if (FAILED(setEventMaskResult) && highEventMask != COR_PRF_HIGH_DISABLE_TIERED_COMPILATION) {
+                        LogWarn(L"SetEventMask2() rejected COR_PRF_HIGH_MONITOR_EVENT_PIPE: ", std::hex, std::showbase, setEventMaskResult,
+                            std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield),
+                            L". Retrying without it; allocation sampling will be unavailable.");
+                        setEventMaskResult = _corProfilerInfo5->SetEventMask2(_eventMask, COR_PRF_HIGH_DISABLE_TIERED_COMPILATION);
+                    }
+
+                    // Same outcome as the ThrowOnError macro this used to be -- open-coded because the macro
+                    // must wrap the call itself, and the retry above needs the HRESULT in hand first.
+                    if (FAILED(setEventMaskResult)) {
+                        LogError(L"Win32 function call failed.  Function: SetEventMask2  HRESULT: ",
+                            std::hex, std::showbase, setEventMaskResult, std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield));
+                        throw NewRelic::Profiler::Win32Exception(setEventMaskResult);
+                    }
                 }
             }
             else
@@ -951,6 +996,32 @@ namespace NewRelic { namespace Profiler {
             _continuousProfiler.Shutdown();
         }
 
+        // Allocation sampling. Note the deliberate asymmetry with the continuous profiler above:
+        // AllocationSampler::Shutdown() is TERMINAL (it latches, and every later Start() is refused),
+        // whereas ContinuousProfiler::Shutdown() is restartable. So enabling/disabling allocation sampling
+        // at runtime -- config change, server-side command, reconnect -- must go through Stop()/Start();
+        // only true agent teardown may call Shutdown(). Wiring a disable to Shutdown() would silently and
+        // permanently end allocation sampling for the life of the process.
+        void AllocationSamplerStart(uint32_t maxSamplesPerMinute) noexcept
+        {
+            _allocationSampler.Start(maxSamplesPerMinute);
+        }
+
+        void AllocationSamplerStop() noexcept
+        {
+            _allocationSampler.Stop();
+        }
+
+        void AllocationSamplerShutdown() noexcept
+        {
+            _allocationSampler.Shutdown();
+        }
+
+        int32_t ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf) noexcept
+        {
+            return _allocationSampler.ReadAllocationSamples(len, buf);
+        }
+
         uintptr_t GetCurrentThreadId() noexcept
         {
             ThreadID tid;
@@ -972,6 +1043,9 @@ namespace NewRelic { namespace Profiler {
         CComPtr<ICorProfilerInfo4> _corProfilerInfo4;
         ThreadProfiler::ThreadProfiler _threadProfiler;
         ContinuousProfiler::ContinuousProfiler _continuousProfiler;
+        // Declared AFTER _continuousProfiler on purpose: it borrows that object's TraceContextMap, and
+        // members are destroyed in reverse declaration order, so the borrower dies first.
+        ContinuousProfiler::AllocationSampler _allocationSampler;
         std::shared_ptr<SystemCalls> _systemCalls;
         std::shared_ptr<FunctionResolver> _functionResolver;
         MethodRewriter::CustomInstrumentationBuilder _customInstrumentationBuilder;
@@ -1606,6 +1680,56 @@ namespace NewRelic { namespace Profiler {
             return;
         }
         profiler->ContinuousProfilerShutdown();
+    }
+
+    // called by managed code to start (or resume) allocation sampling at the given per-minute sample cap.
+    // Safe to call repeatedly -- this is the "enable" half of the runtime enable/disable pair (see
+    // AllocationSamplerStop). It does NOT undo AllocationSamplerShutdown, which is one-way.
+    extern "C" __declspec(dllexport) void __cdecl AllocationSamplerStart(int32_t maxSamplesPerMinute) noexcept
+    {
+        auto profiler = CorProfilerCallbackImpl::GetSingletonish();
+        if (profiler == nullptr) {
+            LogError(L"AllocationSamplerStart: entry point called before the profiler has been initialized");
+            return;
+        }
+        profiler->AllocationSamplerStart(static_cast<uint32_t>(maxSamplesPerMinute));
+    }
+
+    // called by managed code to pause allocation sampling (the EventPipe session stays open, the handler
+    // returns immediately). This -- not AllocationSamplerShutdown -- is what a "disable" must call, so that
+    // a later AllocationSamplerStart can resume sampling.
+    extern "C" __declspec(dllexport) void __cdecl AllocationSamplerStop() noexcept
+    {
+        auto profiler = CorProfilerCallbackImpl::GetSingletonish();
+        if (profiler == nullptr) {
+            LogError(L"AllocationSamplerStop: entry point called before the profiler has been initialized");
+            return;
+        }
+        profiler->AllocationSamplerStop();
+    }
+
+    // called by managed code EXACTLY ONCE, at agent teardown, to close the EventPipe session and drain any
+    // in-flight tick handler. TERMINAL: allocation sampling can never be restarted afterwards. Anything that
+    // may run more than once over the agent's lifetime must call AllocationSamplerStop instead.
+    extern "C" __declspec(dllexport) void __cdecl AllocationSamplerShutdown() noexcept
+    {
+        auto profiler = CorProfilerCallbackImpl::GetSingletonish();
+        if (profiler == nullptr) {
+            LogError(L"AllocationSamplerShutdown: entry point called before the profiler has been initialized");
+            return;
+        }
+        profiler->AllocationSamplerShutdown();
+    }
+
+    // called by managed code to drain one filled allocation-sample buffer into the caller's array
+    extern "C" __declspec(dllexport) int32_t __cdecl ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf) noexcept
+    {
+        auto profiler = CorProfilerCallbackImpl::GetSingletonish();
+        if (profiler == nullptr) {
+            LogError(L"ContinuousProfilerReadAllocationSamples: entry point called before the profiler has been initialized");
+            return 0;
+        }
+        return profiler->ContinuousProfilerReadAllocationSamples(len, buf);
     }
 
     //This method is used only to verify thread profiling.  It is only used by tests in ProfiledMethod project.

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -465,7 +465,12 @@ namespace NewRelic { namespace Profiler {
                     // EventPipeEventDelivered fire at all; without it the allocation sampler can open a
                     // session but never receives a single event. It is only requested when the runtime
                     // actually exposes the EventPipe profiling API (ICorProfilerInfo12, .NET 5+), which is
-                    // exactly the condition under which the sampler can be used.
+                    // exactly the condition under which the sampler can be used -- and, since Info12 and
+                    // this mask bit both shipped in .NET 5 while MinimumDotnetVersionCheck already requires
+                    // Info11, that probe is the real gate. It has to be: CoreCLR was measured to SILENTLY
+                    // ACCEPT unknown high-mask bits (setting 0x40000000 alongside succeeds), so a runtime
+                    // too old to know 0x80 would not report an error here either -- it would just never
+                    // deliver events. Do not rely on the failure branch below to catch a version mismatch.
                     const DWORD highEventMask = COR_PRF_HIGH_DISABLE_TIERED_COMPILATION
                         | (_allocationSampler.IsAvailable() ? (DWORD)COR_PRF_HIGH_MONITOR_EVENT_PIPE : 0u);
 
@@ -474,20 +479,36 @@ namespace NewRelic { namespace Profiler {
                     HRESULT setEventMaskResult = _corProfilerInfo5->SetEventMask2(_eventMask, highEventMask);
 
                     // Allocation sampling is optional; profiler activation is not. If the runtime rejects the
-                    // high mask (e.g. it does not know the EventPipe bit), retry with only the bit this
-                    // profiler has always set, so an unusable allocation sampler cannot cost us the agent.
+                    // high mask for ANY reason, retry with only the bit this profiler has always set, so an
+                    // unusable allocation sampler can never cost us the agent. (Verified by temporarily
+                    // forcing this branch: the retry succeeds, the profiler still initializes, no session is
+                    // ever opened, and every Start() no-ops with a reason.)
                     if (FAILED(setEventMaskResult) && highEventMask != COR_PRF_HIGH_DISABLE_TIERED_COMPILATION) {
                         LogWarn(L"SetEventMask2() rejected COR_PRF_HIGH_MONITOR_EVENT_PIPE: ", std::hex, std::showbase, setEventMaskResult,
                             std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield),
-                            L". Retrying without it; allocation sampling will be unavailable.");
+                            L". Retrying without it.");
                         setEventMaskResult = _corProfilerInfo5->SetEventMask2(_eventMask, COR_PRF_HIGH_DISABLE_TIERED_COMPILATION);
+
+                        // Load-bearing, not just bookkeeping: without the mask bit the runtime never calls
+                        // EventPipeEventDelivered, so a session opened later would make the CLR generate
+                        // AllocationTick events at full cost and deliver none of them. Telling the sampler
+                        // turns that into a clean "unavailable" (Start() no-ops) instead of paying for the
+                        // whole feature and silently producing nothing.
+                        _allocationSampler.MarkUnavailable();
                     }
 
-                    // Same outcome as the ThrowOnError macro this used to be -- open-coded because the macro
-                    // must wrap the call itself, and the retry above needs the HRESULT in hand first.
-                    if (FAILED(setEventMaskResult)) {
-                        LogError(L"Win32 function call failed.  Function: SetEventMask2  HRESULT: ",
-                            std::hex, std::showbase, setEventMaskResult, std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield));
+                    // Same outcome as the ThrowOnError macro this replaces -- open-coded because the macro
+                    // must wrap the call itself, and the retry above needs the HRESULT in hand first. The
+                    // log lines are kept character-for-character identical to the macro's, including the
+                    // symbolic CORPROF_E_UNSUPPORTED_CALL_SEQUENCE branch, in case anything scrapes them.
+                    if (setEventMaskResult == CORPROF_E_UNSUPPORTED_CALL_SEQUENCE) {
+                        LogError("Win32 function call failed.  Function: _corProfilerInfo5->SetEventMask2  HRESULT: CORPROF_E_UNSUPPORTED_CALL_SEQUENCE");
+                        throw NewRelic::Profiler::Win32Exception(setEventMaskResult);
+                    }
+                    else if (FAILED(setEventMaskResult)) {
+                        LogError("Win32 function call failed.  Function: _corProfilerInfo5->SetEventMask2  HRESULT: ",
+                            std::hex, std::showbase, setEventMaskResult,
+                            std::resetiosflags(std::ios_base::showbase | std::ios_base::basefield));
                         throw NewRelic::Profiler::Win32Exception(setEventMaskResult);
                     }
                 }
@@ -1002,9 +1023,30 @@ namespace NewRelic { namespace Profiler {
         // at runtime -- config change, server-side command, reconnect -- must go through Stop()/Start();
         // only true agent teardown may call Shutdown(). Wiring a disable to Shutdown() would silently and
         // permanently end allocation sampling for the life of the process.
-        void AllocationSamplerStart(uint32_t maxSamplesPerMinute) noexcept
+        // Takes the budget as SIGNED, exactly as it crosses the P/Invoke boundary, and validates before any
+        // cast. This export is a trust boundary: it defends itself rather than assuming the managed caller
+        // validated, because a blind static_cast<uint32_t> of a non-positive value is a performance hazard,
+        // not a no-op (see AllocationSampler::TryNormalizeMaxSamplesPerMinute for the mechanism). Task 5/6's
+        // config validation is a second layer, not the only one.
+        void AllocationSamplerStart(int32_t maxSamplesPerMinute) noexcept
         {
-            _allocationSampler.Start(maxSamplesPerMinute);
+            uint32_t budget = 0;
+            if (!ContinuousProfiler::AllocationSampler::TryNormalizeMaxSamplesPerMinute(maxSamplesPerMinute, budget))
+            {
+                LogWarn(L"AllocationSamplerStart ignored: maxSamplesPerMinute must be positive, got ",
+                    maxSamplesPerMinute, L". Allocation sampling not started -- a zero or negative budget "
+                    L"cannot produce samples, so opening an EventPipe session would cost the runtime's "
+                    L"AllocationTick generation for no benefit.");
+                return;
+            }
+
+            if (budget != static_cast<uint32_t>(maxSamplesPerMinute))
+            {
+                LogWarn(L"AllocationSamplerStart: requested maxSamplesPerMinute of ", maxSamplesPerMinute,
+                    L" exceeds the supported ceiling; clamping to ", budget);
+            }
+
+            _allocationSampler.Start(budget);
         }
 
         void AllocationSamplerStop() noexcept
@@ -1685,6 +1727,8 @@ namespace NewRelic { namespace Profiler {
     // called by managed code to start (or resume) allocation sampling at the given per-minute sample cap.
     // Safe to call repeatedly -- this is the "enable" half of the runtime enable/disable pair (see
     // AllocationSamplerStop). It does NOT undo AllocationSamplerShutdown, which is one-way.
+    // maxSamplesPerMinute is forwarded SIGNED and validated there; nothing here casts it (see
+    // CorProfilerCallbackImpl::AllocationSamplerStart for why a blind cast is a performance hazard).
     extern "C" __declspec(dllexport) void __cdecl AllocationSamplerStart(int32_t maxSamplesPerMinute) noexcept
     {
         auto profiler = CorProfilerCallbackImpl::GetSingletonish();
@@ -1692,7 +1736,7 @@ namespace NewRelic { namespace Profiler {
             LogError(L"AllocationSamplerStart: entry point called before the profiler has been initialized");
             return;
         }
-        profiler->AllocationSamplerStart(static_cast<uint32_t>(maxSamplesPerMinute));
+        profiler->AllocationSamplerStart(maxSamplesPerMinute);
     }
 
     // called by managed code to pause allocation sampling (the EventPipe session stays open, the handler

--- a/src/Agent/NewRelic/Profiler/Profiler/Profiler.vcxproj
+++ b/src/Agent/NewRelic/Profiler/Profiler/Profiler.vcxproj
@@ -139,7 +139,6 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <BrowseInformation>true</BrowseInformation>
       <DisableSpecificWarnings>4091; 4467; 4458</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -154,9 +153,6 @@
       <Command>
       </Command>
     </PostBuildEvent>
-    <Bscmake>
-      <PreserveSbr>true</PreserveSbr>
-    </Bscmake>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>

--- a/src/Agent/NewRelic/Profiler/externals/coreclr-headers/README.md
+++ b/src/Agent/NewRelic/Profiler/externals/coreclr-headers/README.md
@@ -4,10 +4,38 @@ This directory contains a frozen copy of CLR profiling-API headers from `dotnet/
 
 ## Provenance
 
+Base set (everything except the per-file overrides listed below):
+
 - Upstream repository: https://github.com/dotnet/coreclr
 - Upstream branch: `release/3.1`
 - Upstream commit: `1b04187394cd1de5b316c40a3ad9d9189f4cb5b0` (2023-01-20) — the final commit on `release/3.1` before the repository was archived
 - License: MIT (see `LICENSE.TXT` in this directory)
+
+### Per-file overrides
+
+`dotnet/coreclr` was archived at .NET Core 3.1, so headers describing
+profiling-API surface added after 3.1 must come from `dotnet/runtime`. Files
+refreshed from there are listed individually so the rest of the set stays
+pinned to the base commit above:
+
+| File | Source repository | Tag | Commit | Blob SHA-1 | Reason |
+|------|-------------------|-----|--------|-----------|--------|
+| `src/pal/prebuilt/inc/corprof.h` | https://github.com/dotnet/runtime | `v5.0.17` | `6a984143635bde23e728abaaccbde52f5ea8fa3e` | `9a1e4b490a66f5a88a34e814c3d4c01256a937f0` | Adds `ICorProfilerCallback10` and `ICorProfilerInfo12` (EventPipe profiling API), needed for allocation sampling |
+
+Upstream path for that file at that tag is
+`src/coreclr/src/pal/prebuilt/inc/corprof.h` (the `src/coreclr/src` → `src/coreclr`
+flattening happened after .NET 5, so newer tags use `src/coreclr/pal/prebuilt/inc/`).
+The copy is byte-identical to upstream — verify with
+`git hash-object src/pal/prebuilt/inc/corprof.h`, which must print the Blob SHA-1
+above.
+
+`v5.0.17` is deliberately chosen over a newer tag: .NET 5 is the release that
+introduced `ICorProfilerCallback10` / `ICorProfilerInfo12`, and it is the last
+release whose `corprof.h` stops there. Pinning to its final servicing tag gives
+the required surface as a whole-file (never hand-edited) copy without dragging in
+later API surface (`ICorProfilerCallback11`, `ICorProfilerInfo13`+) that the
+profiler does not use. Bump this pin only when a newer interface is actually
+needed.
 
 ## Why this is vendored
 
@@ -51,8 +79,11 @@ The equivalent headers live under `src/coreclr/inc/` and
    directives from the new entry point).
 2. Copying only the required files into this vendored tree, preserving the
    upstream path layout.
-3. Updating the "Upstream repository" and "Upstream commit" lines in the
-   **Provenance** section above to reflect the new source and SHA.
+3. Pinning the source to a **tagged release**, never a moving branch, and
+   recording it in the **Per-file overrides** table in the **Provenance**
+   section above (file, repo, tag, commit, blob SHA-1, reason). Prefer the
+   oldest tag that contains the needed surface, so the refresh does not pull in
+   unrelated newer API.
 4. Updates to `licenses/THIRD_PARTY_NOTICES.txt` if license text or
    attribution changed (`dotnet/runtime` is also MIT).
 

--- a/src/Agent/NewRelic/Profiler/externals/coreclr-headers/src/pal/prebuilt/inc/corprof.h
+++ b/src/Agent/NewRelic/Profiler/externals/coreclr-headers/src/pal/prebuilt/inc/corprof.h
@@ -6,7 +6,7 @@
  /* File created by MIDL compiler version 8.01.0622 */
 /* at Mon Jan 18 19:14:07 2038
  */
-/* Compiler settings for C:/git/coreclr/src/inc/corprof.idl:
+/* Compiler settings for C:/git/runtime/src/coreclr/src/inc/corprof.idl:
     Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
     protocol : dce , ms_ext, c_ext, robust
     error checks: allocation ref bounds_check enum stub_data 
@@ -106,6 +106,13 @@ typedef interface ICorProfilerCallback8 ICorProfilerCallback8;
 typedef interface ICorProfilerCallback9 ICorProfilerCallback9;
 
 #endif  /* __ICorProfilerCallback9_FWD_DEFINED__ */
+
+
+#ifndef __ICorProfilerCallback10_FWD_DEFINED__
+#define __ICorProfilerCallback10_FWD_DEFINED__
+typedef interface ICorProfilerCallback10 ICorProfilerCallback10;
+
+#endif  /* __ICorProfilerCallback10_FWD_DEFINED__ */
 
 
 #ifndef __ICorProfilerInfo_FWD_DEFINED__
@@ -218,6 +225,13 @@ typedef interface ICorProfilerInfo10 ICorProfilerInfo10;
 typedef interface ICorProfilerInfo11 ICorProfilerInfo11;
 
 #endif  /* __ICorProfilerInfo11_FWD_DEFINED__ */
+
+
+#ifndef __ICorProfilerInfo12_FWD_DEFINED__
+#define __ICorProfilerInfo12_FWD_DEFINED__
+typedef interface ICorProfilerInfo12 ICorProfilerInfo12;
+
+#endif  /* __ICorProfilerInfo12_FWD_DEFINED__ */
 
 
 #ifndef __ICorProfilerMethodEnum_FWD_DEFINED__
@@ -553,7 +567,8 @@ enum __MIDL___MIDL_itf_corprof_0000_0000_0006
         COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS   = 0x20,
         COR_PRF_HIGH_REQUIRE_PROFILE_IMAGE  = 0,
         COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED  = 0x40,
-        COR_PRF_HIGH_ALLOWABLE_AFTER_ATTACH = ( ( ( ( COR_PRF_HIGH_IN_MEMORY_SYMBOLS_UPDATED | COR_PRF_HIGH_MONITOR_DYNAMIC_FUNCTION_UNLOADS )  | COR_PRF_HIGH_BASIC_GC )  | COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS )  | COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED ) ,
+        COR_PRF_HIGH_MONITOR_EVENT_PIPE = 0x80,
+        COR_PRF_HIGH_ALLOWABLE_AFTER_ATTACH = ( ( ( ( ( COR_PRF_HIGH_IN_MEMORY_SYMBOLS_UPDATED | COR_PRF_HIGH_MONITOR_DYNAMIC_FUNCTION_UNLOADS )  | COR_PRF_HIGH_BASIC_GC )  | COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS )  | COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED )  | COR_PRF_HIGH_MONITOR_EVENT_PIPE ) ,
         COR_PRF_HIGH_MONITOR_IMMUTABLE  = COR_PRF_HIGH_DISABLE_TIERED_COMPILATION
     }   COR_PRF_HIGH_MONITOR;
 
@@ -606,6 +621,68 @@ enum __MIDL___MIDL_itf_corprof_0000_0000_0012
         COR_PRF_REJIT_BLOCK_INLINING    = 0x1,
         COR_PRF_REJIT_INLINING_CALLBACKS    = 0x2
     }   COR_PRF_REJIT_FLAGS;
+
+typedef UINT_PTR EVENTPIPE_PROVIDER;
+
+typedef UINT_PTR EVENTPIPE_EVENT;
+
+typedef UINT64 EVENTPIPE_SESSION;
+
+typedef /* [public] */ 
+enum __MIDL___MIDL_itf_corprof_0000_0000_0013
+    {
+        COR_PRF_EVENTPIPE_OBJECT    = 1,
+        COR_PRF_EVENTPIPE_BOOLEAN   = 3,
+        COR_PRF_EVENTPIPE_CHAR  = 4,
+        COR_PRF_EVENTPIPE_SBYTE = 5,
+        COR_PRF_EVENTPIPE_BYTE  = 6,
+        COR_PRF_EVENTPIPE_INT16 = 7,
+        COR_PRF_EVENTPIPE_UINT16    = 8,
+        COR_PRF_EVENTPIPE_INT32 = 9,
+        COR_PRF_EVENTPIPE_UINT32    = 10,
+        COR_PRF_EVENTPIPE_INT64 = 11,
+        COR_PRF_EVENTPIPE_UINT64    = 12,
+        COR_PRF_EVENTPIPE_SINGLE    = 13,
+        COR_PRF_EVENTPIPE_DOUBLE    = 14,
+        COR_PRF_EVENTPIPE_DECIMAL   = 15,
+        COR_PRF_EVENTPIPE_DATETIME  = 16,
+        COR_PRF_EVENTPIPE_GUID  = 17,
+        COR_PRF_EVENTPIPE_STRING    = 18,
+        COR_PRF_EVENTPIPE_ARRAY = 19
+    }   COR_PRF_EVENTPIPE_PARAM_TYPE;
+
+typedef /* [public] */ 
+enum __MIDL___MIDL_itf_corprof_0000_0000_0014
+    {
+        COR_PRF_EVENTPIPE_LOGALWAYS = 0,
+        COR_PRF_EVENTPIPE_CRITICAL  = 1,
+        COR_PRF_EVENTPIPE_ERROR = 2,
+        COR_PRF_EVENTPIPE_WARNING   = 3,
+        COR_PRF_EVENTPIPE_INFORMATIONAL = 4,
+        COR_PRF_EVENTPIPE_VERBOSE   = 5
+    }   COR_PRF_EVENTPIPE_LEVEL;
+
+typedef /* [public][public][public] */ struct __MIDL___MIDL_itf_corprof_0000_0000_0015
+    {
+    const WCHAR *providerName;
+    UINT64 keywords;
+    UINT32 loggingLevel;
+    const WCHAR *filterData;
+    }   COR_PRF_EVENTPIPE_PROVIDER_CONFIG;
+
+typedef /* [public][public] */ struct __MIDL___MIDL_itf_corprof_0000_0000_0016
+    {
+    UINT32 type;
+    UINT32 elementType;
+    const WCHAR *name;
+    }   COR_PRF_EVENTPIPE_PARAM_DESC;
+
+typedef /* [public][public] */ struct __MIDL___MIDL_itf_corprof_0000_0000_0017
+    {
+    UINT64 ptr;
+    UINT32 size;
+    UINT32 reserved;
+    }   COR_PRF_EVENT_DATA;
 
 
 
@@ -1467,7 +1544,8 @@ enum __MIDL___MIDL_itf_corprof_0000_0001_0004
         COR_PRF_GC_GEN_0    = 0,
         COR_PRF_GC_GEN_1    = 1,
         COR_PRF_GC_GEN_2    = 2,
-        COR_PRF_GC_LARGE_OBJECT_HEAP    = 3
+        COR_PRF_GC_LARGE_OBJECT_HEAP    = 3,
+        COR_PRF_GC_PINNED_OBJECT_HEAP   = 4
     }   COR_PRF_GC_GENERATION;
 
 typedef struct COR_PRF_GC_GENERATION_RANGE
@@ -7449,11 +7527,835 @@ EXTERN_C const IID IID_ICorProfilerCallback9;
 #endif  /* __ICorProfilerCallback9_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_corprof_0000_0009 */
+#ifndef __ICorProfilerCallback10_INTERFACE_DEFINED__
+#define __ICorProfilerCallback10_INTERFACE_DEFINED__
+
+/* interface ICorProfilerCallback10 */
+/* [local][unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ICorProfilerCallback10;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("CEC5B60E-C69C-495F-87F6-84D28EE16FFB")
+    ICorProfilerCallback10 : public ICorProfilerCallback9
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE EventPipeEventDelivered( 
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [in] */ DWORD eventId,
+            /* [in] */ DWORD eventVersion,
+            /* [in] */ ULONG cbMetadataBlob,
+            /* [size_is][in] */ LPCBYTE metadataBlob,
+            /* [in] */ ULONG cbEventData,
+            /* [size_is][in] */ LPCBYTE eventData,
+            /* [in] */ LPCGUID pActivityId,
+            /* [in] */ LPCGUID pRelatedActivityId,
+            /* [in] */ ThreadID eventThread,
+            /* [in] */ ULONG numStackFrames,
+            /* [length_is][in] */ UINT_PTR stackFrames[  ]) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeProviderCreated( 
+            /* [in] */ EVENTPIPE_PROVIDER provider) = 0;
+        
+    };
+    
+    
+#else   /* C style interface */
+
+    typedef struct ICorProfilerCallback10Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ICorProfilerCallback10 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Initialize )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ IUnknown *pICorProfilerInfoUnk);
+        
+        HRESULT ( STDMETHODCALLTYPE *Shutdown )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AppDomainCreationStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AppDomainID appDomainId);
+        
+        HRESULT ( STDMETHODCALLTYPE *AppDomainCreationFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AppDomainID appDomainId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *AppDomainShutdownStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AppDomainID appDomainId);
+        
+        HRESULT ( STDMETHODCALLTYPE *AppDomainShutdownFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AppDomainID appDomainId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *AssemblyLoadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AssemblyID assemblyId);
+        
+        HRESULT ( STDMETHODCALLTYPE *AssemblyLoadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AssemblyID assemblyId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *AssemblyUnloadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AssemblyID assemblyId);
+        
+        HRESULT ( STDMETHODCALLTYPE *AssemblyUnloadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ AssemblyID assemblyId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleLoadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleLoadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleUnloadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleUnloadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleAttachedToAssembly )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ AssemblyID AssemblyId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ClassLoadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID classId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ClassLoadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *ClassUnloadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID classId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ClassUnloadFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *FunctionUnloadStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITCompilationStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ BOOL fIsSafeToBlock);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITCompilationFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ HRESULT hrStatus,
+            /* [in] */ BOOL fIsSafeToBlock);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITCachedFunctionSearchStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [out] */ BOOL *pbUseCachedFunction);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITCachedFunctionSearchFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_JIT_CACHE result);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITFunctionPitched )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *JITInlining )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID callerId,
+            /* [in] */ FunctionID calleeId,
+            /* [out] */ BOOL *pfShouldInline);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadCreated )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID threadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadDestroyed )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID threadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadAssignedToOSThread )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID managedThreadId,
+            /* [in] */ DWORD osThreadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingClientInvocationStarted )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingClientSendingMessage )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GUID *pCookie,
+            /* [in] */ BOOL fIsAsync);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingClientReceivingReply )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GUID *pCookie,
+            /* [in] */ BOOL fIsAsync);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingClientInvocationFinished )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingServerReceivingMessage )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GUID *pCookie,
+            /* [in] */ BOOL fIsAsync);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingServerInvocationStarted )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingServerInvocationReturned )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemotingServerSendingReply )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GUID *pCookie,
+            /* [in] */ BOOL fIsAsync);
+        
+        HRESULT ( STDMETHODCALLTYPE *UnmanagedToManagedTransition )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_TRANSITION_REASON reason);
+        
+        HRESULT ( STDMETHODCALLTYPE *ManagedToUnmanagedTransition )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_TRANSITION_REASON reason);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeSuspendStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ COR_PRF_SUSPEND_REASON suspendReason);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeSuspendFinished )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeSuspendAborted )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeResumeStarted )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeResumeFinished )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeThreadSuspended )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID threadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *RuntimeThreadResumed )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID threadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *MovedReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cMovedObjectIDRanges,
+            /* [size_is][in] */ ObjectID oldObjectIDRangeStart[  ],
+            /* [size_is][in] */ ObjectID newObjectIDRangeStart[  ],
+            /* [size_is][in] */ ULONG cObjectIDRangeLength[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *ObjectAllocated )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ObjectID objectId,
+            /* [in] */ ClassID classId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ObjectsAllocatedByClass )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cClassCount,
+            /* [size_is][in] */ ClassID classIds[  ],
+            /* [size_is][in] */ ULONG cObjects[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *ObjectReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ObjectID objectId,
+            /* [in] */ ClassID classId,
+            /* [in] */ ULONG cObjectRefs,
+            /* [size_is][in] */ ObjectID objectRefIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *RootReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cRootRefs,
+            /* [size_is][in] */ ObjectID rootRefIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionThrown )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ObjectID thrownObjectId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionSearchFunctionEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionSearchFunctionLeave )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionSearchFilterEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionSearchFilterLeave )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionSearchCatcherFound )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionOSHandlerEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ UINT_PTR __unused);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionOSHandlerLeave )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ UINT_PTR __unused);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionUnwindFunctionEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionUnwindFunctionLeave )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionUnwindFinallyEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionUnwindFinallyLeave )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionCatcherEnter )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ObjectID objectId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionCatcherLeave )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *COMClassicVTableCreated )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID wrappedClassId,
+            /* [in] */ REFGUID implementedIID,
+            /* [in] */ void *pVTable,
+            /* [in] */ ULONG cSlots);
+        
+        HRESULT ( STDMETHODCALLTYPE *COMClassicVTableDestroyed )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ClassID wrappedClassId,
+            /* [in] */ REFGUID implementedIID,
+            /* [in] */ void *pVTable);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionCLRCatcherFound )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ExceptionCLRCatcherExecute )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadNameChanged )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ThreadID threadId,
+            /* [in] */ ULONG cchName,
+            /* [annotation][in] */ 
+            _In_reads_opt_(cchName)  WCHAR name[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GarbageCollectionStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ int cGenerations,
+            /* [size_is][in] */ BOOL generationCollected[  ],
+            /* [in] */ COR_PRF_GC_REASON reason);
+        
+        HRESULT ( STDMETHODCALLTYPE *SurvivingReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cSurvivingObjectIDRanges,
+            /* [size_is][in] */ ObjectID objectIDRangeStart[  ],
+            /* [size_is][in] */ ULONG cObjectIDRangeLength[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GarbageCollectionFinished )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *FinalizeableObjectQueued )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ DWORD finalizerFlags,
+            /* [in] */ ObjectID objectID);
+        
+        HRESULT ( STDMETHODCALLTYPE *RootReferences2 )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cRootRefs,
+            /* [size_is][in] */ ObjectID rootRefIds[  ],
+            /* [size_is][in] */ COR_PRF_GC_ROOT_KIND rootKinds[  ],
+            /* [size_is][in] */ COR_PRF_GC_ROOT_FLAGS rootFlags[  ],
+            /* [size_is][in] */ UINT_PTR rootIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *HandleCreated )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GCHandleID handleId,
+            /* [in] */ ObjectID initialObjectId);
+        
+        HRESULT ( STDMETHODCALLTYPE *HandleDestroyed )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ GCHandleID handleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *InitializeForAttach )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ IUnknown *pCorProfilerInfoUnk,
+            /* [in] */ void *pvClientData,
+            /* [in] */ UINT cbClientData);
+        
+        HRESULT ( STDMETHODCALLTYPE *ProfilerAttachComplete )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ProfilerDetachSucceeded )( 
+            ICorProfilerCallback10 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReJITCompilationStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ReJITID rejitId,
+            /* [in] */ BOOL fIsSafeToBlock);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetReJITParameters )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdMethodDef methodId,
+            /* [in] */ ICorProfilerFunctionControl *pFunctionControl);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReJITCompilationFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ReJITID rejitId,
+            /* [in] */ HRESULT hrStatus,
+            /* [in] */ BOOL fIsSafeToBlock);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReJITError )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdMethodDef methodId,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ HRESULT hrStatus);
+        
+        HRESULT ( STDMETHODCALLTYPE *MovedReferences2 )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cMovedObjectIDRanges,
+            /* [size_is][in] */ ObjectID oldObjectIDRangeStart[  ],
+            /* [size_is][in] */ ObjectID newObjectIDRangeStart[  ],
+            /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *SurvivingReferences2 )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cSurvivingObjectIDRanges,
+            /* [size_is][in] */ ObjectID objectIDRangeStart[  ],
+            /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *ConditionalWeakTableElementReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ ULONG cRootRefs,
+            /* [size_is][in] */ ObjectID keyRefIds[  ],
+            /* [size_is][in] */ ObjectID valueRefIds[  ],
+            /* [size_is][in] */ GCHandleID rootIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyReferences )( 
+            ICorProfilerCallback10 * This,
+            /* [string][in] */ const WCHAR *wszAssemblyPath,
+            /* [in] */ ICorProfilerAssemblyReferenceProvider *pAsmRefProvider);
+        
+        HRESULT ( STDMETHODCALLTYPE *ModuleInMemorySymbolsUpdated )( 
+            ICorProfilerCallback10 * This,
+            ModuleID moduleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *DynamicMethodJITCompilationStarted )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ BOOL fIsSafeToBlock,
+            /* [in] */ LPCBYTE pILHeader,
+            /* [in] */ ULONG cbILHeader);
+        
+        HRESULT ( STDMETHODCALLTYPE *DynamicMethodJITCompilationFinished )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ HRESULT hrStatus,
+            /* [in] */ BOOL fIsSafeToBlock);
+        
+        HRESULT ( STDMETHODCALLTYPE *DynamicMethodUnloaded )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeEventDelivered )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [in] */ DWORD eventId,
+            /* [in] */ DWORD eventVersion,
+            /* [in] */ ULONG cbMetadataBlob,
+            /* [size_is][in] */ LPCBYTE metadataBlob,
+            /* [in] */ ULONG cbEventData,
+            /* [size_is][in] */ LPCBYTE eventData,
+            /* [in] */ LPCGUID pActivityId,
+            /* [in] */ LPCGUID pRelatedActivityId,
+            /* [in] */ ThreadID eventThread,
+            /* [in] */ ULONG numStackFrames,
+            /* [length_is][in] */ UINT_PTR stackFrames[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeProviderCreated )( 
+            ICorProfilerCallback10 * This,
+            /* [in] */ EVENTPIPE_PROVIDER provider);
+        
+        END_INTERFACE
+    } ICorProfilerCallback10Vtbl;
+
+    interface ICorProfilerCallback10
+    {
+        CONST_VTBL struct ICorProfilerCallback10Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICorProfilerCallback10_QueryInterface(This,riid,ppvObject)  \
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICorProfilerCallback10_AddRef(This) \
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICorProfilerCallback10_Release(This)    \
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICorProfilerCallback10_Initialize(This,pICorProfilerInfoUnk)    \
+    ( (This)->lpVtbl -> Initialize(This,pICorProfilerInfoUnk) ) 
+
+#define ICorProfilerCallback10_Shutdown(This)   \
+    ( (This)->lpVtbl -> Shutdown(This) ) 
+
+#define ICorProfilerCallback10_AppDomainCreationStarted(This,appDomainId)   \
+    ( (This)->lpVtbl -> AppDomainCreationStarted(This,appDomainId) ) 
+
+#define ICorProfilerCallback10_AppDomainCreationFinished(This,appDomainId,hrStatus) \
+    ( (This)->lpVtbl -> AppDomainCreationFinished(This,appDomainId,hrStatus) ) 
+
+#define ICorProfilerCallback10_AppDomainShutdownStarted(This,appDomainId)   \
+    ( (This)->lpVtbl -> AppDomainShutdownStarted(This,appDomainId) ) 
+
+#define ICorProfilerCallback10_AppDomainShutdownFinished(This,appDomainId,hrStatus) \
+    ( (This)->lpVtbl -> AppDomainShutdownFinished(This,appDomainId,hrStatus) ) 
+
+#define ICorProfilerCallback10_AssemblyLoadStarted(This,assemblyId) \
+    ( (This)->lpVtbl -> AssemblyLoadStarted(This,assemblyId) ) 
+
+#define ICorProfilerCallback10_AssemblyLoadFinished(This,assemblyId,hrStatus)   \
+    ( (This)->lpVtbl -> AssemblyLoadFinished(This,assemblyId,hrStatus) ) 
+
+#define ICorProfilerCallback10_AssemblyUnloadStarted(This,assemblyId)   \
+    ( (This)->lpVtbl -> AssemblyUnloadStarted(This,assemblyId) ) 
+
+#define ICorProfilerCallback10_AssemblyUnloadFinished(This,assemblyId,hrStatus) \
+    ( (This)->lpVtbl -> AssemblyUnloadFinished(This,assemblyId,hrStatus) ) 
+
+#define ICorProfilerCallback10_ModuleLoadStarted(This,moduleId) \
+    ( (This)->lpVtbl -> ModuleLoadStarted(This,moduleId) ) 
+
+#define ICorProfilerCallback10_ModuleLoadFinished(This,moduleId,hrStatus)   \
+    ( (This)->lpVtbl -> ModuleLoadFinished(This,moduleId,hrStatus) ) 
+
+#define ICorProfilerCallback10_ModuleUnloadStarted(This,moduleId)   \
+    ( (This)->lpVtbl -> ModuleUnloadStarted(This,moduleId) ) 
+
+#define ICorProfilerCallback10_ModuleUnloadFinished(This,moduleId,hrStatus) \
+    ( (This)->lpVtbl -> ModuleUnloadFinished(This,moduleId,hrStatus) ) 
+
+#define ICorProfilerCallback10_ModuleAttachedToAssembly(This,moduleId,AssemblyId)   \
+    ( (This)->lpVtbl -> ModuleAttachedToAssembly(This,moduleId,AssemblyId) ) 
+
+#define ICorProfilerCallback10_ClassLoadStarted(This,classId)   \
+    ( (This)->lpVtbl -> ClassLoadStarted(This,classId) ) 
+
+#define ICorProfilerCallback10_ClassLoadFinished(This,classId,hrStatus) \
+    ( (This)->lpVtbl -> ClassLoadFinished(This,classId,hrStatus) ) 
+
+#define ICorProfilerCallback10_ClassUnloadStarted(This,classId) \
+    ( (This)->lpVtbl -> ClassUnloadStarted(This,classId) ) 
+
+#define ICorProfilerCallback10_ClassUnloadFinished(This,classId,hrStatus)   \
+    ( (This)->lpVtbl -> ClassUnloadFinished(This,classId,hrStatus) ) 
+
+#define ICorProfilerCallback10_FunctionUnloadStarted(This,functionId)   \
+    ( (This)->lpVtbl -> FunctionUnloadStarted(This,functionId) ) 
+
+#define ICorProfilerCallback10_JITCompilationStarted(This,functionId,fIsSafeToBlock)    \
+    ( (This)->lpVtbl -> JITCompilationStarted(This,functionId,fIsSafeToBlock) ) 
+
+#define ICorProfilerCallback10_JITCompilationFinished(This,functionId,hrStatus,fIsSafeToBlock)  \
+    ( (This)->lpVtbl -> JITCompilationFinished(This,functionId,hrStatus,fIsSafeToBlock) ) 
+
+#define ICorProfilerCallback10_JITCachedFunctionSearchStarted(This,functionId,pbUseCachedFunction)  \
+    ( (This)->lpVtbl -> JITCachedFunctionSearchStarted(This,functionId,pbUseCachedFunction) ) 
+
+#define ICorProfilerCallback10_JITCachedFunctionSearchFinished(This,functionId,result)  \
+    ( (This)->lpVtbl -> JITCachedFunctionSearchFinished(This,functionId,result) ) 
+
+#define ICorProfilerCallback10_JITFunctionPitched(This,functionId)  \
+    ( (This)->lpVtbl -> JITFunctionPitched(This,functionId) ) 
+
+#define ICorProfilerCallback10_JITInlining(This,callerId,calleeId,pfShouldInline)   \
+    ( (This)->lpVtbl -> JITInlining(This,callerId,calleeId,pfShouldInline) ) 
+
+#define ICorProfilerCallback10_ThreadCreated(This,threadId) \
+    ( (This)->lpVtbl -> ThreadCreated(This,threadId) ) 
+
+#define ICorProfilerCallback10_ThreadDestroyed(This,threadId)   \
+    ( (This)->lpVtbl -> ThreadDestroyed(This,threadId) ) 
+
+#define ICorProfilerCallback10_ThreadAssignedToOSThread(This,managedThreadId,osThreadId)    \
+    ( (This)->lpVtbl -> ThreadAssignedToOSThread(This,managedThreadId,osThreadId) ) 
+
+#define ICorProfilerCallback10_RemotingClientInvocationStarted(This)    \
+    ( (This)->lpVtbl -> RemotingClientInvocationStarted(This) ) 
+
+#define ICorProfilerCallback10_RemotingClientSendingMessage(This,pCookie,fIsAsync)  \
+    ( (This)->lpVtbl -> RemotingClientSendingMessage(This,pCookie,fIsAsync) ) 
+
+#define ICorProfilerCallback10_RemotingClientReceivingReply(This,pCookie,fIsAsync)  \
+    ( (This)->lpVtbl -> RemotingClientReceivingReply(This,pCookie,fIsAsync) ) 
+
+#define ICorProfilerCallback10_RemotingClientInvocationFinished(This)   \
+    ( (This)->lpVtbl -> RemotingClientInvocationFinished(This) ) 
+
+#define ICorProfilerCallback10_RemotingServerReceivingMessage(This,pCookie,fIsAsync)    \
+    ( (This)->lpVtbl -> RemotingServerReceivingMessage(This,pCookie,fIsAsync) ) 
+
+#define ICorProfilerCallback10_RemotingServerInvocationStarted(This)    \
+    ( (This)->lpVtbl -> RemotingServerInvocationStarted(This) ) 
+
+#define ICorProfilerCallback10_RemotingServerInvocationReturned(This)   \
+    ( (This)->lpVtbl -> RemotingServerInvocationReturned(This) ) 
+
+#define ICorProfilerCallback10_RemotingServerSendingReply(This,pCookie,fIsAsync)    \
+    ( (This)->lpVtbl -> RemotingServerSendingReply(This,pCookie,fIsAsync) ) 
+
+#define ICorProfilerCallback10_UnmanagedToManagedTransition(This,functionId,reason) \
+    ( (This)->lpVtbl -> UnmanagedToManagedTransition(This,functionId,reason) ) 
+
+#define ICorProfilerCallback10_ManagedToUnmanagedTransition(This,functionId,reason) \
+    ( (This)->lpVtbl -> ManagedToUnmanagedTransition(This,functionId,reason) ) 
+
+#define ICorProfilerCallback10_RuntimeSuspendStarted(This,suspendReason)    \
+    ( (This)->lpVtbl -> RuntimeSuspendStarted(This,suspendReason) ) 
+
+#define ICorProfilerCallback10_RuntimeSuspendFinished(This) \
+    ( (This)->lpVtbl -> RuntimeSuspendFinished(This) ) 
+
+#define ICorProfilerCallback10_RuntimeSuspendAborted(This)  \
+    ( (This)->lpVtbl -> RuntimeSuspendAborted(This) ) 
+
+#define ICorProfilerCallback10_RuntimeResumeStarted(This)   \
+    ( (This)->lpVtbl -> RuntimeResumeStarted(This) ) 
+
+#define ICorProfilerCallback10_RuntimeResumeFinished(This)  \
+    ( (This)->lpVtbl -> RuntimeResumeFinished(This) ) 
+
+#define ICorProfilerCallback10_RuntimeThreadSuspended(This,threadId)    \
+    ( (This)->lpVtbl -> RuntimeThreadSuspended(This,threadId) ) 
+
+#define ICorProfilerCallback10_RuntimeThreadResumed(This,threadId)  \
+    ( (This)->lpVtbl -> RuntimeThreadResumed(This,threadId) ) 
+
+#define ICorProfilerCallback10_MovedReferences(This,cMovedObjectIDRanges,oldObjectIDRangeStart,newObjectIDRangeStart,cObjectIDRangeLength)  \
+    ( (This)->lpVtbl -> MovedReferences(This,cMovedObjectIDRanges,oldObjectIDRangeStart,newObjectIDRangeStart,cObjectIDRangeLength) ) 
+
+#define ICorProfilerCallback10_ObjectAllocated(This,objectId,classId)   \
+    ( (This)->lpVtbl -> ObjectAllocated(This,objectId,classId) ) 
+
+#define ICorProfilerCallback10_ObjectsAllocatedByClass(This,cClassCount,classIds,cObjects)  \
+    ( (This)->lpVtbl -> ObjectsAllocatedByClass(This,cClassCount,classIds,cObjects) ) 
+
+#define ICorProfilerCallback10_ObjectReferences(This,objectId,classId,cObjectRefs,objectRefIds) \
+    ( (This)->lpVtbl -> ObjectReferences(This,objectId,classId,cObjectRefs,objectRefIds) ) 
+
+#define ICorProfilerCallback10_RootReferences(This,cRootRefs,rootRefIds)    \
+    ( (This)->lpVtbl -> RootReferences(This,cRootRefs,rootRefIds) ) 
+
+#define ICorProfilerCallback10_ExceptionThrown(This,thrownObjectId) \
+    ( (This)->lpVtbl -> ExceptionThrown(This,thrownObjectId) ) 
+
+#define ICorProfilerCallback10_ExceptionSearchFunctionEnter(This,functionId)    \
+    ( (This)->lpVtbl -> ExceptionSearchFunctionEnter(This,functionId) ) 
+
+#define ICorProfilerCallback10_ExceptionSearchFunctionLeave(This)   \
+    ( (This)->lpVtbl -> ExceptionSearchFunctionLeave(This) ) 
+
+#define ICorProfilerCallback10_ExceptionSearchFilterEnter(This,functionId)  \
+    ( (This)->lpVtbl -> ExceptionSearchFilterEnter(This,functionId) ) 
+
+#define ICorProfilerCallback10_ExceptionSearchFilterLeave(This) \
+    ( (This)->lpVtbl -> ExceptionSearchFilterLeave(This) ) 
+
+#define ICorProfilerCallback10_ExceptionSearchCatcherFound(This,functionId) \
+    ( (This)->lpVtbl -> ExceptionSearchCatcherFound(This,functionId) ) 
+
+#define ICorProfilerCallback10_ExceptionOSHandlerEnter(This,__unused)   \
+    ( (This)->lpVtbl -> ExceptionOSHandlerEnter(This,__unused) ) 
+
+#define ICorProfilerCallback10_ExceptionOSHandlerLeave(This,__unused)   \
+    ( (This)->lpVtbl -> ExceptionOSHandlerLeave(This,__unused) ) 
+
+#define ICorProfilerCallback10_ExceptionUnwindFunctionEnter(This,functionId)    \
+    ( (This)->lpVtbl -> ExceptionUnwindFunctionEnter(This,functionId) ) 
+
+#define ICorProfilerCallback10_ExceptionUnwindFunctionLeave(This)   \
+    ( (This)->lpVtbl -> ExceptionUnwindFunctionLeave(This) ) 
+
+#define ICorProfilerCallback10_ExceptionUnwindFinallyEnter(This,functionId) \
+    ( (This)->lpVtbl -> ExceptionUnwindFinallyEnter(This,functionId) ) 
+
+#define ICorProfilerCallback10_ExceptionUnwindFinallyLeave(This)    \
+    ( (This)->lpVtbl -> ExceptionUnwindFinallyLeave(This) ) 
+
+#define ICorProfilerCallback10_ExceptionCatcherEnter(This,functionId,objectId)  \
+    ( (This)->lpVtbl -> ExceptionCatcherEnter(This,functionId,objectId) ) 
+
+#define ICorProfilerCallback10_ExceptionCatcherLeave(This)  \
+    ( (This)->lpVtbl -> ExceptionCatcherLeave(This) ) 
+
+#define ICorProfilerCallback10_COMClassicVTableCreated(This,wrappedClassId,implementedIID,pVTable,cSlots)   \
+    ( (This)->lpVtbl -> COMClassicVTableCreated(This,wrappedClassId,implementedIID,pVTable,cSlots) ) 
+
+#define ICorProfilerCallback10_COMClassicVTableDestroyed(This,wrappedClassId,implementedIID,pVTable)    \
+    ( (This)->lpVtbl -> COMClassicVTableDestroyed(This,wrappedClassId,implementedIID,pVTable) ) 
+
+#define ICorProfilerCallback10_ExceptionCLRCatcherFound(This)   \
+    ( (This)->lpVtbl -> ExceptionCLRCatcherFound(This) ) 
+
+#define ICorProfilerCallback10_ExceptionCLRCatcherExecute(This) \
+    ( (This)->lpVtbl -> ExceptionCLRCatcherExecute(This) ) 
+
+
+#define ICorProfilerCallback10_ThreadNameChanged(This,threadId,cchName,name)    \
+    ( (This)->lpVtbl -> ThreadNameChanged(This,threadId,cchName,name) ) 
+
+#define ICorProfilerCallback10_GarbageCollectionStarted(This,cGenerations,generationCollected,reason)   \
+    ( (This)->lpVtbl -> GarbageCollectionStarted(This,cGenerations,generationCollected,reason) ) 
+
+#define ICorProfilerCallback10_SurvivingReferences(This,cSurvivingObjectIDRanges,objectIDRangeStart,cObjectIDRangeLength)   \
+    ( (This)->lpVtbl -> SurvivingReferences(This,cSurvivingObjectIDRanges,objectIDRangeStart,cObjectIDRangeLength) ) 
+
+#define ICorProfilerCallback10_GarbageCollectionFinished(This)  \
+    ( (This)->lpVtbl -> GarbageCollectionFinished(This) ) 
+
+#define ICorProfilerCallback10_FinalizeableObjectQueued(This,finalizerFlags,objectID)   \
+    ( (This)->lpVtbl -> FinalizeableObjectQueued(This,finalizerFlags,objectID) ) 
+
+#define ICorProfilerCallback10_RootReferences2(This,cRootRefs,rootRefIds,rootKinds,rootFlags,rootIds)   \
+    ( (This)->lpVtbl -> RootReferences2(This,cRootRefs,rootRefIds,rootKinds,rootFlags,rootIds) ) 
+
+#define ICorProfilerCallback10_HandleCreated(This,handleId,initialObjectId) \
+    ( (This)->lpVtbl -> HandleCreated(This,handleId,initialObjectId) ) 
+
+#define ICorProfilerCallback10_HandleDestroyed(This,handleId)   \
+    ( (This)->lpVtbl -> HandleDestroyed(This,handleId) ) 
+
+
+#define ICorProfilerCallback10_InitializeForAttach(This,pCorProfilerInfoUnk,pvClientData,cbClientData)  \
+    ( (This)->lpVtbl -> InitializeForAttach(This,pCorProfilerInfoUnk,pvClientData,cbClientData) ) 
+
+#define ICorProfilerCallback10_ProfilerAttachComplete(This) \
+    ( (This)->lpVtbl -> ProfilerAttachComplete(This) ) 
+
+#define ICorProfilerCallback10_ProfilerDetachSucceeded(This)    \
+    ( (This)->lpVtbl -> ProfilerDetachSucceeded(This) ) 
+
+
+#define ICorProfilerCallback10_ReJITCompilationStarted(This,functionId,rejitId,fIsSafeToBlock)  \
+    ( (This)->lpVtbl -> ReJITCompilationStarted(This,functionId,rejitId,fIsSafeToBlock) ) 
+
+#define ICorProfilerCallback10_GetReJITParameters(This,moduleId,methodId,pFunctionControl)  \
+    ( (This)->lpVtbl -> GetReJITParameters(This,moduleId,methodId,pFunctionControl) ) 
+
+#define ICorProfilerCallback10_ReJITCompilationFinished(This,functionId,rejitId,hrStatus,fIsSafeToBlock)    \
+    ( (This)->lpVtbl -> ReJITCompilationFinished(This,functionId,rejitId,hrStatus,fIsSafeToBlock) ) 
+
+#define ICorProfilerCallback10_ReJITError(This,moduleId,methodId,functionId,hrStatus)   \
+    ( (This)->lpVtbl -> ReJITError(This,moduleId,methodId,functionId,hrStatus) ) 
+
+#define ICorProfilerCallback10_MovedReferences2(This,cMovedObjectIDRanges,oldObjectIDRangeStart,newObjectIDRangeStart,cObjectIDRangeLength) \
+    ( (This)->lpVtbl -> MovedReferences2(This,cMovedObjectIDRanges,oldObjectIDRangeStart,newObjectIDRangeStart,cObjectIDRangeLength) ) 
+
+#define ICorProfilerCallback10_SurvivingReferences2(This,cSurvivingObjectIDRanges,objectIDRangeStart,cObjectIDRangeLength)  \
+    ( (This)->lpVtbl -> SurvivingReferences2(This,cSurvivingObjectIDRanges,objectIDRangeStart,cObjectIDRangeLength) ) 
+
+
+#define ICorProfilerCallback10_ConditionalWeakTableElementReferences(This,cRootRefs,keyRefIds,valueRefIds,rootIds)  \
+    ( (This)->lpVtbl -> ConditionalWeakTableElementReferences(This,cRootRefs,keyRefIds,valueRefIds,rootIds) ) 
+
+
+#define ICorProfilerCallback10_GetAssemblyReferences(This,wszAssemblyPath,pAsmRefProvider)  \
+    ( (This)->lpVtbl -> GetAssemblyReferences(This,wszAssemblyPath,pAsmRefProvider) ) 
+
+
+#define ICorProfilerCallback10_ModuleInMemorySymbolsUpdated(This,moduleId)  \
+    ( (This)->lpVtbl -> ModuleInMemorySymbolsUpdated(This,moduleId) ) 
+
+
+#define ICorProfilerCallback10_DynamicMethodJITCompilationStarted(This,functionId,fIsSafeToBlock,pILHeader,cbILHeader)  \
+    ( (This)->lpVtbl -> DynamicMethodJITCompilationStarted(This,functionId,fIsSafeToBlock,pILHeader,cbILHeader) ) 
+
+#define ICorProfilerCallback10_DynamicMethodJITCompilationFinished(This,functionId,hrStatus,fIsSafeToBlock) \
+    ( (This)->lpVtbl -> DynamicMethodJITCompilationFinished(This,functionId,hrStatus,fIsSafeToBlock) ) 
+
+
+#define ICorProfilerCallback10_DynamicMethodUnloaded(This,functionId)   \
+    ( (This)->lpVtbl -> DynamicMethodUnloaded(This,functionId) ) 
+
+
+#define ICorProfilerCallback10_EventPipeEventDelivered(This,provider,eventId,eventVersion,cbMetadataBlob,metadataBlob,cbEventData,eventData,pActivityId,pRelatedActivityId,eventThread,numStackFrames,stackFrames)  \
+    ( (This)->lpVtbl -> EventPipeEventDelivered(This,provider,eventId,eventVersion,cbMetadataBlob,metadataBlob,cbEventData,eventData,pActivityId,pRelatedActivityId,eventThread,numStackFrames,stackFrames) ) 
+
+#define ICorProfilerCallback10_EventPipeProviderCreated(This,provider)  \
+    ( (This)->lpVtbl -> EventPipeProviderCreated(This,provider) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif  /* C style interface */
+
+
+
+
+#endif  /* __ICorProfilerCallback10_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_corprof_0000_0010 */
 /* [local] */ 
 
 typedef /* [public] */ 
-enum __MIDL___MIDL_itf_corprof_0000_0009_0001
+enum __MIDL___MIDL_itf_corprof_0000_0010_0001
     {
         COR_PRF_CODEGEN_DISABLE_INLINING    = 0x1,
         COR_PRF_CODEGEN_DISABLE_ALL_OPTIMIZATIONS   = 0x2
@@ -7461,8 +8363,8 @@ enum __MIDL___MIDL_itf_corprof_0000_0009_0001
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_corprof_0000_0009_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_corprof_0000_0009_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_corprof_0000_0010_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_corprof_0000_0010_v0_0_s_ifspec;
 
 #ifndef __ICorProfilerInfo_INTERFACE_DEFINED__
 #define __ICorProfilerInfo_INTERFACE_DEFINED__
@@ -17152,6 +18054,1102 @@ EXTERN_C const IID IID_ICorProfilerInfo11;
 
 
 #endif  /* __ICorProfilerInfo11_INTERFACE_DEFINED__ */
+
+
+#ifndef __ICorProfilerInfo12_INTERFACE_DEFINED__
+#define __ICorProfilerInfo12_INTERFACE_DEFINED__
+
+/* interface ICorProfilerInfo12 */
+/* [local][unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ICorProfilerInfo12;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("27b24ccd-1cb1-47c5-96ee-98190dc30959")
+    ICorProfilerInfo12 : public ICorProfilerInfo11
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE EventPipeStartSession( 
+            /* [in] */ UINT32 cProviderConfigs,
+            /* [size_is][in] */ COR_PRF_EVENTPIPE_PROVIDER_CONFIG pProviderConfigs[  ],
+            /* [in] */ BOOL requestRundown,
+            /* [out] */ EVENTPIPE_SESSION *pSession) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeAddProviderToSession( 
+            /* [in] */ EVENTPIPE_SESSION session,
+            /* [in] */ COR_PRF_EVENTPIPE_PROVIDER_CONFIG providerConfig) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeStopSession( 
+            /* [in] */ EVENTPIPE_SESSION session) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeCreateProvider( 
+            /* [string][in] */ const WCHAR *providerName,
+            /* [out] */ EVENTPIPE_PROVIDER *pProvider) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeGetProviderInfo( 
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR providerName[  ]) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeDefineEvent( 
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [string][in] */ const WCHAR *eventName,
+            /* [in] */ UINT32 eventID,
+            /* [in] */ UINT64 keywords,
+            /* [in] */ UINT32 eventVersion,
+            /* [in] */ UINT32 level,
+            /* [in] */ UINT8 opcode,
+            /* [in] */ BOOL needStack,
+            /* [in] */ UINT32 cParamDescs,
+            /* [size_is][in] */ COR_PRF_EVENTPIPE_PARAM_DESC pParamDescs[  ],
+            /* [out] */ EVENTPIPE_EVENT *pEvent) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EventPipeWriteEvent( 
+            /* [in] */ EVENTPIPE_EVENT event,
+            /* [in] */ UINT32 cData,
+            /* [size_is][in] */ COR_PRF_EVENT_DATA data[  ],
+            /* [in] */ LPCGUID pActivityId,
+            /* [in] */ LPCGUID pRelatedActivityId) = 0;
+        
+    };
+    
+    
+#else   /* C style interface */
+
+    typedef struct ICorProfilerInfo12Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ICorProfilerInfo12 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ICorProfilerInfo12 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassFromObject )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ObjectID objectId,
+            /* [out] */ ClassID *pClassId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassFromToken )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdTypeDef typeDef,
+            /* [out] */ ClassID *pClassId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodeInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [out] */ LPCBYTE *pStart,
+            /* [out] */ ULONG *pcSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetEventMask )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ DWORD *pdwEvents);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionFromIP )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ LPCBYTE ip,
+            /* [out] */ FunctionID *pFunctionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionFromToken )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdToken token,
+            /* [out] */ FunctionID *pFunctionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetHandleFromThread )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ HANDLE *phThread);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetObjectSize )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ObjectID objectId,
+            /* [out] */ ULONG *pcSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsArrayClass )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [out] */ CorElementType *pBaseElemType,
+            /* [out] */ ClassID *pBaseClassId,
+            /* [out] */ ULONG *pcRank);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetThreadInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ DWORD *pdwWin32ThreadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCurrentThreadID )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ThreadID *pThreadId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassIDInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [out] */ ModuleID *pModuleId,
+            /* [out] */ mdTypeDef *pTypeDefToken);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [out] */ ClassID *pClassId,
+            /* [out] */ ModuleID *pModuleId,
+            /* [out] */ mdToken *pToken);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEventMask )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ DWORD dwEvents);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEnterLeaveFunctionHooks )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionEnter *pFuncEnter,
+            /* [in] */ FunctionLeave *pFuncLeave,
+            /* [in] */ FunctionTailcall *pFuncTailcall);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetFunctionIDMapper )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionIDMapper *pFunc);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetTokenAndMetaDataFromFunction )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ REFIID riid,
+            /* [out] */ IUnknown **ppImport,
+            /* [out] */ mdToken *pToken);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetModuleInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [out] */ LPCBYTE *ppBaseLoadAddress,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR szName[  ],
+            /* [out] */ AssemblyID *pAssemblyId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetModuleMetaData )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ DWORD dwOpenFlags,
+            /* [in] */ REFIID riid,
+            /* [out] */ IUnknown **ppOut);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetILFunctionBody )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdMethodDef methodId,
+            /* [out] */ LPCBYTE *ppMethodHeader,
+            /* [out] */ ULONG *pcbMethodSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetILFunctionBodyAllocator )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [out] */ IMethodMalloc **ppMalloc);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetILFunctionBody )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ mdMethodDef methodid,
+            /* [in] */ LPCBYTE pbNewILMethodHeader);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ AppDomainID appDomainId,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR szName[  ],
+            /* [out] */ ProcessID *pProcessId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ AssemblyID assemblyId,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR szName[  ],
+            /* [out] */ AppDomainID *pAppDomainId,
+            /* [out] */ ModuleID *pModuleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetFunctionReJIT )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId);
+        
+        HRESULT ( STDMETHODCALLTYPE *ForceGC )( 
+            ICorProfilerInfo12 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetILInstrumentedCodeMap )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ BOOL fStartJit,
+            /* [in] */ ULONG cILMapEntries,
+            /* [size_is][in] */ COR_IL_MAP rgILMapEntries[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetInprocInspectionInterface )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ IUnknown **ppicd);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetInprocInspectionIThisThread )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ IUnknown **ppicd);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetThreadContext )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ ContextID *pContextId);
+        
+        HRESULT ( STDMETHODCALLTYPE *BeginInprocDebugging )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ BOOL fThisThreadOnly,
+            /* [out] */ DWORD *pdwProfilerContext);
+        
+        HRESULT ( STDMETHODCALLTYPE *EndInprocDebugging )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ DWORD dwProfilerContext);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetILToNativeMapping )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ULONG32 cMap,
+            /* [out] */ ULONG32 *pcMap,
+            /* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *DoStackSnapshot )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ThreadID thread,
+            /* [in] */ StackSnapshotCallback *callback,
+            /* [in] */ ULONG32 infoFlags,
+            /* [in] */ void *clientData,
+            /* [size_is][in] */ BYTE context[  ],
+            /* [in] */ ULONG32 contextSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEnterLeaveFunctionHooks2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionEnter2 *pFuncEnter,
+            /* [in] */ FunctionLeave2 *pFuncLeave,
+            /* [in] */ FunctionTailcall2 *pFuncTailcall);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionInfo2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID funcId,
+            /* [in] */ COR_PRF_FRAME_INFO frameInfo,
+            /* [out] */ ClassID *pClassId,
+            /* [out] */ ModuleID *pModuleId,
+            /* [out] */ mdToken *pToken,
+            /* [in] */ ULONG32 cTypeArgs,
+            /* [out] */ ULONG32 *pcTypeArgs,
+            /* [out] */ ClassID typeArgs[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetStringLayout )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ULONG *pBufferLengthOffset,
+            /* [out] */ ULONG *pStringLengthOffset,
+            /* [out] */ ULONG *pBufferOffset);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassLayout )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classID,
+            /* [out][in] */ COR_FIELD_OFFSET rFieldOffset[  ],
+            /* [in] */ ULONG cFieldOffset,
+            /* [out] */ ULONG *pcFieldOffset,
+            /* [out] */ ULONG *pulClassSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassIDInfo2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [out] */ ModuleID *pModuleId,
+            /* [out] */ mdTypeDef *pTypeDefToken,
+            /* [out] */ ClassID *pParentClassId,
+            /* [in] */ ULONG32 cNumTypeArgs,
+            /* [out] */ ULONG32 *pcNumTypeArgs,
+            /* [out] */ ClassID typeArgs[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodeInfo2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionID,
+            /* [in] */ ULONG32 cCodeInfos,
+            /* [out] */ ULONG32 *pcCodeInfos,
+            /* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassFromTokenAndTypeArgs )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleID,
+            /* [in] */ mdTypeDef typeDef,
+            /* [in] */ ULONG32 cTypeArgs,
+            /* [size_is][in] */ ClassID typeArgs[  ],
+            /* [out] */ ClassID *pClassID);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionFromTokenAndTypeArgs )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleID,
+            /* [in] */ mdMethodDef funcDef,
+            /* [in] */ ClassID classId,
+            /* [in] */ ULONG32 cTypeArgs,
+            /* [size_is][in] */ ClassID typeArgs[  ],
+            /* [out] */ FunctionID *pFunctionID);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumModuleFrozenObjects )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleID,
+            /* [out] */ ICorProfilerObjectEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetArrayObjectInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ObjectID objectId,
+            /* [in] */ ULONG32 cDimensions,
+            /* [size_is][out] */ ULONG32 pDimensionSizes[  ],
+            /* [size_is][out] */ int pDimensionLowerBounds[  ],
+            /* [out] */ BYTE **ppData);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetBoxClassLayout )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [out] */ ULONG32 *pBufferOffset);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetThreadAppDomain )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ AppDomainID *pAppDomainId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRVAStaticAddress )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [out] */ void **ppAddress);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainStaticAddress )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [in] */ AppDomainID appDomainId,
+            /* [out] */ void **ppAddress);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetThreadStaticAddress )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ void **ppAddress);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetContextStaticAddress )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [in] */ ContextID contextId,
+            /* [out] */ void **ppAddress);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetStaticFieldInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [out] */ COR_PRF_STATIC_TYPE *pFieldInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetGenerationBounds )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ULONG cObjectRanges,
+            /* [out] */ ULONG *pcObjectRanges,
+            /* [length_is][size_is][out] */ COR_PRF_GC_GENERATION_RANGE ranges[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetObjectGeneration )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ObjectID objectId,
+            /* [out] */ COR_PRF_GC_GENERATION_RANGE *range);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetNotifiedExceptionClauseInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ COR_PRF_EX_CLAUSE_INFO *pinfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumJITedFunctions )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ICorProfilerFunctionEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *RequestProfilerDetach )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ DWORD dwExpectedCompletionMilliseconds);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetFunctionIDMapper2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionIDMapper2 *pFunc,
+            /* [in] */ void *clientData);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetStringLayout2 )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ULONG *pStringLengthOffset,
+            /* [out] */ ULONG *pBufferOffset);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEnterLeaveFunctionHooks3 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionEnter3 *pFuncEnter3,
+            /* [in] */ FunctionLeave3 *pFuncLeave3,
+            /* [in] */ FunctionTailcall3 *pFuncTailcall3);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEnterLeaveFunctionHooks3WithInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionEnter3WithInfo *pFuncEnter3WithInfo,
+            /* [in] */ FunctionLeave3WithInfo *pFuncLeave3WithInfo,
+            /* [in] */ FunctionTailcall3WithInfo *pFuncTailcall3WithInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionEnter3Info )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_ELT_INFO eltInfo,
+            /* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
+            /* [out][in] */ ULONG *pcbArgumentInfo,
+            /* [size_is][out] */ COR_PRF_FUNCTION_ARGUMENT_INFO *pArgumentInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionLeave3Info )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_ELT_INFO eltInfo,
+            /* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
+            /* [out] */ COR_PRF_FUNCTION_ARGUMENT_RANGE *pRetvalRange);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionTailcall3Info )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ COR_PRF_ELT_INFO eltInfo,
+            /* [out] */ COR_PRF_FRAME_INFO *pFrameInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumModules )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ICorProfilerModuleEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRuntimeInformation )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ USHORT *pClrInstanceId,
+            /* [out] */ COR_PRF_RUNTIME_TYPE *pRuntimeType,
+            /* [out] */ USHORT *pMajorVersion,
+            /* [out] */ USHORT *pMinorVersion,
+            /* [out] */ USHORT *pBuildNumber,
+            /* [out] */ USHORT *pQFEVersion,
+            /* [in] */ ULONG cchVersionString,
+            /* [out] */ ULONG *pcchVersionString,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchVersionString, *pcchVersionString)  WCHAR szVersionString[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetThreadStaticAddress2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ClassID classId,
+            /* [in] */ mdFieldDef fieldToken,
+            /* [in] */ AppDomainID appDomainId,
+            /* [in] */ ThreadID threadId,
+            /* [out] */ void **ppAddress);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainsContainingModule )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ ULONG32 cAppDomainIds,
+            /* [out] */ ULONG32 *pcAppDomainIds,
+            /* [length_is][size_is][out] */ AppDomainID appDomainIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetModuleInfo2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [out] */ LPCBYTE *ppBaseLoadAddress,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR szName[  ],
+            /* [out] */ AssemblyID *pAssemblyId,
+            /* [out] */ DWORD *pdwModuleFlags);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumThreads )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ICorProfilerThreadEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *InitializeCurrentThread )( 
+            ICorProfilerInfo12 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *RequestReJIT )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ULONG cFunctions,
+            /* [size_is][in] */ ModuleID moduleIds[  ],
+            /* [size_is][in] */ mdMethodDef methodIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *RequestRevert )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ULONG cFunctions,
+            /* [size_is][in] */ ModuleID moduleIds[  ],
+            /* [size_is][in] */ mdMethodDef methodIds[  ],
+            /* [size_is][out] */ HRESULT status[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodeInfo3 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionID,
+            /* [in] */ ReJITID reJitId,
+            /* [in] */ ULONG32 cCodeInfos,
+            /* [out] */ ULONG32 *pcCodeInfos,
+            /* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionFromIP2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ LPCBYTE ip,
+            /* [out] */ FunctionID *pFunctionId,
+            /* [out] */ ReJITID *pReJitId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetReJITIDs )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ULONG cReJitIds,
+            /* [out] */ ULONG *pcReJitIds,
+            /* [length_is][size_is][out] */ ReJITID reJitIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetILToNativeMapping2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [in] */ ReJITID reJitId,
+            /* [in] */ ULONG32 cMap,
+            /* [out] */ ULONG32 *pcMap,
+            /* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumJITedFunctions2 )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ ICorProfilerFunctionEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetObjectSize2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ObjectID objectId,
+            /* [out] */ SIZE_T *pcSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetEventMask2 )( 
+            ICorProfilerInfo12 * This,
+            /* [out] */ DWORD *pdwEventsLow,
+            /* [out] */ DWORD *pdwEventsHigh);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEventMask2 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ DWORD dwEventsLow,
+            /* [in] */ DWORD dwEventsHigh);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumNgenModuleMethodsInliningThisMethod )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID inlinersModuleId,
+            /* [in] */ ModuleID inlineeModuleId,
+            /* [in] */ mdMethodDef inlineeMethodId,
+            /* [out] */ BOOL *incompleteData,
+            /* [out] */ ICorProfilerMethodEnum **ppEnum);
+        
+        HRESULT ( STDMETHODCALLTYPE *ApplyMetaData )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetInMemorySymbolsLength )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [out] */ DWORD *pCountSymbolBytes);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReadInMemorySymbols )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ ModuleID moduleId,
+            /* [in] */ DWORD symbolsReadOffset,
+            /* [out] */ BYTE *pSymbolBytes,
+            /* [in] */ DWORD countSymbolBytes,
+            /* [out] */ DWORD *pCountSymbolBytesRead);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsFunctionDynamic )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [out] */ BOOL *isDynamic);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFunctionFromIP3 )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ LPCBYTE ip,
+            /* [out] */ FunctionID *functionId,
+            /* [out] */ ReJITID *pReJitId);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDynamicFunctionInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ FunctionID functionId,
+            /* [out] */ ModuleID *moduleId,
+            /* [out] */ PCCOR_SIGNATURE *ppvSig,
+            /* [out] */ ULONG *pbSig,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [out] */ WCHAR wszName[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetNativeCodeStartAddresses )( 
+            ICorProfilerInfo12 * This,
+            FunctionID functionID,
+            ReJITID reJitId,
+            ULONG32 cCodeStartAddresses,
+            ULONG32 *pcCodeStartAddresses,
+            UINT_PTR codeStartAddresses[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetILToNativeMapping3 )( 
+            ICorProfilerInfo12 * This,
+            UINT_PTR pNativeCodeStartAddress,
+            ULONG32 cMap,
+            ULONG32 *pcMap,
+            COR_DEBUG_IL_TO_NATIVE_MAP map[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodeInfo4 )( 
+            ICorProfilerInfo12 * This,
+            UINT_PTR pNativeCodeStartAddress,
+            ULONG32 cCodeInfos,
+            ULONG32 *pcCodeInfos,
+            COR_PRF_CODE_INFO codeInfos[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateObjectReferences )( 
+            ICorProfilerInfo12 * This,
+            ObjectID objectId,
+            ObjectReferenceCallback callback,
+            void *clientData);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsFrozenObject )( 
+            ICorProfilerInfo12 * This,
+            ObjectID objectId,
+            BOOL *pbFrozen);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLOHObjectSizeThreshold )( 
+            ICorProfilerInfo12 * This,
+            DWORD *pThreshold);
+        
+        HRESULT ( STDMETHODCALLTYPE *RequestReJITWithInliners )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ DWORD dwRejitFlags,
+            /* [in] */ ULONG cFunctions,
+            /* [size_is][in] */ ModuleID moduleIds[  ],
+            /* [size_is][in] */ mdMethodDef methodIds[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *SuspendRuntime )( 
+            ICorProfilerInfo12 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ResumeRuntime )( 
+            ICorProfilerInfo12 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetEnvironmentVariable )( 
+            ICorProfilerInfo12 * This,
+            /* [string][in] */ const WCHAR *szName,
+            /* [in] */ ULONG cchValue,
+            /* [out] */ ULONG *pcchValue,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchValue, *pcchValue)  WCHAR szValue[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetEnvironmentVariable )( 
+            ICorProfilerInfo12 * This,
+            /* [string][in] */ const WCHAR *szName,
+            /* [string][in] */ const WCHAR *szValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeStartSession )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ UINT32 cProviderConfigs,
+            /* [size_is][in] */ COR_PRF_EVENTPIPE_PROVIDER_CONFIG pProviderConfigs[  ],
+            /* [in] */ BOOL requestRundown,
+            /* [out] */ EVENTPIPE_SESSION *pSession);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeAddProviderToSession )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ EVENTPIPE_SESSION session,
+            /* [in] */ COR_PRF_EVENTPIPE_PROVIDER_CONFIG providerConfig);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeStopSession )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ EVENTPIPE_SESSION session);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeCreateProvider )( 
+            ICorProfilerInfo12 * This,
+            /* [string][in] */ const WCHAR *providerName,
+            /* [out] */ EVENTPIPE_PROVIDER *pProvider);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeGetProviderInfo )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [in] */ ULONG cchName,
+            /* [out] */ ULONG *pcchName,
+            /* [annotation][out] */ 
+            _Out_writes_to_(cchName, *pcchName)  WCHAR providerName[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeDefineEvent )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ EVENTPIPE_PROVIDER provider,
+            /* [string][in] */ const WCHAR *eventName,
+            /* [in] */ UINT32 eventID,
+            /* [in] */ UINT64 keywords,
+            /* [in] */ UINT32 eventVersion,
+            /* [in] */ UINT32 level,
+            /* [in] */ UINT8 opcode,
+            /* [in] */ BOOL needStack,
+            /* [in] */ UINT32 cParamDescs,
+            /* [size_is][in] */ COR_PRF_EVENTPIPE_PARAM_DESC pParamDescs[  ],
+            /* [out] */ EVENTPIPE_EVENT *pEvent);
+        
+        HRESULT ( STDMETHODCALLTYPE *EventPipeWriteEvent )( 
+            ICorProfilerInfo12 * This,
+            /* [in] */ EVENTPIPE_EVENT event,
+            /* [in] */ UINT32 cData,
+            /* [size_is][in] */ COR_PRF_EVENT_DATA data[  ],
+            /* [in] */ LPCGUID pActivityId,
+            /* [in] */ LPCGUID pRelatedActivityId);
+        
+        END_INTERFACE
+    } ICorProfilerInfo12Vtbl;
+
+    interface ICorProfilerInfo12
+    {
+        CONST_VTBL struct ICorProfilerInfo12Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICorProfilerInfo12_QueryInterface(This,riid,ppvObject)  \
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICorProfilerInfo12_AddRef(This) \
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICorProfilerInfo12_Release(This)    \
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICorProfilerInfo12_GetClassFromObject(This,objectId,pClassId)   \
+    ( (This)->lpVtbl -> GetClassFromObject(This,objectId,pClassId) ) 
+
+#define ICorProfilerInfo12_GetClassFromToken(This,moduleId,typeDef,pClassId)    \
+    ( (This)->lpVtbl -> GetClassFromToken(This,moduleId,typeDef,pClassId) ) 
+
+#define ICorProfilerInfo12_GetCodeInfo(This,functionId,pStart,pcSize)   \
+    ( (This)->lpVtbl -> GetCodeInfo(This,functionId,pStart,pcSize) ) 
+
+#define ICorProfilerInfo12_GetEventMask(This,pdwEvents) \
+    ( (This)->lpVtbl -> GetEventMask(This,pdwEvents) ) 
+
+#define ICorProfilerInfo12_GetFunctionFromIP(This,ip,pFunctionId)   \
+    ( (This)->lpVtbl -> GetFunctionFromIP(This,ip,pFunctionId) ) 
+
+#define ICorProfilerInfo12_GetFunctionFromToken(This,moduleId,token,pFunctionId)    \
+    ( (This)->lpVtbl -> GetFunctionFromToken(This,moduleId,token,pFunctionId) ) 
+
+#define ICorProfilerInfo12_GetHandleFromThread(This,threadId,phThread)  \
+    ( (This)->lpVtbl -> GetHandleFromThread(This,threadId,phThread) ) 
+
+#define ICorProfilerInfo12_GetObjectSize(This,objectId,pcSize)  \
+    ( (This)->lpVtbl -> GetObjectSize(This,objectId,pcSize) ) 
+
+#define ICorProfilerInfo12_IsArrayClass(This,classId,pBaseElemType,pBaseClassId,pcRank) \
+    ( (This)->lpVtbl -> IsArrayClass(This,classId,pBaseElemType,pBaseClassId,pcRank) ) 
+
+#define ICorProfilerInfo12_GetThreadInfo(This,threadId,pdwWin32ThreadId)    \
+    ( (This)->lpVtbl -> GetThreadInfo(This,threadId,pdwWin32ThreadId) ) 
+
+#define ICorProfilerInfo12_GetCurrentThreadID(This,pThreadId)   \
+    ( (This)->lpVtbl -> GetCurrentThreadID(This,pThreadId) ) 
+
+#define ICorProfilerInfo12_GetClassIDInfo(This,classId,pModuleId,pTypeDefToken) \
+    ( (This)->lpVtbl -> GetClassIDInfo(This,classId,pModuleId,pTypeDefToken) ) 
+
+#define ICorProfilerInfo12_GetFunctionInfo(This,functionId,pClassId,pModuleId,pToken)   \
+    ( (This)->lpVtbl -> GetFunctionInfo(This,functionId,pClassId,pModuleId,pToken) ) 
+
+#define ICorProfilerInfo12_SetEventMask(This,dwEvents)  \
+    ( (This)->lpVtbl -> SetEventMask(This,dwEvents) ) 
+
+#define ICorProfilerInfo12_SetEnterLeaveFunctionHooks(This,pFuncEnter,pFuncLeave,pFuncTailcall) \
+    ( (This)->lpVtbl -> SetEnterLeaveFunctionHooks(This,pFuncEnter,pFuncLeave,pFuncTailcall) ) 
+
+#define ICorProfilerInfo12_SetFunctionIDMapper(This,pFunc)  \
+    ( (This)->lpVtbl -> SetFunctionIDMapper(This,pFunc) ) 
+
+#define ICorProfilerInfo12_GetTokenAndMetaDataFromFunction(This,functionId,riid,ppImport,pToken)    \
+    ( (This)->lpVtbl -> GetTokenAndMetaDataFromFunction(This,functionId,riid,ppImport,pToken) ) 
+
+#define ICorProfilerInfo12_GetModuleInfo(This,moduleId,ppBaseLoadAddress,cchName,pcchName,szName,pAssemblyId)   \
+    ( (This)->lpVtbl -> GetModuleInfo(This,moduleId,ppBaseLoadAddress,cchName,pcchName,szName,pAssemblyId) ) 
+
+#define ICorProfilerInfo12_GetModuleMetaData(This,moduleId,dwOpenFlags,riid,ppOut)  \
+    ( (This)->lpVtbl -> GetModuleMetaData(This,moduleId,dwOpenFlags,riid,ppOut) ) 
+
+#define ICorProfilerInfo12_GetILFunctionBody(This,moduleId,methodId,ppMethodHeader,pcbMethodSize)   \
+    ( (This)->lpVtbl -> GetILFunctionBody(This,moduleId,methodId,ppMethodHeader,pcbMethodSize) ) 
+
+#define ICorProfilerInfo12_GetILFunctionBodyAllocator(This,moduleId,ppMalloc)   \
+    ( (This)->lpVtbl -> GetILFunctionBodyAllocator(This,moduleId,ppMalloc) ) 
+
+#define ICorProfilerInfo12_SetILFunctionBody(This,moduleId,methodid,pbNewILMethodHeader)    \
+    ( (This)->lpVtbl -> SetILFunctionBody(This,moduleId,methodid,pbNewILMethodHeader) ) 
+
+#define ICorProfilerInfo12_GetAppDomainInfo(This,appDomainId,cchName,pcchName,szName,pProcessId)    \
+    ( (This)->lpVtbl -> GetAppDomainInfo(This,appDomainId,cchName,pcchName,szName,pProcessId) ) 
+
+#define ICorProfilerInfo12_GetAssemblyInfo(This,assemblyId,cchName,pcchName,szName,pAppDomainId,pModuleId)  \
+    ( (This)->lpVtbl -> GetAssemblyInfo(This,assemblyId,cchName,pcchName,szName,pAppDomainId,pModuleId) ) 
+
+#define ICorProfilerInfo12_SetFunctionReJIT(This,functionId)    \
+    ( (This)->lpVtbl -> SetFunctionReJIT(This,functionId) ) 
+
+#define ICorProfilerInfo12_ForceGC(This)    \
+    ( (This)->lpVtbl -> ForceGC(This) ) 
+
+#define ICorProfilerInfo12_SetILInstrumentedCodeMap(This,functionId,fStartJit,cILMapEntries,rgILMapEntries) \
+    ( (This)->lpVtbl -> SetILInstrumentedCodeMap(This,functionId,fStartJit,cILMapEntries,rgILMapEntries) ) 
+
+#define ICorProfilerInfo12_GetInprocInspectionInterface(This,ppicd) \
+    ( (This)->lpVtbl -> GetInprocInspectionInterface(This,ppicd) ) 
+
+#define ICorProfilerInfo12_GetInprocInspectionIThisThread(This,ppicd)   \
+    ( (This)->lpVtbl -> GetInprocInspectionIThisThread(This,ppicd) ) 
+
+#define ICorProfilerInfo12_GetThreadContext(This,threadId,pContextId)   \
+    ( (This)->lpVtbl -> GetThreadContext(This,threadId,pContextId) ) 
+
+#define ICorProfilerInfo12_BeginInprocDebugging(This,fThisThreadOnly,pdwProfilerContext)    \
+    ( (This)->lpVtbl -> BeginInprocDebugging(This,fThisThreadOnly,pdwProfilerContext) ) 
+
+#define ICorProfilerInfo12_EndInprocDebugging(This,dwProfilerContext)   \
+    ( (This)->lpVtbl -> EndInprocDebugging(This,dwProfilerContext) ) 
+
+#define ICorProfilerInfo12_GetILToNativeMapping(This,functionId,cMap,pcMap,map) \
+    ( (This)->lpVtbl -> GetILToNativeMapping(This,functionId,cMap,pcMap,map) ) 
+
+
+#define ICorProfilerInfo12_DoStackSnapshot(This,thread,callback,infoFlags,clientData,context,contextSize)   \
+    ( (This)->lpVtbl -> DoStackSnapshot(This,thread,callback,infoFlags,clientData,context,contextSize) ) 
+
+#define ICorProfilerInfo12_SetEnterLeaveFunctionHooks2(This,pFuncEnter,pFuncLeave,pFuncTailcall)    \
+    ( (This)->lpVtbl -> SetEnterLeaveFunctionHooks2(This,pFuncEnter,pFuncLeave,pFuncTailcall) ) 
+
+#define ICorProfilerInfo12_GetFunctionInfo2(This,funcId,frameInfo,pClassId,pModuleId,pToken,cTypeArgs,pcTypeArgs,typeArgs)  \
+    ( (This)->lpVtbl -> GetFunctionInfo2(This,funcId,frameInfo,pClassId,pModuleId,pToken,cTypeArgs,pcTypeArgs,typeArgs) ) 
+
+#define ICorProfilerInfo12_GetStringLayout(This,pBufferLengthOffset,pStringLengthOffset,pBufferOffset)  \
+    ( (This)->lpVtbl -> GetStringLayout(This,pBufferLengthOffset,pStringLengthOffset,pBufferOffset) ) 
+
+#define ICorProfilerInfo12_GetClassLayout(This,classID,rFieldOffset,cFieldOffset,pcFieldOffset,pulClassSize)    \
+    ( (This)->lpVtbl -> GetClassLayout(This,classID,rFieldOffset,cFieldOffset,pcFieldOffset,pulClassSize) ) 
+
+#define ICorProfilerInfo12_GetClassIDInfo2(This,classId,pModuleId,pTypeDefToken,pParentClassId,cNumTypeArgs,pcNumTypeArgs,typeArgs) \
+    ( (This)->lpVtbl -> GetClassIDInfo2(This,classId,pModuleId,pTypeDefToken,pParentClassId,cNumTypeArgs,pcNumTypeArgs,typeArgs) ) 
+
+#define ICorProfilerInfo12_GetCodeInfo2(This,functionID,cCodeInfos,pcCodeInfos,codeInfos)   \
+    ( (This)->lpVtbl -> GetCodeInfo2(This,functionID,cCodeInfos,pcCodeInfos,codeInfos) ) 
+
+#define ICorProfilerInfo12_GetClassFromTokenAndTypeArgs(This,moduleID,typeDef,cTypeArgs,typeArgs,pClassID)  \
+    ( (This)->lpVtbl -> GetClassFromTokenAndTypeArgs(This,moduleID,typeDef,cTypeArgs,typeArgs,pClassID) ) 
+
+#define ICorProfilerInfo12_GetFunctionFromTokenAndTypeArgs(This,moduleID,funcDef,classId,cTypeArgs,typeArgs,pFunctionID)    \
+    ( (This)->lpVtbl -> GetFunctionFromTokenAndTypeArgs(This,moduleID,funcDef,classId,cTypeArgs,typeArgs,pFunctionID) ) 
+
+#define ICorProfilerInfo12_EnumModuleFrozenObjects(This,moduleID,ppEnum)    \
+    ( (This)->lpVtbl -> EnumModuleFrozenObjects(This,moduleID,ppEnum) ) 
+
+#define ICorProfilerInfo12_GetArrayObjectInfo(This,objectId,cDimensions,pDimensionSizes,pDimensionLowerBounds,ppData)   \
+    ( (This)->lpVtbl -> GetArrayObjectInfo(This,objectId,cDimensions,pDimensionSizes,pDimensionLowerBounds,ppData) ) 
+
+#define ICorProfilerInfo12_GetBoxClassLayout(This,classId,pBufferOffset)    \
+    ( (This)->lpVtbl -> GetBoxClassLayout(This,classId,pBufferOffset) ) 
+
+#define ICorProfilerInfo12_GetThreadAppDomain(This,threadId,pAppDomainId)   \
+    ( (This)->lpVtbl -> GetThreadAppDomain(This,threadId,pAppDomainId) ) 
+
+#define ICorProfilerInfo12_GetRVAStaticAddress(This,classId,fieldToken,ppAddress)   \
+    ( (This)->lpVtbl -> GetRVAStaticAddress(This,classId,fieldToken,ppAddress) ) 
+
+#define ICorProfilerInfo12_GetAppDomainStaticAddress(This,classId,fieldToken,appDomainId,ppAddress) \
+    ( (This)->lpVtbl -> GetAppDomainStaticAddress(This,classId,fieldToken,appDomainId,ppAddress) ) 
+
+#define ICorProfilerInfo12_GetThreadStaticAddress(This,classId,fieldToken,threadId,ppAddress)   \
+    ( (This)->lpVtbl -> GetThreadStaticAddress(This,classId,fieldToken,threadId,ppAddress) ) 
+
+#define ICorProfilerInfo12_GetContextStaticAddress(This,classId,fieldToken,contextId,ppAddress) \
+    ( (This)->lpVtbl -> GetContextStaticAddress(This,classId,fieldToken,contextId,ppAddress) ) 
+
+#define ICorProfilerInfo12_GetStaticFieldInfo(This,classId,fieldToken,pFieldInfo)   \
+    ( (This)->lpVtbl -> GetStaticFieldInfo(This,classId,fieldToken,pFieldInfo) ) 
+
+#define ICorProfilerInfo12_GetGenerationBounds(This,cObjectRanges,pcObjectRanges,ranges)    \
+    ( (This)->lpVtbl -> GetGenerationBounds(This,cObjectRanges,pcObjectRanges,ranges) ) 
+
+#define ICorProfilerInfo12_GetObjectGeneration(This,objectId,range) \
+    ( (This)->lpVtbl -> GetObjectGeneration(This,objectId,range) ) 
+
+#define ICorProfilerInfo12_GetNotifiedExceptionClauseInfo(This,pinfo)   \
+    ( (This)->lpVtbl -> GetNotifiedExceptionClauseInfo(This,pinfo) ) 
+
+
+#define ICorProfilerInfo12_EnumJITedFunctions(This,ppEnum)  \
+    ( (This)->lpVtbl -> EnumJITedFunctions(This,ppEnum) ) 
+
+#define ICorProfilerInfo12_RequestProfilerDetach(This,dwExpectedCompletionMilliseconds) \
+    ( (This)->lpVtbl -> RequestProfilerDetach(This,dwExpectedCompletionMilliseconds) ) 
+
+#define ICorProfilerInfo12_SetFunctionIDMapper2(This,pFunc,clientData)  \
+    ( (This)->lpVtbl -> SetFunctionIDMapper2(This,pFunc,clientData) ) 
+
+#define ICorProfilerInfo12_GetStringLayout2(This,pStringLengthOffset,pBufferOffset) \
+    ( (This)->lpVtbl -> GetStringLayout2(This,pStringLengthOffset,pBufferOffset) ) 
+
+#define ICorProfilerInfo12_SetEnterLeaveFunctionHooks3(This,pFuncEnter3,pFuncLeave3,pFuncTailcall3) \
+    ( (This)->lpVtbl -> SetEnterLeaveFunctionHooks3(This,pFuncEnter3,pFuncLeave3,pFuncTailcall3) ) 
+
+#define ICorProfilerInfo12_SetEnterLeaveFunctionHooks3WithInfo(This,pFuncEnter3WithInfo,pFuncLeave3WithInfo,pFuncTailcall3WithInfo) \
+    ( (This)->lpVtbl -> SetEnterLeaveFunctionHooks3WithInfo(This,pFuncEnter3WithInfo,pFuncLeave3WithInfo,pFuncTailcall3WithInfo) ) 
+
+#define ICorProfilerInfo12_GetFunctionEnter3Info(This,functionId,eltInfo,pFrameInfo,pcbArgumentInfo,pArgumentInfo)  \
+    ( (This)->lpVtbl -> GetFunctionEnter3Info(This,functionId,eltInfo,pFrameInfo,pcbArgumentInfo,pArgumentInfo) ) 
+
+#define ICorProfilerInfo12_GetFunctionLeave3Info(This,functionId,eltInfo,pFrameInfo,pRetvalRange)   \
+    ( (This)->lpVtbl -> GetFunctionLeave3Info(This,functionId,eltInfo,pFrameInfo,pRetvalRange) ) 
+
+#define ICorProfilerInfo12_GetFunctionTailcall3Info(This,functionId,eltInfo,pFrameInfo) \
+    ( (This)->lpVtbl -> GetFunctionTailcall3Info(This,functionId,eltInfo,pFrameInfo) ) 
+
+#define ICorProfilerInfo12_EnumModules(This,ppEnum) \
+    ( (This)->lpVtbl -> EnumModules(This,ppEnum) ) 
+
+#define ICorProfilerInfo12_GetRuntimeInformation(This,pClrInstanceId,pRuntimeType,pMajorVersion,pMinorVersion,pBuildNumber,pQFEVersion,cchVersionString,pcchVersionString,szVersionString)  \
+    ( (This)->lpVtbl -> GetRuntimeInformation(This,pClrInstanceId,pRuntimeType,pMajorVersion,pMinorVersion,pBuildNumber,pQFEVersion,cchVersionString,pcchVersionString,szVersionString) ) 
+
+#define ICorProfilerInfo12_GetThreadStaticAddress2(This,classId,fieldToken,appDomainId,threadId,ppAddress)  \
+    ( (This)->lpVtbl -> GetThreadStaticAddress2(This,classId,fieldToken,appDomainId,threadId,ppAddress) ) 
+
+#define ICorProfilerInfo12_GetAppDomainsContainingModule(This,moduleId,cAppDomainIds,pcAppDomainIds,appDomainIds)   \
+    ( (This)->lpVtbl -> GetAppDomainsContainingModule(This,moduleId,cAppDomainIds,pcAppDomainIds,appDomainIds) ) 
+
+#define ICorProfilerInfo12_GetModuleInfo2(This,moduleId,ppBaseLoadAddress,cchName,pcchName,szName,pAssemblyId,pdwModuleFlags)   \
+    ( (This)->lpVtbl -> GetModuleInfo2(This,moduleId,ppBaseLoadAddress,cchName,pcchName,szName,pAssemblyId,pdwModuleFlags) ) 
+
+
+#define ICorProfilerInfo12_EnumThreads(This,ppEnum) \
+    ( (This)->lpVtbl -> EnumThreads(This,ppEnum) ) 
+
+#define ICorProfilerInfo12_InitializeCurrentThread(This)    \
+    ( (This)->lpVtbl -> InitializeCurrentThread(This) ) 
+
+#define ICorProfilerInfo12_RequestReJIT(This,cFunctions,moduleIds,methodIds)    \
+    ( (This)->lpVtbl -> RequestReJIT(This,cFunctions,moduleIds,methodIds) ) 
+
+#define ICorProfilerInfo12_RequestRevert(This,cFunctions,moduleIds,methodIds,status)    \
+    ( (This)->lpVtbl -> RequestRevert(This,cFunctions,moduleIds,methodIds,status) ) 
+
+#define ICorProfilerInfo12_GetCodeInfo3(This,functionID,reJitId,cCodeInfos,pcCodeInfos,codeInfos)   \
+    ( (This)->lpVtbl -> GetCodeInfo3(This,functionID,reJitId,cCodeInfos,pcCodeInfos,codeInfos) ) 
+
+#define ICorProfilerInfo12_GetFunctionFromIP2(This,ip,pFunctionId,pReJitId) \
+    ( (This)->lpVtbl -> GetFunctionFromIP2(This,ip,pFunctionId,pReJitId) ) 
+
+#define ICorProfilerInfo12_GetReJITIDs(This,functionId,cReJitIds,pcReJitIds,reJitIds)   \
+    ( (This)->lpVtbl -> GetReJITIDs(This,functionId,cReJitIds,pcReJitIds,reJitIds) ) 
+
+#define ICorProfilerInfo12_GetILToNativeMapping2(This,functionId,reJitId,cMap,pcMap,map)    \
+    ( (This)->lpVtbl -> GetILToNativeMapping2(This,functionId,reJitId,cMap,pcMap,map) ) 
+
+#define ICorProfilerInfo12_EnumJITedFunctions2(This,ppEnum) \
+    ( (This)->lpVtbl -> EnumJITedFunctions2(This,ppEnum) ) 
+
+#define ICorProfilerInfo12_GetObjectSize2(This,objectId,pcSize) \
+    ( (This)->lpVtbl -> GetObjectSize2(This,objectId,pcSize) ) 
+
+
+#define ICorProfilerInfo12_GetEventMask2(This,pdwEventsLow,pdwEventsHigh)   \
+    ( (This)->lpVtbl -> GetEventMask2(This,pdwEventsLow,pdwEventsHigh) ) 
+
+#define ICorProfilerInfo12_SetEventMask2(This,dwEventsLow,dwEventsHigh) \
+    ( (This)->lpVtbl -> SetEventMask2(This,dwEventsLow,dwEventsHigh) ) 
+
+
+#define ICorProfilerInfo12_EnumNgenModuleMethodsInliningThisMethod(This,inlinersModuleId,inlineeModuleId,inlineeMethodId,incompleteData,ppEnum) \
+    ( (This)->lpVtbl -> EnumNgenModuleMethodsInliningThisMethod(This,inlinersModuleId,inlineeModuleId,inlineeMethodId,incompleteData,ppEnum) ) 
+
+
+#define ICorProfilerInfo12_ApplyMetaData(This,moduleId) \
+    ( (This)->lpVtbl -> ApplyMetaData(This,moduleId) ) 
+
+#define ICorProfilerInfo12_GetInMemorySymbolsLength(This,moduleId,pCountSymbolBytes)    \
+    ( (This)->lpVtbl -> GetInMemorySymbolsLength(This,moduleId,pCountSymbolBytes) ) 
+
+#define ICorProfilerInfo12_ReadInMemorySymbols(This,moduleId,symbolsReadOffset,pSymbolBytes,countSymbolBytes,pCountSymbolBytesRead) \
+    ( (This)->lpVtbl -> ReadInMemorySymbols(This,moduleId,symbolsReadOffset,pSymbolBytes,countSymbolBytes,pCountSymbolBytesRead) ) 
+
+
+#define ICorProfilerInfo12_IsFunctionDynamic(This,functionId,isDynamic) \
+    ( (This)->lpVtbl -> IsFunctionDynamic(This,functionId,isDynamic) ) 
+
+#define ICorProfilerInfo12_GetFunctionFromIP3(This,ip,functionId,pReJitId)  \
+    ( (This)->lpVtbl -> GetFunctionFromIP3(This,ip,functionId,pReJitId) ) 
+
+#define ICorProfilerInfo12_GetDynamicFunctionInfo(This,functionId,moduleId,ppvSig,pbSig,cchName,pcchName,wszName)   \
+    ( (This)->lpVtbl -> GetDynamicFunctionInfo(This,functionId,moduleId,ppvSig,pbSig,cchName,pcchName,wszName) ) 
+
+
+#define ICorProfilerInfo12_GetNativeCodeStartAddresses(This,functionID,reJitId,cCodeStartAddresses,pcCodeStartAddresses,codeStartAddresses) \
+    ( (This)->lpVtbl -> GetNativeCodeStartAddresses(This,functionID,reJitId,cCodeStartAddresses,pcCodeStartAddresses,codeStartAddresses) ) 
+
+#define ICorProfilerInfo12_GetILToNativeMapping3(This,pNativeCodeStartAddress,cMap,pcMap,map)   \
+    ( (This)->lpVtbl -> GetILToNativeMapping3(This,pNativeCodeStartAddress,cMap,pcMap,map) ) 
+
+#define ICorProfilerInfo12_GetCodeInfo4(This,pNativeCodeStartAddress,cCodeInfos,pcCodeInfos,codeInfos)  \
+    ( (This)->lpVtbl -> GetCodeInfo4(This,pNativeCodeStartAddress,cCodeInfos,pcCodeInfos,codeInfos) ) 
+
+
+#define ICorProfilerInfo12_EnumerateObjectReferences(This,objectId,callback,clientData) \
+    ( (This)->lpVtbl -> EnumerateObjectReferences(This,objectId,callback,clientData) ) 
+
+#define ICorProfilerInfo12_IsFrozenObject(This,objectId,pbFrozen)   \
+    ( (This)->lpVtbl -> IsFrozenObject(This,objectId,pbFrozen) ) 
+
+#define ICorProfilerInfo12_GetLOHObjectSizeThreshold(This,pThreshold)   \
+    ( (This)->lpVtbl -> GetLOHObjectSizeThreshold(This,pThreshold) ) 
+
+#define ICorProfilerInfo12_RequestReJITWithInliners(This,dwRejitFlags,cFunctions,moduleIds,methodIds)   \
+    ( (This)->lpVtbl -> RequestReJITWithInliners(This,dwRejitFlags,cFunctions,moduleIds,methodIds) ) 
+
+#define ICorProfilerInfo12_SuspendRuntime(This) \
+    ( (This)->lpVtbl -> SuspendRuntime(This) ) 
+
+#define ICorProfilerInfo12_ResumeRuntime(This)  \
+    ( (This)->lpVtbl -> ResumeRuntime(This) ) 
+
+
+#define ICorProfilerInfo12_GetEnvironmentVariable(This,szName,cchValue,pcchValue,szValue)   \
+    ( (This)->lpVtbl -> GetEnvironmentVariable(This,szName,cchValue,pcchValue,szValue) ) 
+
+#define ICorProfilerInfo12_SetEnvironmentVariable(This,szName,szValue)  \
+    ( (This)->lpVtbl -> SetEnvironmentVariable(This,szName,szValue) ) 
+
+
+#define ICorProfilerInfo12_EventPipeStartSession(This,cProviderConfigs,pProviderConfigs,requestRundown,pSession)    \
+    ( (This)->lpVtbl -> EventPipeStartSession(This,cProviderConfigs,pProviderConfigs,requestRundown,pSession) ) 
+
+#define ICorProfilerInfo12_EventPipeAddProviderToSession(This,session,providerConfig)   \
+    ( (This)->lpVtbl -> EventPipeAddProviderToSession(This,session,providerConfig) ) 
+
+#define ICorProfilerInfo12_EventPipeStopSession(This,session)   \
+    ( (This)->lpVtbl -> EventPipeStopSession(This,session) ) 
+
+#define ICorProfilerInfo12_EventPipeCreateProvider(This,providerName,pProvider) \
+    ( (This)->lpVtbl -> EventPipeCreateProvider(This,providerName,pProvider) ) 
+
+#define ICorProfilerInfo12_EventPipeGetProviderInfo(This,provider,cchName,pcchName,providerName)    \
+    ( (This)->lpVtbl -> EventPipeGetProviderInfo(This,provider,cchName,pcchName,providerName) ) 
+
+#define ICorProfilerInfo12_EventPipeDefineEvent(This,provider,eventName,eventID,keywords,eventVersion,level,opcode,needStack,cParamDescs,pParamDescs,pEvent)    \
+    ( (This)->lpVtbl -> EventPipeDefineEvent(This,provider,eventName,eventID,keywords,eventVersion,level,opcode,needStack,cParamDescs,pParamDescs,pEvent) ) 
+
+#define ICorProfilerInfo12_EventPipeWriteEvent(This,event,cData,data,pActivityId,pRelatedActivityId)    \
+    ( (This)->lpVtbl -> EventPipeWriteEvent(This,event,cData,data,pActivityId,pRelatedActivityId) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif  /* C style interface */
+
+
+
+
+#endif  /* __ICorProfilerInfo12_INTERFACE_DEFINED__ */
 
 
 #ifndef __ICorProfilerMethodEnum_INTERFACE_DEFINED__

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilerAgentCommandTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilerAgentCommandTests.cs
@@ -83,3 +83,78 @@ public class ContinuousProfilerAgentCommandTests : NewRelicIntegrationTest<AspNe
         );
     }
 }
+
+/// <summary>
+/// The "heap" counterpart to <see cref="ContinuousProfilerAgentCommandTests"/>: the same collector-driven
+/// start/stop command path, but for the ALLOCATION sampler rather than the thread sampler. The two profile
+/// types are independently toggleable by the command, so each token needs its own coverage -- and the
+/// allocation sampler's own start/stop log lines (not the thread sampler's "Session started/stopped") are what
+/// prove the heap token reached it.
+///
+/// Allocation sampling is left disabled in local config (no
+/// <c>NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED</c>) so a start is proof the command turned it on.
+/// This asserts the command path only; that the sampler then produces real allocation profiles end to end is
+/// covered by <c>ContinuousProfilingAllocationTests</c>.
+/// </summary>
+public class ContinuousProfilerHeapAgentCommandTests : NewRelicIntegrationTest<AspNetCoreWebApiWithCollectorFixture>
+{
+    private readonly AspNetCoreWebApiWithCollectorFixture _fixture;
+    private int _commandAcksSent;
+
+    private static readonly string AllocationStartedLogLineRegex =
+        AgentLogBase.InfoLogLinePrefixRegex + @"\[ContinuousProfiling\] Allocation sampling started; up to (\d+) samples/minute\.";
+
+    private static readonly string AllocationStoppedLogLineRegex =
+        AgentLogBase.InfoLogLinePrefixRegex + @"\[ContinuousProfiling\] Allocation sampling stopped\.";
+
+    // The command carries no allocation budget of its own, so a command-started sampler is paced from
+    // configuration -- which here is the shipped default, since nothing overrides it.
+    private const int DefaultMaxSamplesPerMinute = 200;
+
+    public ContinuousProfilerHeapAgentCommandTests(AspNetCoreWebApiWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.SetLogLevel("finest");
+                configModifier.ConfigureFasterGetAgentCommandsCycle(10);
+                // Deliberately no NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED -- allocation sampling must
+                // start from the command alone.
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.Get();
+
+                _fixture.TriggerStartContinuousProfiler(include: "heap");
+                _fixture.AgentLog.WaitForLogLine(AllocationStartedLogLineRegex, TimeSpan.FromMinutes(1));
+
+                _fixture.TriggerStopContinuousProfiler(include: "heap");
+                _fixture.AgentLog.WaitForLogLine(AllocationStoppedLogLineRegex, TimeSpan.FromMinutes(1));
+
+                // Read back inside exerciseApplication -- see the note in ContinuousProfilerAgentCommandTests.
+                _commandAcksSent = _fixture.GetCollectedRequests()
+                    .Count(r => r.Querystring.Any(qs => qs.Key == "method" && qs.Value == "agent_command_results"));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void HeapStartAndStopCommandsControlAllocationSampling()
+    {
+        var startMatch = _fixture.AgentLog.TryGetLogLines(AllocationStartedLogLineRegex).FirstOrDefault();
+        var stopped = _fixture.AgentLog.TryGetLogLines(AllocationStoppedLogLineRegex).Any();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(startMatch),
+            () => Assert.Equal(DefaultMaxSamplesPerMinute, int.Parse(startMatch.Groups[1].Value)),
+            () => Assert.True(stopped, "stop_continuous_profiler (heap) did not stop allocation sampling."),
+            () => Assert.True(_commandAcksSent >= 2, $"Expected at least 2 agent_command_results posts (start + stop), got {_commandAcksSent}.")
+        );
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilingAllocationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilingAllocationTests.cs
@@ -35,25 +35,23 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures;
 public abstract class ContinuousProfilingAllocationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
     // With thread sampling off this is ONLY the shared drain cadence (there is no thread-sampling interval to
-    // set). 1000 ms is the minimum the agent clamps to, so a short exercise window spans many drains -- and it
-    // is load-bearing for this test's runtime, because the delivered allocation-sample rate is currently one
-    // sample per drain (see MaxSamplesPerMinute), not the configured budget.
+    // set). 1000 ms is the minimum the agent clamps to, so a short exercise window spans many drains.
     private const int DrainIntervalMs = 1000;
 
     // Well above the shipped default of 200/minute so the configured budget is never the binding constraint
     // inside the test window.
     //
-    // MEASURED, not assumed: the budget is not in fact what limits delivery today. The native sampler
-    // publishes ONE sample per SampleBufferQueue slot and the managed drain frees one slot per tick, so the
-    // delivered rate is capped at one allocation sample per drain interval regardless of the budget -- this
-    // run selected ~1600 samples and delivered 18, dropping the rest with "sample buffers full" (a native
-    // Trace line). The assertions below deliberately do not depend on any per-payload sample count, only on
-    // at least one drain producing a profile; see the task-9 report for the throughput finding.
+    // HISTORY WORTH KEEPING, because it is what AllocationSamplingDeliversManySamplesPerDrain guards: this
+    // test's first run measured ~1600 sub-sampled ticks SELECTED and only 18 delivered -- one per drain,
+    // exactly -- because the native sampler published a single-sample batch per tick into a two-slot queue
+    // and the managed drain read that queue once per tick. The fix (native batch accumulation under
+    // back-pressure + a drain that reads until the source is empty) removed that ceiling; the throughput
+    // fact below asserts it stays removed, since nothing else here would notice its return.
     private const int MaxSamplesPerMinute = 6000;
 
-    // How long the exerciser allocates for. At one delivered sample per drain interval this is many more
-    // drains than the assertions need; the margin is for slower/loaded hosts, where the allocation rate (and
-    // therefore the time to the first captured sample) is lower.
+    // How long the exerciser allocates for. Many more drains than the assertions need; the margin is for
+    // slower/loaded hosts, where the allocation rate (and therefore the time to the first captured sample)
+    // is lower.
     private const int AllocateSeconds = 30;
 
     protected readonly TFixture _fixture;
@@ -95,6 +93,7 @@ public abstract class ContinuousProfilingAllocationTestsBase<TFixture> : NewReli
     private const string DrainMetricName = "Supportability/DotNET/ContinuousProfiling/Drain";
     private const string AllocationSamplesMetricName = "Supportability/DotNET/ContinuousProfiling/AllocationSamples";
     private const string ThreadSamplesMetricName = "Supportability/DotNET/ContinuousProfiling/Samples";
+    private const string AllocationSamplesDroppedMetricName = "Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped";
 
     protected ContinuousProfilingAllocationTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
@@ -267,6 +266,43 @@ public abstract class ContinuousProfilingAllocationTestsBase<TFixture> : NewReli
             () => Assert.NotNull(allocationSamplesMetric),
             () => Assert.True(allocationSamplesMetric.Values.CallCount > 0, "AllocationSamples metric call count was zero."),
             () => Assert.Null(threadSamplesMetric)
+        );
+    }
+
+    [Fact]
+    public void AllocationSamplingDeliversManySamplesPerDrain()
+    {
+        // THE THROUGHPUT REGRESSION GUARD. Both supportability metrics are count metrics, so their harvested
+        // CallCount IS the reported count: AllocationSamples totals the samples delivered, Drain totals the
+        // drains that delivered them. Their ratio is therefore the delivered samples per drain -- the exact
+        // number that used to be pinned at 1 no matter what budget was configured (see MaxSamplesPerMinute).
+        //
+        // Summed across every harvest in the run rather than taken from the first: one harvest window can be
+        // short (the run's first) and would understate the rate.
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        // CallCount is a ulong (no LINQ Sum overload for it); a count that could overflow long is impossible here.
+        var drains = metrics.Where(x => x.MetricSpec.Name == DrainMetricName).Sum(x => (long)x.Values.CallCount);
+        var delivered = metrics.Where(x => x.MetricSpec.Name == AllocationSamplesMetricName).Sum(x => (long)x.Values.CallCount);
+        var dropped = metrics.Where(x => x.MetricSpec.Name == AllocationSamplesDroppedMetricName).Sum(x => (long)x.Values.CallCount);
+
+        var samplesPerDrain = drains > 0 ? delivered / (double)drains : 0d;
+
+        // Logged so the numbers land in the test output, where a regression's magnitude is visible rather
+        // than just its verdict.
+        _fixture.TestLogger?.WriteLine(
+            $"Allocation delivery: {delivered} samples over {drains} drains = {samplesPerDrain:F1}/drain (native dropped: {dropped}).");
+
+        // ONLY the > 1.0 check, deliberately. Pre-fix, samples/drain was pinned at exactly 1 by the queue
+        // mechanics, independently of how fast the host allocated -- so "more than one per drain" is a
+        // rate-INDEPENDENT statement of the fix and cannot flake on a slow or loaded CI host. A higher
+        // hardcoded floor (an earlier draft used 3) would have been rate-DEPENDENT: post-fix the ratio tracks
+        // the delivered AllocationTick rate, so a host yielding few ticks per second could fail it while the
+        // fix is working perfectly. The measured magnitude is logged above instead of asserted.
+        NrAssert.Multiple(
+            () => Assert.True(drains > 0, "No drains were reported, so throughput cannot be measured."),
+            () => Assert.True(samplesPerDrain > 1.0,
+                $"Delivered {samplesPerDrain:F2} allocation samples per drain ({delivered} over {drains} drains) -- at or below the pre-fix ceiling of one per drain.")
         );
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilingAllocationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ContinuousProfilingAllocationTests.cs
@@ -1,0 +1,296 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures;
+
+/// <summary>
+/// End-to-end coverage for ALLOCATION sampling: native EventPipe AllocationTick capture -> wire format ->
+/// managed decode -> OTLP build -> transport, on a real running agent. Structured exactly like
+/// <c>ContinuousProfilingTests</c> (its CPU/thread-sampling sibling) and, like it, <b>log-based only</b> --
+/// assertions key off the built-profile summary line and the Debug protobuf-JSON payload dump, not off a
+/// payload received at a collector, because whether the POST is accepted depends on the target
+/// endpoint/account being reachable from the test host.
+///
+/// This run is deliberately ALLOCATION-ONLY: <c>NEW_RELIC_CONTINUOUS_PROFILING_ENABLED</c> is NOT set, so
+/// the timer-driven thread sampler never starts. That matters twice over -- it proves allocation sampling is
+/// independent of the thread-sampling flag (the two have separate config gates), and it means every profile
+/// in the dumped payload can only have come from the allocation path, so <c>allocated_objects</c>/
+/// <c>allocated_space</c> appearing there is unambiguous. The shared drain timer is still armed (both
+/// samplers share one drain), which is why the sampling-interval env var is set: with thread sampling off it
+/// serves only as the drain cadence.
+///
+/// Trace/span correlation is asserted the same way as in the CPU test, from the dumped payload's linkTable.
+/// It carries more weight here: an allocation sample's trace/span link is a REQUIRED part of the sample
+/// (captured at the allocating call site, on the allocating thread, inside the transaction), where for a
+/// thread sample it is merely common.
+/// </summary>
+public abstract class ContinuousProfilingAllocationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+{
+    // With thread sampling off this is ONLY the shared drain cadence (there is no thread-sampling interval to
+    // set). 1000 ms is the minimum the agent clamps to, so a short exercise window spans many drains -- and it
+    // is load-bearing for this test's runtime, because the delivered allocation-sample rate is currently one
+    // sample per drain (see MaxSamplesPerMinute), not the configured budget.
+    private const int DrainIntervalMs = 1000;
+
+    // Well above the shipped default of 200/minute so the configured budget is never the binding constraint
+    // inside the test window.
+    //
+    // MEASURED, not assumed: the budget is not in fact what limits delivery today. The native sampler
+    // publishes ONE sample per SampleBufferQueue slot and the managed drain frees one slot per tick, so the
+    // delivered rate is capped at one allocation sample per drain interval regardless of the budget -- this
+    // run selected ~1600 samples and delivered 18, dropping the rest with "sample buffers full" (a native
+    // Trace line). The assertions below deliberately do not depend on any per-payload sample count, only on
+    // at least one drain producing a profile; see the task-9 report for the throughput finding.
+    private const int MaxSamplesPerMinute = 6000;
+
+    // How long the exerciser allocates for. At one delivered sample per drain interval this is many more
+    // drains than the assertions need; the margin is for slower/loaded hosts, where the allocation rate (and
+    // therefore the time to the first captured sample) is lower.
+    private const int AllocateSeconds = 30;
+
+    protected readonly TFixture _fixture;
+
+    // The allocation sampler's own start line -- NOT the CPU path's "Session started; draining every ..." line,
+    // which is emitted by the thread sampler's start and never fires on an allocation-only run.
+    private static readonly string AllocationSamplingStartedLogLineRegex =
+        AgentLogBase.InfoLogLinePrefixRegex + @"\[ContinuousProfiling\] Allocation sampling started; up to (\d+) samples/minute\.";
+
+    // Built-profile summary logged on every drain that produced something; group 2 is the byte count.
+    // A drain that read no samples of either kind logs nothing at all, so a match here already means a
+    // non-empty profile was built -- and on this allocation-only run, that it was built from allocation samples.
+    private static readonly string BuiltProfileLogLineRegex =
+        AgentLogBase.DebugLogLinePrefixRegex + @"\[ContinuousProfiling\] Posting profile \((\w+)\); (\d+) bytes to (\S+)\.";
+
+    // Reused VERBATIM from ContinuousProfilingTests -- the payload dump is generic, not CPU-specific.
+    // Group 1 captures the single-line protobuf-JSON blob in the same shape POSTed to the collector.
+    private static readonly string ProfileJsonLogLineRegex =
+        AgentLogBase.DebugLogLinePrefixRegex + @"Request\(.+?\): Invoked ""continuous_profiling"" with : (\{.*\})";
+
+    // Also verbatim from ContinuousProfilingTests: allocation samples are interned into the SAME linkTable by
+    // the same InternLink call, so the correlation evidence has exactly the same shape. The diagnostic log
+    // rewrites the proto `bytes` id to lowercase hex, so the reserved "no link" entry is 32 zeros and any other
+    // value proves a sample was correlated to a live transaction/span.
+    private const string ZeroTraceIdHex = "00000000000000000000000000000000";
+    private static readonly System.Text.RegularExpressions.Regex TraceIdInJsonRegex =
+        new System.Text.RegularExpressions.Regex(@"""traceId"":""([0-9a-f]{32})""");
+
+    // OTLP sample-type names for the two allocation profiles, interned as string-table entries and therefore
+    // present verbatim in the dumped JSON (OtlpProfileBuilder: AllocatedObjectsSampleTypeName /
+    // AllocatedSpaceSampleTypeName).
+    private const string AllocatedObjectsSampleType = "allocated_objects";
+    private const string AllocatedSpaceSampleType = "allocated_space";
+
+    // The thread-sampling profiles' sample-type name. Must NOT appear: thread sampling is off, and its absence
+    // is what makes the presence of the two names above attributable to the allocation path alone.
+    private const string OffCpuSampleType = "off_cpu";
+
+    private const string DrainMetricName = "Supportability/DotNET/ContinuousProfiling/Drain";
+    private const string AllocationSamplesMetricName = "Supportability/DotNET/ContinuousProfiling/AllocationSamples";
+    private const string ThreadSamplesMetricName = "Supportability/DotNET/ContinuousProfiling/Samples";
+
+    protected ContinuousProfilingAllocationTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+
+        // Allocate synchronously and inline on a SINGLE thread, inside one instrumented [Transaction]/[Trace]
+        // method. The allocation sampler reads the ALLOCATING thread's own trace context, and SetTraceContext is
+        // pushed at the wrapper boundary keyed by the calling OS thread only (never propagated to spawned
+        // threads), so keeping the allocation loop on the calling (traced) thread is what makes a captured
+        // sample's trace/span link observable -- see ContinuousProfilingExerciser.RunCorrelatedAllocatingWork.
+        _fixture.AddCommand($"ContinuousProfilingExerciser RunCorrelatedAllocatingWork {AllocateSeconds}");
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                // Debug (via finest) so the payload dump + correlation lines are emitted; faster metrics cycle
+                // so the drain supportability metrics harvest within the test window (default cycle is 60s).
+                configModifier.SetLogLevel("finest");
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+
+                // Enable ALLOCATION sampling only, via the environment overrides (never ad-hoc config XML).
+                // NEW_RELIC_CONTINUOUS_PROFILING_ENABLED is deliberately absent -- see the class remarks.
+                _fixture.EnvironmentVariables["NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED"] = "true";
+                _fixture.EnvironmentVariables["NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE"] = MaxSamplesPerMinute.ToString();
+                // Drain cadence only, on this run: the thread sampler that would otherwise consume this as its
+                // sampling interval is not started.
+                _fixture.EnvironmentVariables["NEW_RELIC_CONTINUOUS_PROFILING_SAMPLING_INTERVAL_MS"] = DrainIntervalMs.ToString();
+            },
+            exerciseApplication: () =>
+            {
+                // The allocation sampler starts at agent init; confirm it before waiting on drain output.
+                _fixture.AgentLog.WaitForLogLine(AllocationSamplingStartedLogLineRegex, TimeSpan.FromMinutes(1));
+
+                // Wait for a drain to build a profile. On this run that cannot happen until allocation samples
+                // have actually been captured and decoded -- a drain that reads nothing returns without logging.
+                _fixture.AgentLog.WaitForLogLine(BuiltProfileLogLineRegex, TimeSpan.FromMinutes(2));
+
+                // Best-effort wait for the Debug JSON payload line; the [Fact]s assert it directly.
+                _fixture.AgentLog.TryGetLogLines(ProfileJsonLogLineRegex);
+
+                // Give the metric harvest a chance to ship the drain supportability metrics.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    /// <summary>
+    /// The dumped protobuf-JSON payloads, newest last, as raw single-line blobs.
+    /// </summary>
+    private string[] GetProfileJsonPayloads() =>
+        _fixture.AgentLog.WaitForLogLines(ProfileJsonLogLineRegex, TimeSpan.FromSeconds(30))
+            .Select(m => m.Groups[1].Value)
+            .ToArray();
+
+    [Fact]
+    public void AllocationSamplingStartsWithConfiguredBudget()
+    {
+        var match = _fixture.AgentLog.WaitForLogLine(AllocationSamplingStartedLogLineRegex, TimeSpan.FromSeconds(30));
+        var reportedBudget = int.Parse(match.Groups[1].Value);
+
+        Assert.Equal(MaxSamplesPerMinute, reportedBudget);
+    }
+
+    [Fact]
+    public void AllocationSamplingBuildsNonEmptyProfile()
+    {
+        // Multiple drains may occur; take the first that reports a non-empty ("built") profile. With thread
+        // sampling off, a built profile can only have come from decoded allocation samples.
+        var matches = _fixture.AgentLog.WaitForLogLines(BuiltProfileLogLineRegex, TimeSpan.FromSeconds(30)).ToArray();
+
+        var builtProfile = matches.FirstOrDefault(m => m.Groups[1].Value == "built");
+
+        NrAssert.Multiple(
+            () => Assert.NotEmpty(matches),
+            () => Assert.NotNull(builtProfile),
+            () => Assert.True(int.Parse(builtProfile.Groups[2].Value) > 0, "Built profile reported zero bytes.")
+        );
+    }
+
+    [Fact]
+    public void AllocationProfilesAppearInBuiltProfileJson()
+    {
+        // Both allocation profiles are emitted together or not at all (they always carry the same sample count),
+        // so a payload carrying one must carry the other. Substring checks against the raw blob, matching the
+        // style of the CPU test's resourceProfiles/dictionary assertions -- the sample-type names are interned
+        // string-table entries and appear verbatim in the dump.
+        var payloads = GetProfileJsonPayloads();
+        var allocationPayload = payloads.FirstOrDefault(p => p.Contains(AllocatedObjectsSampleType));
+
+        NrAssert.Multiple(
+            () => Assert.NotEmpty(payloads),
+            () => Assert.NotNull(allocationPayload),
+            () => Assert.Contains("resourceProfiles", allocationPayload),
+            () => Assert.Contains("dictionary", allocationPayload),
+            () => Assert.Contains(AllocatedObjectsSampleType, allocationPayload),
+            () => Assert.Contains(AllocatedSpaceSampleType, allocationPayload),
+            // Thread sampling never started on this run, so no cpu/off_cpu profile may be present. Its absence
+            // is what makes the two names above attributable to the allocation path alone.
+            () => Assert.DoesNotContain(OffCpuSampleType, allocationPayload)
+        );
+    }
+
+    [Fact]
+    public void AllocationProfileCarriesAllocatedTypeName()
+    {
+        // The allocated type name comes from the native AllocationTick payload parse (the field read from the
+        // FRONT of the v4 payload, opposite AllocatedSize at the back), so seeing the exerciser's own allocated
+        // type here is direct evidence that parse produced real data rather than an empty/garbage string. The
+        // exerciser allocates byte arrays exclusively.
+        //
+        // Asserted across ALL payloads, not on the first one: the sampler is process-wide (it captures whatever
+        // thread happens to allocate when a buffer slot is free), so an early drain can legitimately carry some
+        // other type -- observed in practice as a System.Reflection.* allocation from the test app's own command
+        // dispatch, before the exerciser's loop started. Requiring it in a SPECIFIC payload made this flaky.
+        var payloads = GetProfileJsonPayloads();
+        var allocationPayloads = payloads.Where(p => p.Contains(AllocatedObjectsSampleType)).ToArray();
+
+        NrAssert.Multiple(
+            () => Assert.NotEmpty(allocationPayloads),
+            () => Assert.All(allocationPayloads, p => Assert.Contains("type.name", p)),
+            () => Assert.Contains(allocationPayloads, p => p.Contains("System.Byte[]"))
+        );
+    }
+
+    [Fact]
+    public void AllocationSampleTakenDuringTransactionLogsNonZeroTraceSpanLink()
+    {
+        // The exerciser allocates synchronously, inline, on a SINGLE thread inside a [Transaction]/[Trace]-
+        // instrumented method (RunCorrelatedAllocatingWork -> CorrelatedAllocatingTransaction ->
+        // CorrelatedAllocate) for the whole run, without ever handing the work off to another thread. The
+        // native tick handler reads the allocating thread's OWN trace-context slot, and that slot is only
+        // populated for a thread currently executing inside an instrumented method, so keeping the allocation
+        // loop on the calling (traced) thread is what makes the link observable. Across all drained payloads,
+        // at least one linkTable entry must carry a non-zero trace id.
+        var payloads = GetProfileJsonPayloads();
+
+        var correlatedTraceIds = payloads
+            .SelectMany(p => TraceIdInJsonRegex.Matches(p).Cast<System.Text.RegularExpressions.Match>())
+            .Select(tid => tid.Groups[1].Value)
+            .Where(tid => tid != ZeroTraceIdHex)
+            .ToArray();
+
+        NrAssert.Multiple(
+            () => Assert.NotEmpty(payloads),
+            () => Assert.NotEmpty(correlatedTraceIds)
+        );
+    }
+
+    [Fact]
+    public void AllocationDrainReportsSupportabilityMetrics()
+    {
+        // Both sample kinds funnel through the same drain/send path, so an allocation-only drain reports the
+        // same Drain metric the CPU test asserts -- but the per-kind count is a SEPARATE metric
+        // (.../AllocationSamples), reported only when allocation samples actually contributed. The thread-sample
+        // count metric must be absent for the same reason off_cpu is: nothing thread-sampled on this run.
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var drainMetric = metrics.FirstOrDefault(x => x.MetricSpec.Name == DrainMetricName);
+        var allocationSamplesMetric = metrics.FirstOrDefault(x => x.MetricSpec.Name == AllocationSamplesMetricName);
+        var threadSamplesMetric = metrics.FirstOrDefault(x => x.MetricSpec.Name == ThreadSamplesMetricName);
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(drainMetric),
+            () => Assert.True(drainMetric.Values.CallCount > 0, "Drain metric call count was zero."),
+            () => Assert.NotNull(allocationSamplesMetric),
+            () => Assert.True(allocationSamplesMetric.Values.CallCount > 0, "AllocationSamples metric call count was zero."),
+            () => Assert.Null(threadSamplesMetric)
+        );
+    }
+}
+
+public class ContinuousProfilingAllocationTestsCoreLatest : ContinuousProfilingAllocationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public ContinuousProfilingAllocationTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class ContinuousProfilingAllocationTestsCoreOldest : ContinuousProfilingAllocationTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public ContinuousProfilingAllocationTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class ContinuousProfilingAllocationTestsCoreLatestX86 : ContinuousProfilingAllocationTestsBase<ConsoleDynamicMethodFixtureCoreLatestX86>
+{
+    public ContinuousProfilingAllocationTestsCoreLatestX86(ConsoleDynamicMethodFixtureCoreLatestX86 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ContinuousProfilingExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ContinuousProfilingExerciser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -21,6 +22,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.ContinuousProfili
 [Library]
 public class ContinuousProfilingExerciser
 {
+    // Allocations per pass before the live-reference window is released (see CorrelatedAllocate). Sized so a
+    // pass moves a few MB: the CLR raises AllocationTick only once per ~100 KB allocated, so real allocation
+    // VOLUME -- hundreds of MB -- is what produces sampled ticks inside a short test window. Raising the
+    // configured samples/minute budget alone does not: the tick rate is what the native sub-sampler paces
+    // against, and the delivered rate is capped downstream of it at one sample per drain interval.
+    private const int AllocationsPerPass = 256;
+
+    // Rotated so the captured samples carry a MIX of allocated sizes (and therefore a mix of
+    // allocated_space values), rather than one repeated constant. All below the 85 KB large-object
+    // threshold on purpose: this should look like ordinary gen0 pressure from a real application, not one
+    // giant LOH/pinned buffer.
+    private static readonly int[] AllocationSizes = { 1024, 4 * 1024, 16 * 1024, 48 * 1024, 64 * 1024 };
+
     /// <summary>
     /// Spins up <paramref name="threadCount"/> background threads that each run CPU-busy transactions for
     /// <paramref name="runSeconds"/> seconds. With a small sampling interval (e.g. 1000 ms) this comfortably
@@ -139,6 +153,72 @@ public class ContinuousProfilingExerciser
         if (acc < 0)
         {
             ConsoleMFLogger.Info($"[ContinuousProfilingExerciser] Unreachable {acc}.");
+        }
+    }
+
+    /// <summary>
+    /// The allocation-sampling counterpart to <see cref="RunCorrelatedBusyWork"/>: a SINGLE-THREADED,
+    /// synchronous loop that runs inline on the CALLING thread, inside one instrumented
+    /// [Transaction]/[Trace] method, allocating for <paramref name="runSeconds"/> seconds. Same
+    /// no-thread-handoff shape and for the same reason -- allocation samples are captured on the
+    /// allocating thread and read that thread's own trace context, so only allocations made while this
+    /// thread is inside the instrumented method can render a trace/span link.
+    /// </summary>
+    [LibraryMethod]
+    public void RunCorrelatedAllocatingWork(int runSeconds)
+    {
+        ConsoleMFLogger.Info($"[ContinuousProfilingExerciser] Starting single-threaded correlated allocating work for {runSeconds}s.");
+
+        CorrelatedAllocatingTransaction(runSeconds);
+
+        ConsoleMFLogger.Info("[ContinuousProfilingExerciser] Correlated allocating work complete.");
+    }
+
+    [Transaction]
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    public void CorrelatedAllocatingTransaction(int runSeconds)
+    {
+        CorrelatedAllocate(runSeconds);
+    }
+
+    [Trace]
+    private void CorrelatedAllocate(int runSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(runSeconds);
+
+        // A short rolling window of live references, released once per pass. Two purposes: the arrays
+        // actually survive briefly, so the GC sees real pressure (matching production allocation patterns)
+        // rather than immediately-dead garbage; and the reference escaping into this list is what stops the
+        // JIT from stack-allocating the array outright (.NET 9+ does that for small non-escaping arrays),
+        // which would produce no AllocationTick at all.
+        var live = new List<byte[]>(AllocationsPerPass);
+        long consumed = 0;
+        var n = 0;
+
+        // The deadline is checked once per pass, not per allocation: DateTime.UtcNow costs more than the
+        // allocations it would gate, and throttling the loop would starve it of the volume it needs.
+        do
+        {
+            for (var i = 0; i < AllocationsPerPass; i++)
+            {
+                var buffer = new byte[AllocationSizes[n++ % AllocationSizes.Length]];
+
+                // Write then read both ends so the allocation cannot be elided as unused.
+                buffer[0] = (byte)n;
+                buffer[buffer.Length - 1] = (byte)i;
+                consumed += buffer[0] + buffer[buffer.Length - 1];
+
+                live.Add(buffer);
+            }
+
+            live.Clear();
+        }
+        while (DateTime.UtcNow < deadline);
+
+        if (consumed < 0)
+        {
+            ConsoleMFLogger.Info($"[ContinuousProfilingExerciser] Unreachable {consumed}.");
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Commands/ContinuousProfilerResponseFormatterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Commands/ContinuousProfilerResponseFormatterTests.cs
@@ -14,7 +14,9 @@ public class ContinuousProfilerResponseFormatterTests
     [Test]
     public void AckOnly_always_returns_an_empty_dictionary()
     {
-        var result = new ContinuousProfilingCommandResult(new[] { "cpu" }, 10000, 10000, new Dictionary<string, string> { { "heap", "not supported" } });
+        // "bogus" rather than "heap": every recognized token ("all"/"cpu"/"heap") is acted on now, so an
+        // unrecognized token is the only thing that produces an exception entry.
+        var result = new ContinuousProfilingCommandResult(new[] { "cpu" }, 10000, 10000, new Dictionary<string, string> { { "bogus", "not supported" } });
 
         var response = new AckOnlyContinuousProfilerResponseFormatter().Format(result);
 
@@ -40,7 +42,7 @@ public class ContinuousProfilerResponseFormatterTests
     [Test]
     public void Detailed_includes_exceptions_key_when_present()
     {
-        var exceptions = new Dictionary<string, string> { { "heap", "not supported" } };
+        var exceptions = new Dictionary<string, string> { { "bogus", "not supported" } };
         var result = new ContinuousProfilingCommandResult(new[] { "cpu" }, 10000, 10000, exceptions);
 
         var response = new DetailedContinuousProfilerResponseFormatter().Format(result);

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4687,28 +4687,31 @@ public class DefaultConfigurationTests
         return defaultConfig.ContinuousProfilingSamplingIntervalMs;
     }
 
-    // Allocation sampling is a SUB-FEATURE: the child flag is ANDed with continuousProfiling.enabled, matching
-    // its nested position in the XSD and the OpenTelemetryMetricsEnabled precedent.
+    // Allocation sampling is INDEPENDENT of the thread-sampling flag in both directions -- it is
+    // AllocationTick-driven and needs no periodic thread walk. In particular the (false, true) case must be a
+    // durable, supported configuration: allocation sampling with thread sampling off.
     [TestCase(false, false, ExpectedResult = false)]
-    [TestCase(false, true, ExpectedResult = false)]  // parent off kills the child, even when the child asks for it
-    [TestCase(true, false, ExpectedResult = false)]
+    [TestCase(false, true, ExpectedResult = true)]   // thread sampling off, allocation on
+    [TestCase(true, false, ExpectedResult = false)]  // thread sampling on, allocation off
     [TestCase(true, true, ExpectedResult = true)]
-    public bool ContinuousProfilingAllocationEnabled_requires_the_parent_feature(bool parentEnabled, bool allocationEnabled)
+    public bool ContinuousProfilingAllocationEnabled_is_independent_of_the_thread_sampling_flag(bool threadSamplingEnabled, bool allocationEnabled)
     {
-        _localConfig.continuousProfiling.enabled = parentEnabled;
+        _localConfig.continuousProfiling.enabled = threadSamplingEnabled;
         _localConfig.continuousProfiling.allocation.enabled = allocationEnabled;
 
         var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
         return defaultConfig.ContinuousProfilingAllocationEnabled;
     }
 
-    [Test]
-    public void ContinuousProfilingAllocationEnabled_is_killed_by_high_security_mode()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ContinuousProfilingAllocationEnabled_is_killed_by_high_security_mode(bool threadSamplingEnabled)
     {
-        // Inherited from the parent flag, which HSM disables unconditionally -- allocation samples carry stacks
-        // and allocated type names, the same class of data.
+        // Checked directly, NOT inherited by ANDing ContinuousProfilingEnabled -- so it must hold regardless of
+        // the thread-sampling flag. Allocation samples carry stacks and allocated type names, the same class of
+        // data HSM disables continuous profiling for.
         _localConfig.highSecurity.enabled = true;
-        _localConfig.continuousProfiling.enabled = true;
+        _localConfig.continuousProfiling.enabled = threadSamplingEnabled;
         _localConfig.continuousProfiling.allocation.enabled = true;
 
         _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
@@ -4716,14 +4719,29 @@ public class DefaultConfigurationTests
         Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
     }
 
-    [Test]
-    public void ContinuousProfilingAllocationEnabled_can_be_disabled_by_server_side_config_via_the_parent()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ContinuousProfilingAllocationEnabled_is_disabled_by_a_server_side_continuous_profiling_disable(bool threadSamplingEnabled)
     {
-        // There is deliberately no allocation-specific server-side key: the parent's already lets the server
-        // disable the whole feature.
-        _localConfig.continuousProfiling.enabled = true;
+        // Also checked directly, so it holds independently of the thread-sampling flag. There is deliberately no
+        // allocation-specific server-side key; this one lets the server disable the whole feature.
+        _localConfig.continuousProfiling.enabled = threadSamplingEnabled;
         _localConfig.continuousProfiling.allocation.enabled = true;
         _serverConfig.RpmConfig.ContinuousProfilingEnabled = false;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
+    }
+
+    [Test]
+    public void ContinuousProfilingAllocationEnabled_is_not_turned_on_by_a_server_side_continuous_profiling_enable()
+    {
+        // The server-side key is about continuous profiling as a whole and says nothing about whether this
+        // customer wants allocation sampling, so it is read as a kill switch only -- a server TRUE must not
+        // override a local allocation opt-out.
+        _localConfig.continuousProfiling.allocation.enabled = false;
+        _serverConfig.RpmConfig.ContinuousProfilingEnabled = true;
 
         _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
@@ -4741,7 +4759,6 @@ public class DefaultConfigurationTests
     [TestCase(null, "xyz", true, ExpectedResult = true)]        // unparseable appSettings -> element
     public bool ContinuousProfilingAllocationEnabled_precedence(string envValue, string appSettingsValue, bool localElement)
     {
-        _localConfig.continuousProfiling.enabled = true; // the parent, so only the child's layering is under test
         _localConfig.continuousProfiling.allocation.enabled = localElement;
         if (appSettingsValue != null)
             _localConfig.appSettings.Add(new configurationAdd { key = "NewRelic.ContinuousProfilingAllocationEnabled", value = appSettingsValue });

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4687,4 +4687,101 @@ public class DefaultConfigurationTests
         return defaultConfig.ContinuousProfilingSamplingIntervalMs;
     }
 
+    // Allocation sampling is a SUB-FEATURE: the child flag is ANDed with continuousProfiling.enabled, matching
+    // its nested position in the XSD and the OpenTelemetryMetricsEnabled precedent.
+    [TestCase(false, false, ExpectedResult = false)]
+    [TestCase(false, true, ExpectedResult = false)]  // parent off kills the child, even when the child asks for it
+    [TestCase(true, false, ExpectedResult = false)]
+    [TestCase(true, true, ExpectedResult = true)]
+    public bool ContinuousProfilingAllocationEnabled_requires_the_parent_feature(bool parentEnabled, bool allocationEnabled)
+    {
+        _localConfig.continuousProfiling.enabled = parentEnabled;
+        _localConfig.continuousProfiling.allocation.enabled = allocationEnabled;
+
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        return defaultConfig.ContinuousProfilingAllocationEnabled;
+    }
+
+    [Test]
+    public void ContinuousProfilingAllocationEnabled_is_killed_by_high_security_mode()
+    {
+        // Inherited from the parent flag, which HSM disables unconditionally -- allocation samples carry stacks
+        // and allocated type names, the same class of data.
+        _localConfig.highSecurity.enabled = true;
+        _localConfig.continuousProfiling.enabled = true;
+        _localConfig.continuousProfiling.allocation.enabled = true;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
+    }
+
+    [Test]
+    public void ContinuousProfilingAllocationEnabled_can_be_disabled_by_server_side_config_via_the_parent()
+    {
+        // There is deliberately no allocation-specific server-side key: the parent's already lets the server
+        // disable the whole feature.
+        _localConfig.continuousProfiling.enabled = true;
+        _localConfig.continuousProfiling.allocation.enabled = true;
+        _serverConfig.RpmConfig.ContinuousProfilingEnabled = false;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
+    }
+
+    // Same env > appSettings > element layering as the sibling continuous-profiling settings.
+    [TestCase("true", "false", false, ExpectedResult = true)]   // env wins over appSettings + element
+    [TestCase("false", "true", true, ExpectedResult = false)]   // env wins over appSettings + element
+    [TestCase(null, "true", false, ExpectedResult = true)]      // appSettings over element
+    [TestCase(null, "false", true, ExpectedResult = false)]     // appSettings over element
+    [TestCase(null, null, true, ExpectedResult = true)]         // element when no env/appSettings
+    [TestCase(null, null, false, ExpectedResult = false)]       // default
+    [TestCase("xyz", "true", false, ExpectedResult = true)]     // unparseable env -> appSettings
+    [TestCase(null, "xyz", true, ExpectedResult = true)]        // unparseable appSettings -> element
+    public bool ContinuousProfilingAllocationEnabled_precedence(string envValue, string appSettingsValue, bool localElement)
+    {
+        _localConfig.continuousProfiling.enabled = true; // the parent, so only the child's layering is under test
+        _localConfig.continuousProfiling.allocation.enabled = localElement;
+        if (appSettingsValue != null)
+            _localConfig.appSettings.Add(new configurationAdd { key = "NewRelic.ContinuousProfilingAllocationEnabled", value = appSettingsValue });
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED")).Returns(envValue);
+
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        return defaultConfig.ContinuousProfilingAllocationEnabled;
+    }
+
+    // The clamp keeps the value inside the range the native AllocationSampler accepts, so a typo cannot resolve
+    // to a budget the native side rejects outright (which would leave allocation sampling silently dead).
+    [TestCase(null, 200)]      // unset -> default
+    [TestCase(0, 1)]           // native refuses <= 0 -> clamp up to the floor
+    [TestCase(-5, 1)]          // ditto for negatives
+    [TestCase(999999, 60000)]  // above the native ceiling -> clamp down
+    [TestCase(1000, 1000)]     // in range -> verbatim
+    public void ContinuousProfilingAllocationMaxSamplesPerMinute_clamps(int? configured, int expected)
+    {
+        if (configured.HasValue)
+            _localConfig.continuousProfiling.allocation.maxSamplesPerMinute = configured.Value;
+        Assert.That(_defaultConfig.ContinuousProfilingAllocationMaxSamplesPerMinute, Is.EqualTo(expected));
+    }
+
+    // Same layering as the interval, with the [1, 60000] clamp applied last.
+    [TestCase("300", "500", 700, ExpectedResult = 300)]     // env wins, in range
+    [TestCase(null, "500", 700, ExpectedResult = 500)]      // appSettings over element
+    [TestCase(null, null, 700, ExpectedResult = 700)]       // element when no env/appSettings
+    [TestCase(null, "0", 700, ExpectedResult = 1)]          // appSettings below floor -> clamp up
+    [TestCase("999999", null, 700, ExpectedResult = 60000)] // env above ceiling -> clamp down
+    [TestCase("xyz", "400", 700, ExpectedResult = 400)]     // unparseable env -> appSettings
+    [TestCase(null, "xyz", 700, ExpectedResult = 700)]      // unparseable appSettings -> element
+    public int ContinuousProfilingAllocationMaxSamplesPerMinute_precedence(string envValue, string appSettingsValue, int localElement)
+    {
+        _localConfig.continuousProfiling.allocation.maxSamplesPerMinute = localElement;
+        if (appSettingsValue != null)
+            _localConfig.appSettings.Add(new configurationAdd { key = "NewRelic.ContinuousProfilingAllocationMaxSamplesPerMinute", value = appSettingsValue });
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE")).Returns(envValue);
+
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        return defaultConfig.ContinuousProfilingAllocationMaxSamplesPerMinute;
+    }
+
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4699,7 +4699,7 @@ public class DefaultConfigurationTests
         _localConfig.continuousProfiling.enabled = threadSamplingEnabled;
         _localConfig.continuousProfiling.allocation.enabled = allocationEnabled;
 
-        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
         return defaultConfig.ContinuousProfilingAllocationEnabled;
     }
 
@@ -4714,7 +4714,7 @@ public class DefaultConfigurationTests
         _localConfig.continuousProfiling.enabled = threadSamplingEnabled;
         _localConfig.continuousProfiling.allocation.enabled = true;
 
-        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
         Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
     }
@@ -4729,7 +4729,7 @@ public class DefaultConfigurationTests
         _localConfig.continuousProfiling.allocation.enabled = true;
         _serverConfig.RpmConfig.ContinuousProfilingEnabled = false;
 
-        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
         Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
     }
@@ -4743,7 +4743,7 @@ public class DefaultConfigurationTests
         _localConfig.continuousProfiling.allocation.enabled = false;
         _serverConfig.RpmConfig.ContinuousProfilingEnabled = true;
 
-        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
         Assert.That(_defaultConfig.ContinuousProfilingAllocationEnabled, Is.False);
     }
@@ -4764,7 +4764,7 @@ public class DefaultConfigurationTests
             _localConfig.appSettings.Add(new configurationAdd { key = "NewRelic.ContinuousProfilingAllocationEnabled", value = appSettingsValue });
         Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED")).Returns(envValue);
 
-        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
         return defaultConfig.ContinuousProfilingAllocationEnabled;
     }
 
@@ -4797,7 +4797,7 @@ public class DefaultConfigurationTests
             _localConfig.appSettings.Add(new configurationAdd { key = "NewRelic.ContinuousProfilingAllocationMaxSamplesPerMinute", value = appSettingsValue });
         Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE")).Returns(envValue);
 
-        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+        var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
         return defaultConfig.ContinuousProfilingAllocationMaxSamplesPerMinute;
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/BufferParserAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/BufferParserAllocationTests.cs
@@ -1,0 +1,68 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NewRelic.Agent.Core.ContinuousProfiling.Tests;
+
+[TestFixture]
+public class BufferParserAllocationTests
+{
+    // Hand-encodes one 0x08 AllocationSample record using the SAME field order/types the native
+    // SampleBufferWriter.WriteAllocationSample will use: opcode, thread name (string), OS thread id
+    // (int64), traceIdHigh/traceIdLow/spanId (int64 x3), timestampMillis (int64), allocatedSize
+    // (int64, bit-reinterpreted uint64), typeName (string), frame list, terminator.
+    private static byte[] EncodeOneAllocationSample()
+    {
+        var bytes = new List<byte>();
+        void WriteShort(short v) { bytes.Add((byte)((v >> 8) & 0xFF)); bytes.Add((byte)(v & 0xFF)); }
+        void WriteLong(long v) { for (var shift = 56; shift >= 0; shift -= 8) bytes.Add((byte)((v >> shift) & 0xFF)); }
+        void WriteString(string s)
+        {
+            WriteShort((short)s.Length);
+            bytes.AddRange(Encoding.Unicode.GetBytes(s));
+        }
+
+        bytes.Add(0x01); // StartBatch
+        bytes.Add(2);    // version
+        WriteLong(1000L); // timestamp
+
+        bytes.Add(0x08); // AllocationSample
+        WriteString("worker-thread");
+        WriteLong(4242L);           // OS thread id
+        WriteLong(111L);            // traceIdHigh
+        WriteLong(222L);            // traceIdLow
+        WriteLong(333L);            // spanId
+        WriteLong(1700000000000L);  // timestampMillis
+        WriteLong(unchecked((long)65536UL)); // allocatedSize (bit pattern of a ulong)
+        WriteString("MyApp.Widget");
+        WriteShort(-1); WriteString("MyApp.Widget.Create()"); // frame, first sight -> define
+        WriteShort(0); // frame list terminator
+
+        bytes.Add(0x06); // EndBatch
+        return bytes.ToArray();
+    }
+
+    [Test]
+    public void Parse_DecodesOneAllocationSample_WithTraceContextAndFrames()
+    {
+        var buffer = EncodeOneAllocationSample();
+
+        var samples = BufferParser.Parse(buffer, buffer.Length, out _, out var allocations);
+
+        Assert.That(samples, Is.Empty, "no thread samples in this batch");
+        Assert.That(allocations, Has.Count.EqualTo(1));
+        var alloc = allocations[0];
+        Assert.That(alloc.ThreadName, Is.EqualTo("worker-thread"));
+        Assert.That(alloc.OsThreadId, Is.EqualTo(4242L));
+        Assert.That(alloc.TraceIdHigh, Is.EqualTo(111L));
+        Assert.That(alloc.TraceIdLow, Is.EqualTo(222L));
+        Assert.That(alloc.SpanId, Is.EqualTo(333L));
+        Assert.That(alloc.TimestampMillis, Is.EqualTo(1700000000000L));
+        Assert.That(alloc.AllocatedSize, Is.EqualTo(65536UL));
+        Assert.That(alloc.TypeName, Is.EqualTo("MyApp.Widget"));
+        Assert.That(alloc.Frames, Is.EqualTo(new[] { "MyApp.Widget.Create()" }));
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/BufferParserAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/BufferParserAllocationTests.cs
@@ -45,6 +45,76 @@ public class BufferParserAllocationTests
         return bytes.ToArray();
     }
 
+    // Two 0x08 records in ONE batch, which is what the native sampler emits once back-pressure makes it
+    // accumulate several samples into a single published batch. The second sample's frame is a POSITIVE
+    // back-reference to the definition the first sample wrote -- the per-batch interning table is shared
+    // across every sample in the batch, so this is the shape a multi-sample batch really has, and the shape
+    // that would break if the native encoder ever reset its interning table mid-batch. The batch also carries
+    // a 0x07 BatchStats record, which is how the allocation sampler reports dropped samples in band.
+    private static byte[] EncodeTwoAllocationSamplesWithSharedFrameAndStats(int skipped)
+    {
+        var bytes = new List<byte>();
+        void WriteShort(short v) { bytes.Add((byte)((v >> 8) & 0xFF)); bytes.Add((byte)(v & 0xFF)); }
+        void WriteInt(int v) { for (var shift = 24; shift >= 0; shift -= 8) bytes.Add((byte)((v >> shift) & 0xFF)); }
+        void WriteLong(long v) { for (var shift = 56; shift >= 0; shift -= 8) bytes.Add((byte)((v >> shift) & 0xFF)); }
+        void WriteString(string s)
+        {
+            WriteShort((short)s.Length);
+            bytes.AddRange(Encoding.Unicode.GetBytes(s));
+        }
+        void WriteSampleFields(long osThreadId, ulong allocatedSize)
+        {
+            bytes.Add(0x08);
+            WriteString("worker-thread");
+            WriteLong(osThreadId);
+            WriteLong(111L); WriteLong(222L); WriteLong(333L);
+            WriteLong(1700000000000L);
+            WriteLong(unchecked((long)allocatedSize));
+            WriteString("MyApp.Widget");
+        }
+
+        bytes.Add(0x01); // StartBatch
+        bytes.Add(2);    // version
+        WriteLong(1000L);
+
+        WriteSampleFields(1, 1024UL);
+        WriteShort(-1); WriteString("MyApp.Widget.Create()"); // first sight -> define index 1
+        WriteShort(0);
+
+        WriteSampleFields(2, 2048UL);
+        WriteShort(1); // back-reference to the frame defined by the first sample
+        WriteShort(0);
+
+        bytes.Add(0x07); // BatchStats
+        WriteLong(0L);   // microsSuspended (not meaningful for an allocation batch)
+        WriteInt(0);     // threads
+        WriteInt(0);     // frames
+        WriteInt(skipped);
+
+        bytes.Add(0x06); // EndBatch
+        return bytes.ToArray();
+    }
+
+    [Test]
+    public void Parse_DecodesEveryAllocationSampleInAMultiSampleBatch_SharingTheFrameTable()
+    {
+        var buffer = EncodeTwoAllocationSamplesWithSharedFrameAndStats(skipped: 12);
+
+        var samples = BufferParser.Parse(buffer, buffer.Length, out var stats, out var allocations);
+
+        Assert.That(samples, Is.Empty);
+        Assert.That(allocations, Has.Count.EqualTo(2), "both allocation records in the batch must decode");
+        Assert.That(allocations[0].OsThreadId, Is.EqualTo(1L));
+        Assert.That(allocations[1].OsThreadId, Is.EqualTo(2L));
+        Assert.That(allocations[0].AllocatedSize, Is.EqualTo(1024UL));
+        Assert.That(allocations[1].AllocatedSize, Is.EqualTo(2048UL));
+        Assert.That(allocations[1].Frames, Is.EqualTo(new[] { "MyApp.Widget.Create()" }),
+            "the second sample's positive frame code must resolve through the batch's shared interning table");
+
+        Assert.That(stats, Is.Not.Null, "an allocation batch may carry BatchStats");
+        Assert.That(stats.Skipped, Is.EqualTo(12), "Skipped is how the native allocation sampler reports dropped samples");
+    }
+
     [Test]
     public void Parse_DecodesOneAllocationSample_WithTraceContextAndFrames()
     {

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
@@ -1,0 +1,789 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Text;
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.ContinuousProfiling;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.Utilities;
+using NUnit.Framework;
+using Telerik.JustMock;
+using ExportProfilesRequest = OpenTelemetry.Proto.Collector.Profiles.V1Development.ExportProfilesServiceRequest;
+
+namespace NewRelic.Agent.Core.UnitTest.ContinuousProfiling;
+
+/// <summary>
+/// Covers the allocation-sampling lifecycle, which is INDEPENDENT of the thread-sampling lifecycle covered by
+/// <see cref="ContinuousProfilingServiceTests"/>: its own config flag, its own start/stop, but the same drain
+/// tick, the same trace-context seam, the same send-failure backoff and the same one-request-per-drain payload.
+///
+/// Two contracts here are load-bearing enough to call out, because getting either wrong fails silently in the
+/// field rather than in a test:
+///   * The native allocation sampler's Shutdown is TERMINAL -- it latches and refuses every later Start -- so
+///     every disable/pause/retune path must call Stop, and only Dispose may call Shutdown.
+///   * The drain timer is shared, so it must stay armed while EITHER sampler is running and be released only
+///     when both are stopped.
+/// </summary>
+[TestFixture]
+public class ContinuousProfilingServiceAllocationTests
+{
+    private const int DefaultIntervalMs = 10000;
+    private const int DefaultBudget = 200;
+
+    private ISampleSource _source;
+    private INativeContinuousProfiler _native;
+    private IAllocationSampleSource _allocationSource;
+    private IProfilesTransport _transport;
+    private IScheduler _scheduler;
+    private IAgentHealthReporter _health;
+    private IConfiguration _config;
+    private ContinuousProfilingService _service;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _source = Mock.Create<ISampleSource>();
+        _native = Mock.Create<INativeContinuousProfiler>();
+        _allocationSource = Mock.Create<IAllocationSampleSource>();
+        _transport = Mock.Create<IProfilesTransport>();
+        _scheduler = Mock.Create<IScheduler>();
+        _health = Mock.Create<IAgentHealthReporter>();
+        _config = Mock.Create<IConfiguration>();
+
+        // Default to "accepted" so a drain-oriented test doesn't accidentally trip the send-failure backoff.
+        Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
+
+        _service = new ContinuousProfilingService(_source, _native, _allocationSource, _transport, _scheduler, _health);
+        Connect();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _service.Dispose();
+        // Reset the process-wide seam so one test's enabled context can't leak into another.
+        ContinuousProfilingContext.Instance = new ContinuousProfilingContext();
+    }
+
+    #region arrange helpers
+
+    // Drains are gated on having connected (the profiles endpoint is only known post-preconnect), so every
+    // service under test here is put into the connected state.
+    private void Connect()
+    {
+        var connectionInfo = Mock.Create<IConnectionInfo>();
+        Mock.Arrange(() => connectionInfo.HttpProtocol).Returns("https");
+        Mock.Arrange(() => connectionInfo.Host).Returns("collector.nr-data.net");
+        Mock.Arrange(() => connectionInfo.Port).Returns(443);
+        EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent { ConnectInfo = connectionInfo });
+    }
+
+    // A fresh (service, transport) pair, already connected. Needed whenever a test must control Send's result:
+    // re-arranging the SAME shared mock in a test body does not take precedence over SetUp's arrangement (the
+    // earlier-registered match wins), so a fresh transport mock is the only way to override it.
+    private (ContinuousProfilingService Service, IProfilesTransport Transport) NewConnectedService()
+    {
+        var transport = Mock.Create<IProfilesTransport>();
+        var service = new ContinuousProfilingService(_source, _native, _allocationSource, transport, _scheduler, _health);
+        service.OverrideConfigForTesting(_config);
+        Connect();
+        return (service, transport);
+    }
+
+    // The config surface DrainOnce itself reads on its way to Send. Without these, the service falls back to
+    // the real DefaultConfiguration.Instance and DrainOnce's outer catch silently swallows the failure -- every
+    // drain test would then pass for the wrong reason (no send ever attempted).
+    private IConfiguration ArrangeDrainableConfig(IConfiguration configuration)
+    {
+        Mock.Arrange(() => configuration.ApplicationNames).Returns(new[] { "MyApp" });
+        Mock.Arrange(() => configuration.ContinuousProfilingIncludeAgentCode).Returns(false);
+        return configuration;
+    }
+
+    // The three starting shapes, arranged on the fixture's shared _config and applied to the fixture's service.
+    private void ArrangeAllocationOnly(int budget = DefaultBudget, int intervalMs = DefaultIntervalMs)
+        => _service.OverrideConfigForTesting(ArrangeConfigOn(_config, threadSampling: false, allocation: true, intervalMs, budget));
+
+    private void ArrangeThreadSamplingOnly(int intervalMs = DefaultIntervalMs)
+        => _service.OverrideConfigForTesting(ArrangeConfigOn(_config, threadSampling: true, allocation: false, intervalMs, DefaultBudget));
+
+    private void ArrangeBothEnabled(int budget = DefaultBudget, int intervalMs = DefaultIntervalMs)
+        => _service.OverrideConfigForTesting(ArrangeConfigOn(_config, threadSampling: true, allocation: true, intervalMs, budget));
+
+    // Returns a NEW configuration mock (never a re-arrangement of one already in use -- see NewConnectedService)
+    // for tests that change configuration mid-test and then call ApplyConfigChange.
+    private IConfiguration NewConfig(bool threadSampling, bool allocation, int intervalMs = DefaultIntervalMs, int budget = DefaultBudget)
+        => ArrangeConfigOn(Mock.Create<IConfiguration>(), threadSampling, allocation, intervalMs, budget);
+
+    private IConfiguration ArrangeConfigOn(IConfiguration configuration, bool threadSampling, bool allocation, int intervalMs, int budget)
+    {
+        Mock.Arrange(() => configuration.ContinuousProfilingEnabled).Returns(threadSampling);
+        Mock.Arrange(() => configuration.ContinuousProfilingSamplingIntervalMs).Returns(intervalMs);
+        Mock.Arrange(() => configuration.ContinuousProfilingAllocationEnabled).Returns(allocation);
+        Mock.Arrange(() => configuration.ContinuousProfilingAllocationMaxSamplesPerMinute).Returns(budget);
+        ArrangeDrainableConfig(configuration);
+        return configuration;
+    }
+
+    private void ArrangeReadableThreadBatch()
+    {
+        var batch = OneThreadSampleBatch("worker-1", 1, 0, 0, 0, new[] { "F()" });
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+    }
+
+    private void ArrangeReadableAllocationBatch()
+    {
+        var batch = OneAllocationSampleBatch();
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+    }
+
+    #endregion
+
+    #region start/stop gating -- each sampler on its own flag
+
+    [Test]
+    public void StartIfEnabled_with_allocation_enabled_starts_the_allocation_sampler_at_the_configured_budget()
+    {
+        ArrangeBothEnabled(budget: 350);
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _allocationSource.Start(350), Occurs.Once());
+    }
+
+    [Test]
+    public void StartIfEnabled_with_allocation_disabled_does_not_start_the_allocation_sampler()
+    {
+        ArrangeThreadSamplingOnly();
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Never());
+        Mock.Assert(() => _native.Start(DefaultIntervalMs), Occurs.Once(), "the thread sampler must still start");
+    }
+
+    [Test]
+    public void StartIfEnabled_with_allocation_enabled_and_thread_sampling_disabled_still_starts_allocation_sampling()
+    {
+        // The independence that matters: a disabled thread sampler must not short-circuit the allocation
+        // sampler. Before this task, StartIfEnabled returned early on ContinuousProfilingEnabled == false.
+        ArrangeAllocationOnly(budget: 200);
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _allocationSource.Start(200), Occurs.Once());
+        Mock.Assert(() => _native.Start(Arg.AnyInt), Occurs.Never(), "the thread sampler is disabled and must stay stopped");
+        Assert.That(_service.IsActive, Is.False, "IsActive reports the THREAD sampler; allocation sampling must not block thread profiling");
+    }
+
+    [Test]
+    public void StartIfEnabled_while_the_allocation_sampler_is_already_active_does_not_restart_it()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Once());
+    }
+
+    [Test]
+    public void StartIfEnabled_after_Dispose_starts_nothing()
+    {
+        ArrangeBothEnabled();
+
+        _service.Dispose();
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Never());
+        Mock.Assert(() => _native.Start(Arg.AnyInt), Occurs.Never());
+    }
+
+    [Test]
+    public void A_failed_allocation_start_unwinds_the_active_flag_so_a_later_start_can_retry()
+    {
+        // Only the FIRST start throws, so the second call proves the flag was actually unwound rather than left
+        // true with nothing sampling -- which would also pin the shared drain timer open forever.
+        var starts = 0;
+        Mock.Arrange(() => _allocationSource.Start(Arg.AnyInt)).DoInstead(() =>
+        {
+            starts++;
+            if (starts == 1)
+                throw new InvalidOperationException("boom");
+        });
+        ArrangeAllocationOnly();
+
+        Assert.DoesNotThrow(() => _service.StartIfEnabled());
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once(), "the failed start must unwind through Stop");
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never(),
+            "the drain schedule was never armed, so there is nothing to stop");
+
+        _service.StartIfEnabled();
+
+        Assert.That(starts, Is.EqualTo(2), "the second start must be allowed through, i.e. the active flag was unwound");
+    }
+
+    #endregion
+
+    #region ApplyConfigChange
+
+    [Test]
+    public void ApplyConfigChange_enabling_allocation_from_disabled_starts_it()
+    {
+        ArrangeThreadSamplingOnly();
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true, budget: 400));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(400), Occurs.Once());
+    }
+
+    [Test]
+    public void ApplyConfigChange_disabling_allocation_stops_it_and_never_shuts_it_down()
+    {
+        // The single most important assertion in this fixture: the native allocation sampler's Shutdown is a
+        // terminal latch, so wiring a disable to it would permanently end allocation sampling for the life of
+        // the process the first time anyone toggled the setting.
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: false));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Never());
+    }
+
+    [Test]
+    public void ApplyConfigChange_with_a_changed_budget_repaces_the_running_allocation_sampler_without_stopping_it()
+    {
+        ArrangeAllocationOnly(budget: 200);
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: true, budget: 1000));
+        _service.ApplyConfigChange();
+
+        // Re-paced in place: the native Start is idempotent and resets the sub-sampler without reopening the
+        // session, so there is no stop and no drain-timer churn.
+        Mock.Assert(() => _allocationSource.Start(1000), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never());
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never());
+    }
+
+    [Test]
+    public void ApplyConfigChange_with_an_unchanged_budget_does_not_restart_the_allocation_sampler()
+    {
+        ArrangeAllocationOnly(budget: 200);
+        _service.StartIfEnabled();
+
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Once());
+    }
+
+    [Test]
+    public void ApplyConfigChange_reconciles_allocation_even_while_the_cpu_bundle_is_command_owned()
+    {
+        // An agent command owns the cpu bundle until a matching stop, and ApplyConfigChange must not disturb
+        // it. Allocation sampling is not command-controllable yet, so its config-driven reconciliation has to
+        // run anyway -- it must not be nested inside the cpu ownership guard's early return.
+        ArrangeThreadSamplingOnly();
+        _service.StartFromCommand(new[] { "cpu" }, null, null);
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: true, budget: 250));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(250), Occurs.Once(), "allocation config must be applied despite the cpu bundle being command-owned");
+        Mock.Assert(() => _native.Stop(), Occurs.Never(), "the command-owned thread sampler must be left alone");
+        Assert.That(_service.IsActive, Is.True);
+    }
+
+    [Test]
+    public void ApplyConfigChange_after_Dispose_does_not_resurrect_allocation_sampling()
+    {
+        ArrangeAllocationOnly();
+        _service.Dispose();
+
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Never());
+    }
+
+    #endregion
+
+    #region the shared drain schedule and trace-context seam
+
+    [Test]
+    public void Allocation_only_arms_the_drain_schedule_at_the_configured_sampling_interval()
+    {
+        // The drain timer used to be armed exclusively by the thread-sampling start, which would have left an
+        // allocation-only session filling native buffers that nothing ever drained.
+        ArrangeAllocationOnly(intervalMs: 15000);
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), TimeSpan.FromMilliseconds(15000), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+    }
+
+    [Test]
+    public void Allocation_only_arms_the_trace_context_seam()
+    {
+        // Allocation samples correlate through the thread sampler's native trace-context map, and the native
+        // setter does not require the thread sampler's session -- so an allocation-only session must still arm
+        // the push seam or every allocation sample would lose its trace/span link.
+        ArrangeAllocationOnly();
+
+        _service.StartIfEnabled();
+
+        Assert.That(ContinuousProfilingContext.Instance.IsEnabled, Is.True);
+    }
+
+    [Test]
+    public void Both_samplers_enabled_arm_the_drain_schedule_once_at_the_thread_sampling_interval()
+    {
+        ArrangeBothEnabled(intervalMs: 12000);
+
+        _service.StartIfEnabled();
+
+        Mock.Assert(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), TimeSpan.FromMilliseconds(12000), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+        Mock.Assert(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()), Occurs.Once(),
+            "the two samplers share one drain timer; the second start must not register another");
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never(),
+            "and must not retune the one already armed");
+    }
+
+    [Test]
+    public void Stopping_thread_sampling_while_allocation_is_active_keeps_the_drain_schedule_and_seam_armed()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: true));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _native.Stop(), Occurs.Once());
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never(),
+            "the allocation sampler still needs the shared drain");
+        Assert.That(ContinuousProfilingContext.Instance.IsEnabled, Is.True, "allocation samples still need trace-context correlation");
+        Assert.That(_service.IsActive, Is.False);
+    }
+
+    [Test]
+    public void Stopping_allocation_while_thread_sampling_is_active_keeps_the_drain_schedule_armed()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: false));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never());
+        Assert.That(ContinuousProfilingContext.Instance.IsEnabled, Is.True);
+    }
+
+    [Test]
+    public void Stopping_both_samplers_releases_the_drain_schedule_and_the_seam()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: false));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+        Assert.That(ContinuousProfilingContext.Instance.IsEnabled, Is.False);
+    }
+
+    [Test]
+    public void StopFromCommand_for_cpu_while_allocation_is_active_leaves_allocation_sampling_and_the_drain_running()
+    {
+        // The realistic route to an allocation-only session: both configured on, then an operator stops the cpu
+        // bundle by command.
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.StopFromCommand(new[] { "cpu" });
+
+        Mock.Assert(() => _native.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never());
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never());
+
+        // And the drain still ships allocation-only payloads.
+        ArrangeReadableAllocationBatch();
+        _service.DrainOnce();
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once());
+    }
+
+    [Test]
+    public void Re_enabling_thread_sampling_at_a_new_interval_retunes_the_shared_drain()
+    {
+        ArrangeAllocationOnly(intervalMs: 10000);
+        _service.StartIfEnabled();
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true, intervalMs: 30000));
+        _service.ApplyConfigChange();
+
+        // The thread sampler's interval is the authoritative cadence, so it retunes the timer the allocation
+        // path armed at the config interval.
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+        Mock.Assert(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), TimeSpan.FromMilliseconds(30000), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+    }
+
+    #endregion
+
+    #region DrainOnce
+
+    [Test]
+    public void Drain_tick_with_only_allocation_samples_builds_and_sends()
+    {
+        // The widened early-return: a sweep with zero thread samples but non-zero allocation samples must
+        // still be built and shipped.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        ExportProfilesRequest captured = null;
+        Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns((ExportProfilesRequest r) =>
+        {
+            captured = r;
+            return true;
+        });
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once());
+        Assert.That(captured, Is.Not.Null);
+        // allocated_objects + allocated_space, and no cpu/off_cpu profile (there were no thread samples, and
+        // the thread sampler's interval -- the profile period -- is zero while it is stopped).
+        Assert.That(captured.ResourceProfiles[0].ScopeProfiles[0].Profiles, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Drain_tick_with_both_sample_types_ships_them_in_one_request()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+        ArrangeReadableAllocationBatch();
+
+        ExportProfilesRequest captured = null;
+        Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns((ExportProfilesRequest r) =>
+        {
+            captured = r;
+            return true;
+        });
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once(),
+            "both sample types must ride ONE request, not one request each");
+        // off_cpu (the thread batch is version 1, so no sample is classified on-CPU) + allocated_objects +
+        // allocated_space.
+        Assert.That(captured.ResourceProfiles[0].ScopeProfiles[0].Profiles, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public void Drain_tick_with_neither_sample_type_does_not_send()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Never());
+    }
+
+    [Test]
+    public void Drain_tick_does_not_read_the_allocation_source_while_allocation_sampling_is_inactive()
+    {
+        // The thread sampler arms the shared drain on its own, so an ungated allocation read would P/Invoke a
+        // never-started sampler on every tick for the life of the process.
+        ArrangeThreadSamplingOnly();
+        _service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Never());
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_reports_the_allocation_samples_supportability_metric()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/Drain"), Occurs.Once());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", 1), Occurs.Once());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/Samples", Arg.IsAny<long>()), Occurs.Never(),
+            "no thread samples in this sweep -- reporting a zero count would be noise");
+    }
+
+    [Test]
+    public void Drain_tick_never_throws_when_the_allocation_source_throws()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() => _service.DrainOnce());
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Never());
+    }
+
+    [Test]
+    public void Drain_tick_discards_an_allocation_batch_that_overruns_the_drain_buffer()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => dest.Length + 1);
+
+        Assert.DoesNotThrow(() => _service.DrainOnce());
+
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Never());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/Error"), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_reports_the_boundary_metric_for_an_allocation_batch_that_fills_the_drain_buffer()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => dest.Length);
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/DrainBufferBoundary"), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_after_Dispose_reads_neither_source()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        ArrangeReadableAllocationBatch();
+
+        _service.Dispose();
+        _service.DrainOnce();
+
+        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Never());
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Never());
+    }
+
+    #endregion
+
+    #region Dispose -- the one and only Shutdown
+
+    [Test]
+    public void Dispose_shuts_down_the_allocation_sampler_exactly_once()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        _service.Dispose();
+
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Once());
+    }
+
+    [Test]
+    public void Dispose_shuts_down_the_allocation_sampler_even_when_it_was_never_started()
+    {
+        // The native session is closed and its in-flight work drained deterministically on teardown, exactly as
+        // for the thread profiler, whether or not this process ever sampled.
+        _service.Dispose();
+
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Once());
+    }
+
+    [Test]
+    public void Dispose_stops_an_active_allocation_sampler_before_shutting_it_down()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+
+        _service.Dispose();
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Once());
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Once(),
+            "the drain armed by the allocation-only session must be released on teardown");
+    }
+
+    [Test]
+    public void Dispose_does_not_throw_when_the_allocation_shutdown_throws()
+    {
+        Mock.Arrange(() => _allocationSource.Shutdown()).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() => _service.Dispose());
+    }
+
+    [Test]
+    public void Dispose_still_shuts_down_the_allocation_sampler_when_the_thread_profiler_shutdown_throws()
+    {
+        // Separately try/caught: one native teardown failing must not skip the other, or an EventPipe session
+        // would be left open for the life of the process.
+        Mock.Arrange(() => _native.Shutdown()).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() => _service.Dispose());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Once());
+    }
+
+    #endregion
+
+    #region send-failure backoff
+
+    [Test]
+    public void Tripping_backoff_pauses_allocation_sampling()
+    {
+        // Both sample types ride the request that just failed, so there is nothing to gain from continuing to
+        // pay for allocation stack walks on customer threads while the drain is gated off.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // two consecutive failures trip the backoff
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Never(), "a pause must never be a terminal shutdown");
+    }
+
+    [Test]
+    public void A_backoff_probe_resumes_an_allocation_only_session_at_the_same_budget()
+    {
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly(budget: 750);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        Action probe = null;
+        Mock.Arrange(() => _scheduler.ExecuteOnce(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>()))
+            .DoInstead((Action action, TimeSpan delay) => probe = action);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips, schedules the probe
+
+        probe.Invoke();
+
+        // Once from the start, once from the probe's resume -- and the thread sampler, which was never
+        // enabled, must not be resumed by an allocation-only probe.
+        Mock.Assert(() => _allocationSource.Start(750), Occurs.Exactly(2));
+        Mock.Assert(() => _native.Start(Arg.AnyInt), Occurs.Never());
+
+        // The gate is clear again, so the next drain reaches Send.
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
+        service.DrainOnce();
+        Mock.Assert(() => transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Exactly(3));
+    }
+
+    [Test]
+    public void A_probe_firing_after_allocation_was_disabled_does_not_resume_it()
+    {
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        Action probe = null;
+        Mock.Arrange(() => _scheduler.ExecuteOnce(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>()))
+            .DoInstead((Action action, TimeSpan delay) => probe = action);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff, schedules a probe
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: false));
+        service.ApplyConfigChange();
+
+        probe.Invoke();
+
+        // Only the original start: reviving a sampler the configuration no longer wants would be wrong.
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Once());
+    }
+
+    #endregion
+
+    #region batch builders (mirror BufferParserTests / BufferParserAllocationTests)
+
+    private const byte StartBatch = 0x01, StartSample = 0x02, EndBatch = 0x06, AllocationSample = 0x08;
+
+    private static void WriteShort(MemoryStream s, short v) { s.WriteByte((byte)(v >> 8)); s.WriteByte((byte)v); }
+    private static void WriteLong(MemoryStream s, long v) { for (var i = 7; i >= 0; i--) s.WriteByte((byte)(v >> (i * 8))); }
+    private static void WriteString(MemoryStream s, string v)
+    {
+        var bytes = Encoding.Unicode.GetBytes(v); // UTF-16LE
+        WriteShort(s, (short)v.Length);
+        s.Write(bytes, 0, bytes.Length);
+    }
+
+    private static byte[] OneThreadSampleBatch(string thread, long osId, long tHigh, long tLow, long span, string[] framesLeafFirst)
+    {
+        using var s = new MemoryStream();
+        s.WriteByte(StartBatch); s.WriteByte(1); WriteLong(s, 123456789L); // version + timestamp
+        s.WriteByte(StartSample);
+        WriteString(s, thread); WriteLong(s, osId); WriteLong(s, tHigh); WriteLong(s, tLow); WriteLong(s, span);
+        short next = 1;
+        foreach (var f in framesLeafFirst) { WriteShort(s, (short)-next); WriteString(s, f); next++; }
+        WriteShort(s, 0); // end of frames
+        s.WriteByte(EndBatch);
+        return s.ToArray();
+    }
+
+    // One 0x08 allocation-sample record, in the field order the native SampleBufferWriter emits.
+    private static byte[] OneAllocationSampleBatch()
+    {
+        using var s = new MemoryStream();
+        s.WriteByte(StartBatch); s.WriteByte(2); WriteLong(s, 123456789L); // version + timestamp
+        s.WriteByte(AllocationSample);
+        WriteString(s, "worker-1");
+        WriteLong(s, 4242L);                  // OS thread id
+        WriteLong(s, 0x11); WriteLong(s, 0x22); WriteLong(s, 0x33); // traceIdHigh/Low, spanId
+        WriteLong(s, 1700000000000L);         // timestampMillis
+        WriteLong(s, 65536L);                 // allocatedSize
+        WriteString(s, "MyApp.Widget");       // type name
+        WriteShort(s, -1); WriteString(s, "MyApp.Widget.Create()"); // frame, first sight -> define
+        WriteShort(s, 0); // end of frames
+        s.WriteByte(EndBatch);
+        return s.ToArray();
+    }
+
+    #endregion
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
@@ -722,6 +722,22 @@ public class ContinuousProfilingServiceAllocationTests
     }
 
     [Test]
+    public void Drain_tick_does_not_read_the_thread_source_while_thread_sampling_is_inactive()
+    {
+        // The mirror of the gate above, for the configuration this feature explicitly supports: an
+        // allocation-only deployment arms the shared drain itself, so an ungated thread-sample read would
+        // P/Invoke a never-started thread sampler on every tick for the life of the process.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        ArrangeReadableAllocationBatch();
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _source.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Never());
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once());
+    }
+
+    [Test]
     public void Drain_tick_reports_the_allocation_samples_supportability_metric()
     {
         ArrangeAllocationOnly();

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.ContinuousProfiling;
@@ -709,6 +710,295 @@ public class ContinuousProfilingServiceAllocationTests
         Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
         service.DrainOnce();
         Mock.Assert(() => transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Exactly(3));
+    }
+
+    [Test]
+    public void Starting_thread_sampling_during_a_backoff_pause_also_resumes_the_paused_allocation_sampler()
+    {
+        // Regression test for a silent, PERMANENT failure: the trip pauses both natives but leaves both active
+        // flags true, and the pending probe is the only thing that ever resumes them. A thread-sampler start
+        // clears the backoff gate and bumps the generation, superseding that probe -- so unless it resumes
+        // allocation itself, allocation stays Stop()'d forever with _allocationActive still reading true, and
+        // nothing ever tries again.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly(budget: 300);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff: allocation native Stop()'d, flag still true, probe pending
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+
+        // The thread sampler starts later (by command here; a config enable takes the same path).
+        service.StartFromCommand(new[] { "cpu" }, null, null);
+
+        // Once from the original start, once from this start's resume-the-other-sampler step.
+        Mock.Assert(() => _allocationSource.Start(300), Occurs.Exactly(2),
+            "the start that superseded the probe owes the paused allocation sampler a resume");
+    }
+
+    [Test]
+    public void Starting_allocation_during_a_backoff_pause_also_resumes_the_paused_thread_sampler()
+    {
+        // The mirror of the above: an allocation start clears the same shared gate and supersedes the same
+        // probe, so it owes the paused thread sampler a resume.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeThreadSamplingOnly(intervalMs: 11000);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff: thread native Stop()'d, _isActive still true
+        Mock.Assert(() => _native.Stop(), Occurs.Once());
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true, intervalMs: 11000));
+        service.ApplyConfigChange();
+
+        Mock.Assert(() => _native.Start(11000), Occurs.Exactly(2),
+            "the allocation start that superseded the probe owes the paused thread sampler a resume");
+    }
+
+    [Test]
+    public void Starting_thread_sampling_resumes_the_paused_allocation_sampler_even_when_its_own_native_start_throws()
+    {
+        // Regression test for the exception path of the resume fix. The start clears the gate and supersedes the
+        // probe BEFORE doing anything else, so the debt owed to the other sampler must be paid before this
+        // sampler takes its own risk. If the resume sat after the throwing own-start, the catch (which only
+        // unwinds THIS sampler) would leave allocation stopped with its flag true and no probe left to fire --
+        // permanently stranded.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly(budget: 300);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff: allocation paused, flag still true, probe pending
+
+        // The thread sampler's own native start fails.
+        Mock.Arrange(() => _native.Start(Arg.AnyInt)).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() => service.StartFromCommand(new[] { "cpu" }, null, null));
+
+        Mock.Assert(() => _allocationSource.Start(300), Occurs.Exactly(2),
+            "allocation must be resumed even though the thread sampler's own start threw");
+        Assert.That(service.IsActive, Is.False, "the failed thread start still unwinds itself");
+    }
+
+    [Test]
+    public void Starting_allocation_resumes_the_paused_thread_sampler_even_when_its_own_native_start_throws()
+    {
+        // The mirror direction of the above.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeThreadSamplingOnly(intervalMs: 11000);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff: thread sampler paused, _isActive still true, probe pending
+
+        // The allocation sampler's own native start fails.
+        Mock.Arrange(() => _allocationSource.Start(Arg.AnyInt)).Throws(new InvalidOperationException("boom"));
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true, intervalMs: 11000));
+        Assert.DoesNotThrow(() => service.ApplyConfigChange());
+
+        Mock.Assert(() => _native.Start(11000), Occurs.Exactly(2),
+            "thread sampling must be resumed even though the allocation sampler's own start threw");
+    }
+
+    [Test]
+    public void Resuming_after_backoff_resets_the_drain_timestamp_so_the_next_profile_is_not_stretched_over_the_pause()
+    {
+        // Each resume helper owns its own _lastDrainTimestamp reset; without it the first profile after the
+        // resume reports a duration spanning the whole paused window (up to the 300s backoff cap) rather than
+        // one real interval. This exercises the thread-sampling resume specifically, because in this scenario
+        // the drain timer is already armed -- so StartAllocationLocked's trailing ArmDrainScheduleLocked (which
+        // also resets the timestamp) is NOT reached, and only the helper's own reset can save it.
+        const int PauseMs = 300;
+
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeThreadSamplingOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff; _lastDrainTimestamp is left at this moment
+
+        // Stand in for waiting out a real backoff delay.
+        Thread.Sleep(PauseMs);
+
+        // Enabling allocation resumes the paused thread sampler.
+        service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true));
+        service.ApplyConfigChange();
+
+        // Re-arranging this locally-created mock works (the existing backoff tests flip false -> true the same
+        // way); only SetUp's arrangement on the shared _transport can't be overridden in a test body.
+        ExportProfilesRequest captured = null;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns((ExportProfilesRequest r) =>
+        {
+            captured = r;
+            return true;
+        });
+
+        service.DrainOnce();
+
+        Assert.That(captured, Is.Not.Null);
+        var durationNano = captured.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].DurationNano;
+
+        // Generous threshold: with the reset this is the few ms of mock/build work since the resume; without it
+        // this would be at least the full PauseMs. Half the pause leaves a wide margin against CI jitter.
+        Assert.That(durationNano, Is.LessThan((ulong)PauseMs / 2 * 1_000_000UL),
+            "the first profile after a resume must not be stretched over the backoff pause");
+    }
+
+    [Test]
+    public void A_failure_to_resume_allocation_after_backoff_does_not_unwind_the_thread_sampler_start()
+    {
+        // Isolation, the other direction: the resume helper owns its errors, so a broken allocation sampler
+        // fails only allocation sampling. The thread-sampler start that triggered the resume must still succeed.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff
+
+        // Only the RESUME attempt throws; the original start above already succeeded.
+        Mock.Arrange(() => _allocationSource.Start(Arg.AnyInt)).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() => service.StartFromCommand(new[] { "cpu" }, null, null));
+
+        Assert.That(service.IsActive, Is.True, "the thread sampler start must not be unwound by a failed allocation resume");
+        // Once from the backoff trip's pause, once from the failed resume unwinding allocation (fail closed).
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Exactly(2));
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Never(),
+            "the thread sampler is running, so the shared drain must stay armed");
+    }
+
+    [Test]
+    public void A_failure_to_resume_thread_sampling_after_backoff_does_not_unwind_the_allocation_start()
+    {
+        // And the mirror: a broken thread sampler must not take the allocation start down with it.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeThreadSamplingOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        ArrangeReadableThreadBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff
+
+        // Only the RESUME attempt throws; the original start above already succeeded.
+        Mock.Arrange(() => _native.Start(Arg.AnyInt)).Throws(new InvalidOperationException("boom"));
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: true, budget: 275));
+        Assert.DoesNotThrow(() => service.ApplyConfigChange());
+
+        Mock.Assert(() => _allocationSource.Start(275), Occurs.Once(),
+            "the allocation start must not be unwound by a failed thread-sampling resume");
+        Assert.That(service.IsActive, Is.False, "the thread sampler failed to resume and is stopped");
+
+        // And allocation is genuinely live: it re-armed the shared drain and a drain ships its samples.
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
+        service.DrainOnce();
+        Mock.Assert(() => transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Exactly(3));
+    }
+
+    [Test]
+    public void Disabling_and_re_enabling_allocation_while_backing_off_clears_the_stuck_gate()
+    {
+        // Same stuck-gate hazard the thread-sampling path was already fixed for: a probe that fires while
+        // nothing is active cannot clear _sendBackoffActive, so without the allocation start performing the
+        // optimistic reset, re-enabling allocation would sample forever with every drain silently gated off.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        Action probe = null;
+        Mock.Arrange(() => _scheduler.ExecuteOnce(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>()))
+            .DoInstead((Action action, TimeSpan delay) => probe = action);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff, schedules a probe
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: false));
+        service.ApplyConfigChange();
+
+        probe.Invoke(); // fires while nothing is active -- cannot clear the gate
+
+        service.OverrideConfigForTesting(_config);
+        service.ApplyConfigChange(); // re-enable allocation
+
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
+        service.DrainOnce();
+
+        // 2 failures before the disable + 1 recovery send after re-enabling. Without the reset this third send
+        // would never happen, because the drain would still be gated.
+        Mock.Assert(() => transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Exactly(3));
+    }
+
+    [Test]
+    public void A_budget_change_during_a_backoff_pause_does_not_re_arm_sampling_or_collapse_the_round()
+    {
+        // A budget edit is no evidence the send path recovered, so it must neither clear the gate nor re-arm the
+        // native -- re-arming would buy real stack walks on customer threads whose output the gated drain
+        // discards. The new budget is recorded and takes effect when the probe resumes.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly(budget: 200);
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        Action probe = null;
+        Mock.Arrange(() => _scheduler.ExecuteOnce(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>()))
+            .DoInstead((Action action, TimeSpan delay) => probe = action);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+        service.DrainOnce(); // trips backoff
+
+        service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: true, budget: 900));
+        service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(900), Occurs.Never(), "sampling must stay paused while backing off");
+
+        // The probe resumes at the NEW budget, so the edit was recorded rather than dropped.
+        probe.Invoke();
+        Mock.Assert(() => _allocationSource.Start(900), Occurs.Once());
     }
 
     [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
@@ -301,8 +301,9 @@ public class ContinuousProfilingServiceAllocationTests
     public void ApplyConfigChange_reconciles_allocation_even_while_the_cpu_bundle_is_command_owned()
     {
         // An agent command owns the cpu bundle until a matching stop, and ApplyConfigChange must not disturb
-        // it. Allocation sampling is not command-controllable yet, so its config-driven reconciliation has to
-        // run anyway -- it must not be nested inside the cpu ownership guard's early return.
+        // it. Command ownership is tracked PER TYPE, so a command that owns only the cpu bundle must leave
+        // allocation sampling under config control -- the guard must not be an early return out of the whole
+        // method.
         ArrangeThreadSamplingOnly();
         _service.StartFromCommand(new[] { "cpu" }, null, null);
 
@@ -323,6 +324,166 @@ public class ContinuousProfilingServiceAllocationTests
         _service.ApplyConfigChange();
 
         Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Never());
+    }
+
+    #endregion
+
+    #region the heap agent-command token
+
+    [Test]
+    public void StartFromCommand_with_heap_starts_allocation_sampling_even_while_config_has_it_disabled()
+    {
+        // The point of an operator command: it starts a sampler the configuration does not enable. The BUDGET
+        // still comes from configuration, because the command carries none of its own (its two interval
+        // parameters are both cpu-shaped).
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: false, budget: 275));
+
+        var result = _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        Mock.Assert(() => _allocationSource.Start(275), Occurs.Once());
+        Mock.Assert(() => _native.Start(Arg.AnyInt), Occurs.Never(), "\"heap\" is allocations only");
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "heap" }));
+            Assert.That(result.Exceptions, Is.Empty, "allocation sampling is implemented now, so nothing is unsupported");
+        });
+    }
+
+    [Test]
+    public void StartFromCommand_with_heap_arms_the_shared_drain_schedule_and_the_trace_context_seam()
+    {
+        // The command path must go through the same StartAllocationLocked as the config path, not a shortcut
+        // that starts the native sampler with nothing draining it.
+        ArrangeAllocationOnly(intervalMs: 15000);
+
+        _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        Mock.Assert(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), TimeSpan.FromMilliseconds(15000), Arg.IsAny<TimeSpan?>()), Occurs.Once());
+        Assert.That(ContinuousProfilingContext.Instance.IsEnabled, Is.True);
+    }
+
+    [Test]
+    public void StartFromCommand_with_heap_while_allocation_is_already_active_is_an_idempotent_noop()
+    {
+        ArrangeAllocationOnly(budget: 200);
+        _service.StartIfEnabled();
+
+        var result = _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Once(), "a repeat start must not re-pace a running sampler");
+        Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "heap" }));
+    }
+
+    [Test]
+    public void StopFromCommand_with_heap_stops_allocation_sampling_and_releases_the_shared_drain()
+    {
+        ArrangeAllocationOnly();
+        _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        var result = _service.StopFromCommand(new[] { "heap" });
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Never(), "a command stop must never be the terminal shutdown");
+        Mock.Assert(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()), Occurs.Once(),
+            "nothing else is sampling, so the shared drain is released");
+        Assert.That(result.ActiveTypes, Is.Empty);
+    }
+
+    [Test]
+    public void StopFromCommand_with_heap_while_allocation_is_inactive_is_an_idempotent_noop()
+    {
+        ArrangeAllocationOnly();
+
+        var result = _service.StopFromCommand(new[] { "heap" });
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never());
+        Assert.That(result.Exceptions, Is.Empty);
+    }
+
+    [Test]
+    public void A_command_started_allocation_sampler_is_immune_to_an_unrelated_config_update_until_explicitly_stopped()
+    {
+        // The heap mirror of the cpu ownership test in ContinuousProfilingServiceTests: an incidental
+        // config-update event must not silently undo an operator's explicit command.
+        ArrangeAllocationOnly();
+        _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: false));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never());
+
+        // An explicit stop command releases ownership; a subsequent config update can act again.
+        _service.StopFromCommand(new[] { "heap" });
+        _service.ApplyConfigChange(); // config still says disabled -- already stopped, so no second stop
+
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+    }
+
+    [Test]
+    public void ApplyConfigChange_does_not_repace_a_command_owned_allocation_sampler()
+    {
+        // Ownership covers the budget too, not just start/stop: a server-side budget push must not silently
+        // re-pace a sampler an operator started by command.
+        ArrangeAllocationOnly(budget: 200);
+        _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: false, allocation: true, budget: 900));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _allocationSource.Start(900), Occurs.Never());
+        Mock.Assert(() => _allocationSource.Start(200), Occurs.Once());
+    }
+
+    [Test]
+    public void ApplyConfigChange_still_reconciles_thread_sampling_while_allocation_is_command_owned()
+    {
+        // The other direction of the per-type guard: heap ownership must not freeze the thread sampler's
+        // config-driven reconciliation.
+        ArrangeAllocationOnly();
+        _service.StartFromCommand(new[] { "heap" }, null, null);
+
+        // Note this config also DISABLES allocation, which is exactly what the heap ownership guard has to
+        // ignore.
+        _service.OverrideConfigForTesting(NewConfig(threadSampling: true, allocation: false, intervalMs: 20000));
+        _service.ApplyConfigChange();
+
+        Mock.Assert(() => _native.Start(20000), Occurs.Once(), "the thread sampler is still config-controlled");
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never(), "the command-owned allocation sampler must be left alone");
+        Assert.That(_service.IsActive, Is.True);
+
+        // And allocation sampling is genuinely still live, not merely un-stopped: the drain still reads it,
+        // which it only does while the allocation active flag is set.
+        ArrangeReadableAllocationBatch();
+        _service.DrainOnce();
+        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Once());
+    }
+
+    [Test]
+    public void An_empty_include_command_reports_a_config_started_allocation_sampler_as_active()
+    {
+        // The status-query shape of the command (empty include changes nothing): ActiveTypes must report the
+        // allocation sampler even though configuration, not a command, started it.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+
+        var result = _service.StartFromCommand(Array.Empty<string>(), null, null);
+
+        Mock.Assert(() => _allocationSource.Start(Arg.AnyInt), Occurs.Once(), "an empty include must not start anything");
+        Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "heap" }));
+    }
+
+    [Test]
+    public void A_command_result_reports_both_samplers_when_both_are_active()
+    {
+        ArrangeBothEnabled();
+        _service.StartIfEnabled();
+
+        var result = _service.StopFromCommand(Array.Empty<string>());
+
+        Mock.Assert(() => _native.Stop(), Occurs.Never(), "an empty include must not stop anything");
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Never());
+        Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "cpu", "heap" }));
     }
 
     #endregion

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceAllocationTests.cs
@@ -141,13 +141,43 @@ public class ContinuousProfilingServiceAllocationTests
         });
     }
 
+    // One readable allocation batch PER DRAIN. The drain reads this source until a read comes up empty, so a
+    // source that always returned the same bytes would be read until the loop's own cap -- and every
+    // per-drain sample count in this fixture would silently multiply. Alternating batch/empty models the
+    // native contract instead: a drain drains what is there, then stops.
     private void ArrangeReadableAllocationBatch()
     {
         var batch = OneAllocationSampleBatch();
+        var reads = 0;
         Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
         {
+            if (reads++ % 2 == 1)
+                return 0; // this drain has nothing more
+
             Array.Copy(batch, dest, batch.Length);
             return batch.Length;
+        });
+    }
+
+    // `batchesPerDrain` readable allocation batches, then an empty read to end the drain's read loop --
+    // which is what the native sampler produces once back-pressure has made it accumulate several batches.
+    // Each batch carries a distinct allocated size so the combined result can be checked for real
+    // per-batch content rather than a repeated first batch.
+    private void ArrangeMultipleReadableAllocationBatches(int batchesPerDrain, int droppedPerBatch = 0)
+    {
+        var batches = new byte[batchesPerDrain][];
+        for (var i = 0; i < batchesPerDrain; i++)
+            batches[i] = OneAllocationSampleBatch(allocatedSize: 1024 + i, droppedSamples: droppedPerBatch);
+
+        var reads = 0;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            var index = reads++ % (batchesPerDrain + 1);
+            if (index == batchesPerDrain)
+                return 0; // end of this drain's backlog
+
+            Array.Copy(batches[index], dest, batches[index].Length);
+            return batches[index].Length;
         });
     }
 
@@ -456,7 +486,9 @@ public class ContinuousProfilingServiceAllocationTests
         // which it only does while the allocation active flag is set.
         ArrangeReadableAllocationBatch();
         _service.DrainOnce();
-        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Once());
+        // Twice, not once: the drain reads until a read comes up empty (one batch here, then the empty read
+        // that ends the loop).
+        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Exactly(2));
     }
 
     [Test]
@@ -737,11 +769,230 @@ public class ContinuousProfilingServiceAllocationTests
         ArrangeAllocationOnly();
         _service.StartIfEnabled();
         Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
-        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => dest.Length);
+
+        // One buffer-filling batch, then empty -- the drain reads this source until it comes up empty, so a
+        // source that returned a full buffer forever would report the boundary once per read rather than once.
+        var reads = 0;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => reads++ == 0 ? dest.Length : 0);
 
         _service.DrainOnce();
 
         Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/DrainBufferBoundary"), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_reads_the_allocation_source_until_it_comes_up_empty()
+    {
+        // Half of the delivery-ceiling fix: a single ReadBatch per drain could free only one of the native
+        // queue's two slots per drain interval, so no configured budget above ~1 sample per interval could
+        // ever be delivered. The drain must keep reading while there is data.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeMultipleReadableAllocationBatches(batchesPerDrain: 3);
+
+        _service.DrainOnce();
+
+        // 3 batches + the empty read that ends the loop.
+        Mock.Assert(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Exactly(4));
+    }
+
+    [Test]
+    public void Drain_tick_ships_every_allocation_batch_it_read_in_one_request()
+    {
+        // Reading more batches must widen the PAYLOAD, not the number of exports: still one profile per
+        // drain, now carrying every sample the sampler had accumulated.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeMultipleReadableAllocationBatches(batchesPerDrain: 3);
+
+        ExportProfilesRequest captured = null;
+        Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns((ExportProfilesRequest r) =>
+        {
+            captured = r;
+            return true;
+        });
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once(),
+            "several batches must ride ONE request, not one request per batch");
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", 3), Occurs.Once(),
+            "all three batches' samples must be counted, not just the first batch's");
+
+        Assert.That(captured, Is.Not.Null);
+        var profiles = captured.ResourceProfiles[0].ScopeProfiles[0].Profiles;
+        Assert.That(profiles, Has.Count.EqualTo(2), "still just allocated_objects + allocated_space");
+        // One sample per batch per profile, and the three distinct allocated sizes prove the later batches'
+        // real content was carried rather than the first batch being counted three times.
+        Assert.That(profiles[0].Samples, Has.Count.EqualTo(3));
+        var allocatedSpace = profiles[1];
+        Assert.That(allocatedSpace.Samples.Count, Is.EqualTo(3));
+        Assert.That(new[] { allocatedSpace.Samples[0].Values[0], allocatedSpace.Samples[1].Values[0], allocatedSpace.Samples[2].Values[0] },
+            Is.EqualTo(new long[] { 1024, 1025, 1026 }));
+    }
+
+    [Test]
+    public void Drain_tick_stops_reading_the_allocation_source_at_the_first_empty_read()
+    {
+        // The loop's terminating condition, isolated: an empty read ends the sweep even though the source
+        // would happily return more data afterwards. Without this, a drain would always run to the read cap.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+
+        var batch = OneAllocationSampleBatch();
+        var reads = 0;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            reads++;
+            if (reads == 2)
+                return 0; // the empty read that must end the loop
+
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+
+        _service.DrainOnce();
+
+        Assert.That(reads, Is.EqualTo(2), "the drain must stop at the empty read rather than keep polling");
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", 1), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_caps_how_many_allocation_batches_it_reads()
+    {
+        // A native source that never reports empty must not spin the drain thread: the loop is bounded.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+
+        var batch = OneAllocationSampleBatch();
+        var reads = 0;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            reads++;
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+
+        _service.DrainOnce();
+
+        Assert.That(reads, Is.EqualTo(8), "the read loop must stop at its cap");
+        Mock.Assert(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>()), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_stops_reading_once_it_has_capped_out_on_allocation_samples()
+    {
+        // Removing the delivery ceiling made a drain's sample count follow the configured budget, so the
+        // managed side needs its own bound on what it will build/serialize/POST. 5 batches of 400 reach the
+        // 2000 cap exactly: reading must STOP there (not continue to the read cap) and, because nothing was
+        // refused, nothing may be counted as dropped -- the samples still in the native queue are simply the
+        // next drain's.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+
+        var batch = ManyAllocationSampleBatch(400);
+        var reads = 0;
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            reads++;
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+
+        ExportProfilesRequest captured = null;
+        Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns((ExportProfilesRequest r) =>
+        {
+            captured = r;
+            return true;
+        });
+
+        _service.DrainOnce();
+
+        Assert.That(reads, Is.EqualTo(5), "reading must stop once the cap is reached rather than run to the read cap");
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", 2000), Occurs.Once());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped", Arg.IsAny<long>()), Occurs.Never(),
+            "hitting the cap exactly discards nothing");
+        Assert.That(captured.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Samples, Has.Count.EqualTo(2000));
+    }
+
+    [Test]
+    public void Drain_tick_takes_the_part_of_a_batch_that_fits_under_the_cap()
+    {
+        // The partial-take path: 3 x 700 = 2100 against a 2000 cap, so the third batch contributes 600 and
+        // 100 are dropped -- a batch straddling the cap must not be discarded whole.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+
+        var batch = ManyAllocationSampleBatch(700);
+        Mock.Arrange(() => _allocationSource.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) =>
+        {
+            Array.Copy(batch, dest, batch.Length);
+            return batch.Length;
+        });
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", 2000), Occurs.Once());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped", 100), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_reports_the_dropped_allocation_samples_metric_from_the_native_batch_stats()
+    {
+        // The supportability signal for the ceiling this task fixed: when the native sampler still has to
+        // drop samples (queue full AND pending batch full), the count reaches the metric rather than only a
+        // Finest-level native log line.
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeMultipleReadableAllocationBatches(batchesPerDrain: 2, droppedPerBatch: 5);
+
+        _service.DrainOnce();
+
+        // Summed across every batch read in the sweep -- each carries its own delta.
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped", 10), Occurs.Once());
+    }
+
+    [Test]
+    public void Drain_tick_does_not_report_the_dropped_metric_when_nothing_was_dropped()
+    {
+        ArrangeAllocationOnly();
+        _service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeReadableAllocationBatch();
+
+        _service.DrainOnce();
+
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped", Arg.AnyLong), Occurs.Never(),
+            "a zero drop count is noise");
+    }
+
+    [Test]
+    public void Drain_tick_reports_dropped_allocation_samples_even_when_the_send_fails()
+    {
+        // Unlike Drain/AllocationSamples, which describe the request that was accepted, a drop count is a
+        // fact about the native sampler that has already been consumed from its counter -- withholding it on
+        // a failed send would lose it permanently.
+        var (service, transport) = NewConnectedService();
+        using var _ = service;
+        ArrangeAllocationOnly();
+        service.OverrideConfigForTesting(_config);
+        service.StartIfEnabled();
+        Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
+        ArrangeMultipleReadableAllocationBatches(batchesPerDrain: 1, droppedPerBatch: 7);
+        Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
+
+        service.DrainOnce();
+
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamplesDropped", 7), Occurs.Once());
+        Mock.Assert(() => _health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/AllocationSamples", Arg.AnyLong), Occurs.Never(),
+            "the send failed, so the per-request counts are not reported");
     }
 
     [Test]
@@ -1194,9 +1445,10 @@ public class ContinuousProfilingServiceAllocationTests
 
     #region batch builders (mirror BufferParserTests / BufferParserAllocationTests)
 
-    private const byte StartBatch = 0x01, StartSample = 0x02, EndBatch = 0x06, AllocationSample = 0x08;
+    private const byte StartBatch = 0x01, StartSample = 0x02, EndBatch = 0x06, BatchStats = 0x07, AllocationSample = 0x08;
 
     private static void WriteShort(MemoryStream s, short v) { s.WriteByte((byte)(v >> 8)); s.WriteByte((byte)v); }
+    private static void WriteInt(MemoryStream s, int v) { for (var i = 3; i >= 0; i--) s.WriteByte((byte)(v >> (i * 8))); }
     private static void WriteLong(MemoryStream s, long v) { for (var i = 7; i >= 0; i--) s.WriteByte((byte)(v >> (i * 8))); }
     private static void WriteString(MemoryStream s, string v)
     {
@@ -1218,8 +1470,11 @@ public class ContinuousProfilingServiceAllocationTests
         return s.ToArray();
     }
 
-    // One 0x08 allocation-sample record, in the field order the native SampleBufferWriter emits.
-    private static byte[] OneAllocationSampleBatch()
+    // One 0x08 allocation-sample record, in the field order the native SampleBufferWriter emits. When
+    // `droppedSamples` is non-zero the batch also carries a 0x07 BatchStats record, which is how the native
+    // allocation sampler reports samples it had to drop for lack of buffer space (its `skipped` field, the
+    // same one thread-sample batches use).
+    private static byte[] OneAllocationSampleBatch(long allocatedSize = 65536L, int droppedSamples = 0)
     {
         using var s = new MemoryStream();
         s.WriteByte(StartBatch); s.WriteByte(2); WriteLong(s, 123456789L); // version + timestamp
@@ -1228,10 +1483,51 @@ public class ContinuousProfilingServiceAllocationTests
         WriteLong(s, 4242L);                  // OS thread id
         WriteLong(s, 0x11); WriteLong(s, 0x22); WriteLong(s, 0x33); // traceIdHigh/Low, spanId
         WriteLong(s, 1700000000000L);         // timestampMillis
-        WriteLong(s, 65536L);                 // allocatedSize
+        WriteLong(s, allocatedSize);          // allocatedSize
         WriteString(s, "MyApp.Widget");       // type name
         WriteShort(s, -1); WriteString(s, "MyApp.Widget.Create()"); // frame, first sight -> define
         WriteShort(s, 0); // end of frames
+
+        if (droppedSamples != 0)
+        {
+            s.WriteByte(BatchStats);
+            WriteLong(s, 0L);   // microsSuspended -- not meaningful for allocation batches
+            WriteInt(s, 0);     // threads
+            WriteInt(s, 0);     // frames
+            WriteInt(s, droppedSamples);
+        }
+
+        s.WriteByte(EndBatch);
+        return s.ToArray();
+    }
+
+    // A batch of `count` 0x08 records sharing one interned frame -- the shape a real back-pressured native
+    // batch has (first sight defines the frame, every repeat is a positive back-reference).
+    private static byte[] ManyAllocationSampleBatch(int count)
+    {
+        using var s = new MemoryStream();
+        s.WriteByte(StartBatch); s.WriteByte(2); WriteLong(s, 123456789L);
+
+        for (var i = 0; i < count; i++)
+        {
+            s.WriteByte(AllocationSample);
+            WriteString(s, "worker-1");
+            WriteLong(s, 4242L);
+            WriteLong(s, 0x11); WriteLong(s, 0x22); WriteLong(s, 0x33);
+            WriteLong(s, 1700000000000L);
+            WriteLong(s, 1024L + i);
+            WriteString(s, "MyApp.Widget");
+            if (i == 0)
+            {
+                WriteShort(s, -1); WriteString(s, "MyApp.Widget.Create()"); // define
+            }
+            else
+            {
+                WriteShort(s, 1); // back-reference
+            }
+            WriteShort(s, 0);
+        }
+
         s.WriteByte(EndBatch);
         return s.ToArray();
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceDisposeTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceDisposeTests.cs
@@ -21,6 +21,7 @@ public class ContinuousProfilingServiceDisposeTests
 {
     private ISampleSource _source;
     private INativeContinuousProfiler _native;
+    private IAllocationSampleSource _allocationSource;
     private IProfilesTransport _transport;
     private IScheduler _scheduler;
     private IAgentHealthReporter _health;
@@ -32,12 +33,13 @@ public class ContinuousProfilingServiceDisposeTests
     {
         _source = Mock.Create<ISampleSource>();
         _native = Mock.Create<INativeContinuousProfiler>();
+        _allocationSource = Mock.Create<IAllocationSampleSource>();
         _transport = Mock.Create<IProfilesTransport>();
         _scheduler = Mock.Create<IScheduler>();
         _health = Mock.Create<IAgentHealthReporter>();
         _config = Mock.Create<IConfiguration>();
 
-        _service = new ContinuousProfilingService(_source, _native, _transport, _scheduler, _health);
+        _service = new ContinuousProfilingService(_source, _native, _allocationSource, _transport, _scheduler, _health);
     }
 
     [TearDown]

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
@@ -442,6 +442,11 @@ public class ContinuousProfilingServiceTests
     [Test]
     public void Drain_tick_with_no_data_does_not_send()
     {
+        // Started, because the thread-sample read is gated on an active session (an allocation-only
+        // deployment must not P/Invoke into a never-started thread sampler every tick). Without the start
+        // this would assert nothing: the read would be skipped and "no data" would be true by default.
+        ArrangeEnabled(10000);
+        _service.StartIfEnabled();
         Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns(0);
 
         _service.DrainOnce();
@@ -509,6 +514,9 @@ public class ContinuousProfilingServiceTests
     [Test]
     public void Drain_tick_with_bytesRead_exceeding_buffer_length_is_discarded()
     {
+        // Started so the gated thread-sample read actually happens (see Drain_tick_with_no_data_does_not_send).
+        ArrangeEnabled(10000);
+        _service.StartIfEnabled();
         Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => dest.Length + 1);
 
         Assert.DoesNotThrow(() => _service.DrainOnce());
@@ -520,6 +528,9 @@ public class ContinuousProfilingServiceTests
     {
         // Simulates native having filled (or exceeded, then been clamped by ReadBatch itself) the whole
         // managed buffer -- the tripwire for the two buffer-size constants drifting apart again.
+        // Started so the gated thread-sample read actually happens (see Drain_tick_with_no_data_does_not_send).
+        ArrangeEnabled(10000);
+        _service.StartIfEnabled();
         Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Returns((byte[] dest) => dest.Length);
 
         _service.DrainOnce();
@@ -542,6 +553,10 @@ public class ContinuousProfilingServiceTests
     [Test]
     public void Drain_tick_never_throws_when_source_throws()
     {
+        // Started so the gated thread-sample read actually happens (see Drain_tick_with_no_data_does_not_send)
+        // and the source therefore gets the chance to throw.
+        ArrangeEnabled(10000);
+        _service.StartIfEnabled();
         Mock.Arrange(() => _source.ReadBatch(Arg.IsAny<byte[]>())).Throws(new InvalidOperationException("boom"));
 
         Assert.DoesNotThrow(() => _service.DrainOnce());
@@ -844,6 +859,10 @@ public class ContinuousProfilingServiceTests
         // so this proves the pre-connect gate, not just "nothing to drain."
         using var service = new ContinuousProfilingService(_source, _native, _allocationSource, _transport, _scheduler, _health);
 
+        // Sampling IS started (it is decoupled from connect, which is the whole point of the pre-connect
+        // gate), so the read is not skipped by the session gate -- only by the pre-connect one.
+        EnableAndStart(service);
+
         service.DrainOnce();
 
         Mock.Assert(() => _source.ReadBatch(Arg.IsAny<byte[]>()), Occurs.Never());
@@ -946,6 +965,8 @@ public class ContinuousProfilingServiceTests
     {
         var (service, transport) = NewConnectedService();
         using var _ = service;
+        // Started so the gated thread-sample read happens and a real send (and failure) can occur.
+        EnableAndStart(service);
         ArrangeReadableBatch();
         Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
 
@@ -960,6 +981,8 @@ public class ContinuousProfilingServiceTests
     {
         var (service, transport) = NewConnectedService();
         using var _ = service;
+        // Started so the gated thread-sample read happens and a real send (and failure) can occur.
+        EnableAndStart(service);
         ArrangeReadableBatch();
         Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(false);
 
@@ -976,6 +999,8 @@ public class ContinuousProfilingServiceTests
     {
         var (service, transport) = NewConnectedService();
         using var _ = service;
+        // Started so the gated thread-sample read happens and a real send (and throw) can occur.
+        EnableAndStart(service);
         ArrangeReadableBatch();
         Mock.Arrange(() => transport.Send(Arg.IsAny<ExportProfilesRequest>()))
             .Throws(new InvalidOperationException("send failed"));
@@ -1032,6 +1057,9 @@ public class ContinuousProfilingServiceTests
     {
         var (service, transport) = NewConnectedService();
         using var _ = service;
+        // Started so the first two drains really read/send; the third drain is then skipped by the backoff
+        // gate alone (_isActive stays true across a backoff pause, so the session gate is not what stops it).
+        EnableAndStart(service);
 
         var readCount = 0;
         var batch = OneSampleBatch("worker-1", 1, 0, 0, 0, new[] { "F()" });

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
@@ -23,6 +23,8 @@ namespace NewRelic.Agent.Core.UnitTest.ContinuousProfiling;
 [TestFixture]
 public class ContinuousProfilingServiceTests
 {
+    private const int AllocationBudget = 200;
+
     private ISampleSource _source;
     private INativeContinuousProfiler _native;
     private IAllocationSampleSource _allocationSource;
@@ -74,6 +76,11 @@ public class ContinuousProfilingServiceTests
         Mock.Arrange(() => _config.ContinuousProfilingEnabled).Returns(true);
         Mock.Arrange(() => _config.ContinuousProfilingSamplingIntervalMs).Returns(intervalMs);
         Mock.Arrange(() => _config.ApplicationNames).Returns(new[] { "MyApp" });
+        // Allocation sampling stays DISABLED in config here (this fixture covers the thread-sampling path;
+        // ContinuousProfilingServiceAllocationTests covers the other one), but the budget is arranged anyway
+        // because a heap agent command paces a command-started allocation sampler from this value regardless
+        // of the config enable flag.
+        Mock.Arrange(() => _config.ContinuousProfilingAllocationMaxSamplesPerMinute).Returns(AllocationBudget);
         _service.OverrideConfigForTesting(_config);
     }
 
@@ -200,32 +207,71 @@ public class ContinuousProfilingServiceTests
     }
 
     [Test]
-    public void StartFromCommand_with_heap_reports_not_supported_and_does_not_start_anything()
+    public void StartFromCommand_with_heap_starts_only_allocation_sampling()
     {
+        // "heap" = allocations only, so the thread sampler must be left alone -- and IsActive, which reports
+        // the THREAD sampler (the thread-profiling mutual-exclusion guard reads it), stays false.
         ArrangeEnabled(10000);
 
         var result = _service.StartFromCommand(new[] { "heap" }, null, null);
 
         Mock.Assert(() => _native.Start(Arg.IsAny<int>()), Occurs.Never());
+        Mock.Assert(() => _allocationSource.Start(AllocationBudget), Occurs.Once());
         Assert.Multiple(() =>
         {
             Assert.That(_service.IsActive, Is.False);
-            Assert.That(result.Exceptions["heap"], Is.EqualTo("not supported"));
+            Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "heap" }));
+            Assert.That(result.Exceptions, Is.Empty);
         });
     }
 
     [Test]
-    public void StartFromCommand_with_all_starts_cpu_and_reports_heap_as_not_supported()
+    public void StartFromCommand_with_all_starts_both_the_cpu_bundle_and_allocation_sampling()
     {
         ArrangeEnabled(10000);
 
         var result = _service.StartFromCommand(new[] { "all" }, null, null);
 
         Mock.Assert(() => _native.Start(10000), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Start(AllocationBudget), Occurs.Once());
         Assert.Multiple(() =>
         {
-            Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "cpu" }));
-            Assert.That(result.Exceptions["heap"], Is.EqualTo("not supported"));
+            Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "cpu", "heap" }));
+            Assert.That(result.Exceptions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void StopFromCommand_with_all_stops_both_samplers()
+    {
+        ArrangeEnabled(10000);
+        _service.StartFromCommand(new[] { "all" }, null, null);
+
+        var result = _service.StopFromCommand(new[] { "all" });
+
+        Mock.Assert(() => _native.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Stop(), Occurs.Once());
+        Mock.Assert(() => _allocationSource.Shutdown(), Occurs.Never(), "a command stop must never be the terminal shutdown");
+        Assert.Multiple(() =>
+        {
+            Assert.That(_service.IsActive, Is.False);
+            Assert.That(result.ActiveTypes, Is.Empty);
+            Assert.That(result.Exceptions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void StartFromCommand_with_an_unknown_token_alongside_heap_still_starts_allocation_sampling()
+    {
+        ArrangeEnabled(10000);
+
+        var result = _service.StartFromCommand(new[] { "heap", "bogus" }, null, null);
+
+        Mock.Assert(() => _allocationSource.Start(AllocationBudget), Occurs.Once());
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ActiveTypes, Is.EqualTo(new[] { "heap" }));
+            Assert.That(result.Exceptions, Is.EqualTo(new Dictionary<string, string> { { "bogus", "not supported" } }));
         });
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ContinuousProfilingServiceTests.cs
@@ -25,6 +25,7 @@ public class ContinuousProfilingServiceTests
 {
     private ISampleSource _source;
     private INativeContinuousProfiler _native;
+    private IAllocationSampleSource _allocationSource;
     private IProfilesTransport _transport;
     private IScheduler _scheduler;
     private IAgentHealthReporter _health;
@@ -36,6 +37,7 @@ public class ContinuousProfilingServiceTests
     {
         _source = Mock.Create<ISampleSource>();
         _native = Mock.Create<INativeContinuousProfiler>();
+        _allocationSource = Mock.Create<IAllocationSampleSource>();
         _transport = Mock.Create<IProfilesTransport>();
         _scheduler = Mock.Create<IScheduler>();
         _health = Mock.Create<IAgentHealthReporter>();
@@ -46,7 +48,7 @@ public class ContinuousProfilingServiceTests
         // the send-failure backoff after two drains and pause native sampling mid-test.
         Mock.Arrange(() => _transport.Send(Arg.IsAny<ExportProfilesRequest>())).Returns(true);
 
-        _service = new ContinuousProfilingService(_source, _native, _transport, _scheduler, _health);
+        _service = new ContinuousProfilingService(_source, _native, _allocationSource, _transport, _scheduler, _health);
 
         // DrainOnce is gated on having connected -- put _service into the connected state so every
         // existing test below (none of which care about the pre-connect gate) keeps exercising
@@ -762,7 +764,7 @@ public class ContinuousProfilingServiceTests
         // A dedicated transport mock: _transport is shared with _service (already connected in SetUp),
         // whose own handler would also fire on this test's Publish call and double-count the assertion.
         var transport = Mock.Create<IProfilesTransport>();
-        using var service = new ContinuousProfilingService(_source, _native, transport, _scheduler, _health);
+        using var service = new ContinuousProfilingService(_source, _native, _allocationSource, transport, _scheduler, _health);
 
         var connectionInfo = Mock.Create<IConnectionInfo>();
         Mock.Arrange(() => connectionInfo.HttpProtocol).Returns("https");
@@ -779,7 +781,7 @@ public class ContinuousProfilingServiceTests
     {
         // Dedicated transport mock -- see note above.
         var transport = Mock.Create<IProfilesTransport>();
-        using var service = new ContinuousProfilingService(_source, _native, transport, _scheduler, _health);
+        using var service = new ContinuousProfilingService(_source, _native, _allocationSource, transport, _scheduler, _health);
 
         var connectionInfo = Mock.Create<IConnectionInfo>();
         Mock.Arrange(() => connectionInfo.Host).Returns(string.Empty);
@@ -794,7 +796,7 @@ public class ContinuousProfilingServiceTests
     {
         // A fresh, never-connected instance -- distinct from _service (SetUp already connects it) --
         // so this proves the pre-connect gate, not just "nothing to drain."
-        using var service = new ContinuousProfilingService(_source, _native, _transport, _scheduler, _health);
+        using var service = new ContinuousProfilingService(_source, _native, _allocationSource, _transport, _scheduler, _health);
 
         service.DrainOnce();
 
@@ -828,7 +830,7 @@ public class ContinuousProfilingServiceTests
         // setting _disposed and before unsubscribing. Without the gate this would set _isConnected and the
         // profiles endpoint on an already-disposed service, letting a queued drain ship a profile.
         var transport = Mock.Create<IProfilesTransport>();
-        var service = new ContinuousProfilingService(_source, _native, transport, _scheduler, _health);
+        var service = new ContinuousProfilingService(_source, _native, _allocationSource, transport, _scheduler, _health);
 
         var connectionInfo = Mock.Create<IConnectionInfo>();
         Mock.Arrange(() => connectionInfo.HttpProtocol).Returns("https");
@@ -854,7 +856,7 @@ public class ContinuousProfilingServiceTests
     private (ContinuousProfilingService Service, IProfilesTransport Transport) NewConnectedService()
     {
         var transport = Mock.Create<IProfilesTransport>();
-        var service = new ContinuousProfilingService(_source, _native, transport, _scheduler, _health);
+        var service = new ContinuousProfilingService(_source, _native, _allocationSource, transport, _scheduler, _health);
 
         // DrainOnce reads _configuration (ApplicationNames, ContinuousProfilingIncludeAgentCode) on its
         // way to Send. Without this, the service falls back to the real DefaultConfiguration.Instance

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/NativeContinuousProfilerAllocationSampleSourceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/NativeContinuousProfilerAllocationSampleSourceTests.cs
@@ -1,0 +1,54 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Core.ContinuousProfiling;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.UnitTest.ContinuousProfiling;
+
+[TestFixture]
+public class NativeContinuousProfilerAllocationSampleSourceTests
+{
+    private INativeMethods _nativeMethods;
+    private NativeContinuousProfilerAllocationSampleSource _source;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _nativeMethods = Mock.Create<INativeMethods>();
+        _source = new NativeContinuousProfilerAllocationSampleSource(_nativeMethods);
+    }
+
+    [Test]
+    public void Start_DelegatesToNativeAllocationSamplerStart()
+    {
+        _source.Start(200);
+        Mock.Assert(() => _nativeMethods.AllocationSamplerStart(200), Occurs.Once());
+    }
+
+    [Test]
+    public void Stop_DelegatesToNativeAllocationSamplerStop()
+    {
+        _source.Stop();
+        Mock.Assert(() => _nativeMethods.AllocationSamplerStop(), Occurs.Once());
+    }
+
+    [Test]
+    public void Shutdown_DelegatesToNativeAllocationSamplerShutdown()
+    {
+        _source.Shutdown();
+        Mock.Assert(() => _nativeMethods.AllocationSamplerShutdown(), Occurs.Once());
+    }
+
+    [Test]
+    public void ReadBatch_DelegatesToNativeReadAllocationSamples()
+    {
+        var destination = new byte[1024];
+        Mock.Arrange(() => _nativeMethods.ContinuousProfilerReadAllocationSamples(1024, destination)).Returns(42);
+
+        var result = _source.ReadBatch(destination);
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/OtlpProfileBuilderAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/OtlpProfileBuilderAllocationTests.cs
@@ -1,0 +1,356 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.Core.ContinuousProfiling;
+using NUnit.Framework;
+using OpenTelemetry.Proto.Collector.Profiles.V1Development;
+using OpenTelemetry.Proto.Profiles.V1Development;
+
+namespace NewRelic.Agent.Core.UnitTest.ContinuousProfiling;
+
+/// <summary>
+/// Covers the allocation half of <see cref="OtlpProfileBuilder"/>: the allocated_objects / allocated_space
+/// profiles emitted from <see cref="AllocationSample"/>s into the SAME request/dictionary as the cpu/off_cpu
+/// profiles. The cpu/off_cpu behavior itself is covered by <see cref="OtlpProfileBuilderTests"/>.
+/// </summary>
+[TestFixture]
+public class OtlpProfileBuilderAllocationTests
+{
+    private const long PeriodNanos = 1_000_000L;
+
+    private static AllocationSample Allocation(string typeName, ulong size, long span = 0, params string[] frames) =>
+        new AllocationSample("alloc-thread", 42, 0, 0, span, 1_700_000_000_000L, size, typeName,
+            frames.Length == 0 ? new[] { "MyApp.Widget.Create()" } : frames);
+
+    private static ManagedThreadSample ThreadSample(bool onCpu) =>
+        new ManagedThreadSample("worker", 7, 0, 0, 0, new[] { "MyApp.Work()" }, onCpu);
+
+    private static string TypeNameOf(ExportProfilesServiceRequest req, Profile p) =>
+        req.Dictionary.StringTable[p.SampleType.TypeStrindex];
+
+    private static string UnitOf(ExportProfilesServiceRequest req, Profile p) =>
+        req.Dictionary.StringTable[p.SampleType.UnitStrindex];
+
+    private static Profile ProfileOfType(ExportProfilesServiceRequest req, string sampleTypeName) =>
+        req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles.SingleOrDefault(p => TypeNameOf(req, p) == sampleTypeName);
+
+    private static Dictionary<string, OpenTelemetry.Proto.Common.V1.AnyValue> AttributesOf(ExportProfilesServiceRequest req, Sample s) =>
+        s.AttributeIndices
+            .Select(i => req.Dictionary.AttributeTable[i])
+            .ToDictionary(kv => req.Dictionary.StringTable[kv.KeyStrindex], kv => kv.Value);
+
+    [Test]
+    public void Build_with_thread_and_allocation_samples_emits_all_four_profiles_in_one_request()
+    {
+        var req = OtlpProfileBuilder.Build(
+            new[] { ThreadSample(onCpu: true), ThreadSample(onCpu: false) },
+            startUnixNano: 1000, durationNano: 5000, serviceName: "svc", periodNanos: PeriodNanos,
+            includeAgentCode: true,
+            allocationSamples: new[] { Allocation("MyApp.Widget", 65536UL) });
+
+        // One request, one resource, one scope, one shared dictionary -- four profiles inside it.
+        var profiles = req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(profiles.Select(p => TypeNameOf(req, p)),
+                Is.EqualTo(new[] { "off_cpu", "cpu", "allocated_objects", "allocated_space" }));
+            Assert.That(UnitOf(req, profiles[2]), Is.EqualTo("count"));
+            Assert.That(UnitOf(req, profiles[3]), Is.EqualTo("bytes"));
+            Assert.That(req.Dictionary, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void Build_allocation_and_thread_samples_share_one_interned_stack()
+    {
+        // An allocation sample whose stack is identical to a thread sample's must NOT be re-interned: both
+        // sample kinds intern through the same string/function/location/stack caches.
+        var req = OtlpProfileBuilder.Build(
+            new[] { ThreadSample(onCpu: true) },
+            0, 0, "svc", PeriodNanos, includeAgentCode: true,
+            allocationSamples: new[] { Allocation("MyApp.Widget", 8UL, 0, "MyApp.Work()") });
+
+        var dict = req.Dictionary;
+        Assert.Multiple(() =>
+        {
+            // index 0 zero value + the single shared "MyApp.Work()" entry.
+            Assert.That(dict.FunctionTable, Has.Count.EqualTo(2));
+            Assert.That(dict.LocationTable, Has.Count.EqualTo(2));
+            Assert.That(dict.StackTable, Has.Count.EqualTo(2));
+            // Both sample kinds point at the same stack index.
+            Assert.That(ProfileOfType(req, "cpu").Samples.Single().StackIndex,
+                Is.EqualTo(ProfileOfType(req, "allocated_objects").Samples.Single().StackIndex));
+        });
+    }
+
+    [Test]
+    public void Build_allocated_objects_values_are_all_one_and_allocated_space_values_are_the_allocated_sizes()
+    {
+        var allocations = new[]
+        {
+            Allocation("MyApp.A", 16UL, 0, "MyApp.A.Create()"),
+            Allocation("MyApp.B", 1_048_576UL, 0, "MyApp.B.Create()"),
+            Allocation("MyApp.C", 24UL, 0, "MyApp.C.Create()"),
+        };
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: allocations);
+
+        var objects = ProfileOfType(req, "allocated_objects");
+        var space = ProfileOfType(req, "allocated_space");
+
+        Assert.Multiple(() =>
+        {
+            // Not a partition: every allocation sample appears in BOTH profiles.
+            Assert.That(objects.Samples, Has.Count.EqualTo(3));
+            Assert.That(space.Samples, Has.Count.EqualTo(3));
+            Assert.That(objects.Samples.Select(s => s.Values.Single()), Is.EqualTo(new[] { 1L, 1L, 1L }));
+            Assert.That(space.Samples.Select(s => s.Values.Single()), Is.EqualTo(new[] { 16L, 1_048_576L, 24L }));
+            // Same order, same stacks -- the two profiles are two measurements of the same event set.
+            Assert.That(objects.Samples.Select(s => s.StackIndex), Is.EqualTo(space.Samples.Select(s => s.StackIndex)));
+        });
+    }
+
+    [Test]
+    public void Build_allocation_profiles_emitted_without_a_period_because_allocation_is_event_driven()
+    {
+        // Allocation sampling fires on AllocationTick, not on a timer -- there is no period to report, and the
+        // allocation profiles must not be gated on periodNanos the way the time-valued cpu/off_cpu ones are.
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 1234, 5678, "svc", periodNanos: 0,
+            includeAgentCode: true, allocationSamples: new[] { Allocation("MyApp.Widget", 8UL) });
+
+        var profiles = req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles;
+        Assert.Multiple(() =>
+        {
+            Assert.That(profiles.Select(p => TypeNameOf(req, p)), Is.EqualTo(new[] { "allocated_objects", "allocated_space" }));
+            foreach (var p in profiles)
+            {
+                Assert.That(p.PeriodType, Is.Null, "allocation profiles must not carry a period_type");
+                Assert.That(p.Period, Is.EqualTo(0L), "allocation profiles must not carry a period");
+                Assert.That(p.TimeUnixNano, Is.EqualTo(1234UL));
+                Assert.That(p.DurationNano, Is.EqualTo(5678UL));
+            }
+        });
+    }
+
+    [Test]
+    public void Build_allocation_sample_link_round_trips_the_trace_and_span_ids()
+    {
+        var traceHigh = 0x1122334455667788L;
+        var traceLow = 0x0102030405060708L;
+        var spanId = unchecked((long)0xAABBCCDDEEFF0011UL);
+
+        var allocation = new AllocationSample("alloc-thread", 42, traceHigh, traceLow, spanId,
+            1_700_000_000_000L, 4096UL, "MyApp.Widget", new[] { "MyApp.Widget.Create()" });
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { allocation });
+
+        var objectsSample = ProfileOfType(req, "allocated_objects").Samples.Single();
+        var spaceSample = ProfileOfType(req, "allocated_space").Samples.Single();
+
+        var expectedTrace = new byte[]
+        {
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+        };
+        var expectedSpan = new byte[] { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(objectsSample.LinkIndex, Is.Not.EqualTo(0), "trace/span context is required for allocation samples");
+            Assert.That(spaceSample.LinkIndex, Is.EqualTo(objectsSample.LinkIndex), "both profiles reference the same interned link");
+
+            var link = req.Dictionary.LinkTable[objectsSample.LinkIndex];
+            Assert.That(link.TraceId.ToByteArray(), Is.EqualTo(expectedTrace));
+            Assert.That(link.SpanId.ToByteArray(), Is.EqualTo(expectedSpan));
+
+            // index 0 zero-link sentinel + exactly one real link (interned once for both profiles).
+            Assert.That(req.Dictionary.LinkTable, Has.Count.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Build_allocation_sample_without_trace_context_gets_the_zero_link_sentinel()
+    {
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { Allocation("MyApp.Widget", 8UL) });
+
+        Assert.That(ProfileOfType(req, "allocated_objects").Samples.Single().LinkIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Build_allocation_sample_carries_type_name_thread_id_and_thread_name_attributes()
+    {
+        var allocation = new AllocationSample("alloc-worker-3", 4242, 0, 0, 0, 1_700_000_000_000L, 2048UL,
+            "MyApp.Widget", new[] { "MyApp.Widget.Create()" });
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { allocation });
+
+        foreach (var sampleTypeName in new[] { "allocated_objects", "allocated_space" })
+        {
+            var attrs = AttributesOf(req, ProfileOfType(req, sampleTypeName).Samples.Single());
+            Assert.Multiple(() =>
+            {
+                Assert.That(attrs["thread.id"].IntValue, Is.EqualTo(4242L), sampleTypeName);
+                Assert.That(attrs["thread.name"].StringValue, Is.EqualTo("alloc-worker-3"), sampleTypeName);
+                Assert.That(attrs["type.name"].StringValue, Is.EqualTo("MyApp.Widget"), sampleTypeName);
+            });
+        }
+    }
+
+    [Test]
+    public void Build_allocation_sample_with_null_type_name_and_thread_name_interns_empty_strings()
+    {
+        var allocation = new AllocationSample(null, 1, 0, 0, 0, 0, 8UL, null, new[] { "MyApp.Widget.Create()" });
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { allocation });
+
+        var attrs = AttributesOf(req, ProfileOfType(req, "allocated_objects").Samples.Single());
+        Assert.Multiple(() =>
+        {
+            Assert.That(attrs["thread.name"].StringValue, Is.EqualTo(string.Empty));
+            Assert.That(attrs["type.name"].StringValue, Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public void Build_repeated_allocations_of_the_same_shape_reuse_interned_attributes()
+    {
+        // Two allocations of the same type on the same thread with the same stack: attributes/stack interned once.
+        var allocations = new[] { Allocation("MyApp.Widget", 16UL), Allocation("MyApp.Widget", 32UL) };
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: allocations);
+
+        var objects = ProfileOfType(req, "allocated_objects");
+        Assert.Multiple(() =>
+        {
+            Assert.That(objects.Samples, Has.Count.EqualTo(2));
+            Assert.That(objects.Samples[0].AttributeIndices, Is.EqualTo(objects.Samples[1].AttributeIndices));
+            Assert.That(req.Dictionary.StackTable, Has.Count.EqualTo(2)); // zero value + one shared stack
+            // zero value + profile.frame.type + thread.id + thread.name + type.name
+            Assert.That(req.Dictionary.AttributeTable, Has.Count.EqualTo(5));
+            // Values still differ per sample in allocated_space.
+            Assert.That(ProfileOfType(req, "allocated_space").Samples.Select(s => s.Values.Single()),
+                Is.EqualTo(new[] { 16L, 32L }));
+        });
+    }
+
+    [Test]
+    public void Build_saturates_an_allocated_size_larger_than_long_max_instead_of_wrapping_negative()
+    {
+        // Sample.values is int64; AllocatedSize is uint64. No real allocation is this large, but a
+        // garbage/misparsed size must not be emitted as a negative byte count.
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { Allocation("MyApp.Widget", ulong.MaxValue) });
+
+        Assert.That(ProfileOfType(req, "allocated_space").Samples.Single().Values.Single(), Is.EqualTo(long.MaxValue));
+    }
+
+    [Test]
+    public void Build_with_null_allocation_samples_emits_only_cpu_profiles()
+    {
+        var req = OtlpProfileBuilder.Build(new[] { ThreadSample(onCpu: true) }, 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: null);
+
+        Assert.That(req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles.Select(p => TypeNameOf(req, p)),
+            Is.EqualTo(new[] { "cpu" }));
+    }
+
+    [Test]
+    public void Build_with_empty_allocation_samples_emits_no_allocation_profiles()
+    {
+        // An empty Profile is rejected by the OTLP profiles ingest ("no_samples"), so nothing must be emitted.
+        var req = OtlpProfileBuilder.Build(new[] { ThreadSample(onCpu: true) }, 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new List<AllocationSample>());
+
+        Assert.That(req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles.Select(p => TypeNameOf(req, p)),
+            Is.EqualTo(new[] { "cpu" }));
+    }
+
+    [Test]
+    public void Build_with_only_allocation_samples_and_no_thread_samples_emits_just_the_two_allocation_profiles()
+    {
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: false, allocationSamples: new[] { Allocation("MyApp.Widget", 8UL) });
+
+        Assert.That(req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles.Select(p => TypeNameOf(req, p)),
+            Is.EqualTo(new[] { "allocated_objects", "allocated_space" }));
+    }
+
+    [Test]
+    public void Build_skips_an_allocation_sample_with_null_frames_rather_than_throwing()
+    {
+        // Defensive: a malformed sample must not take the whole drain's payload (thread samples included) down
+        // with an exception. Only the malformed sample is dropped.
+        var allocations = new[]
+        {
+            new AllocationSample("t", 1, 0, 0, 0, 0, 8UL, "MyApp.Widget", null),
+            Allocation("MyApp.Widget", 16UL),
+        };
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: allocations);
+
+        Assert.That(ProfileOfType(req, "allocated_objects").Samples, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Build_emits_no_allocation_profiles_when_every_allocation_sample_is_skipped()
+    {
+        // All inputs malformed -> nothing resolvable -> no empty Profile may be emitted.
+        var allocations = new[] { new AllocationSample("t", 1, 0, 0, 0, 0, 8UL, "MyApp.Widget", null) };
+
+        var req = OtlpProfileBuilder.Build(new[] { ThreadSample(onCpu: true) }, 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: allocations);
+
+        Assert.That(req.ResourceProfiles.Single().ScopeProfiles.Single().Profiles.Select(p => TypeNameOf(req, p)),
+            Is.EqualTo(new[] { "cpu" }));
+    }
+
+    [Test]
+    public void Build_allocation_frames_are_leaf_first_and_tagged_with_frame_type()
+    {
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true,
+            allocationSamples: new[] { Allocation("MyApp.Widget", 8UL, 0, "Leaf()", "Middle()", "Native.Function Call") });
+
+        var dict = req.Dictionary;
+        var stack = dict.StackTable[ProfileOfType(req, "allocated_objects").Samples.Single().StackIndex];
+        var frameNames = stack.LocationIndices
+            .Select(li => dict.LocationTable[li])
+            .Select(loc => dict.StringTable[dict.FunctionTable[loc.Lines.Single().FunctionIndex].NameStrindex])
+            .ToArray();
+
+        string FrameTypeAt(int locationIndex) => dict.LocationTable[locationIndex].AttributeIndices
+            .Select(ai => dict.AttributeTable[ai])
+            .Where(kv => dict.StringTable[kv.KeyStrindex] == "profile.frame.type")
+            .Select(kv => kv.Value.StringValue)
+            .SingleOrDefault();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(frameNames, Is.EqualTo(new[] { "Leaf()", "Middle()", "Native.Function Call" }));
+            Assert.That(FrameTypeAt(stack.LocationIndices[0]), Is.EqualTo("dotnet"));
+            Assert.That(FrameTypeAt(stack.LocationIndices[2]), Is.EqualTo("native"));
+        });
+    }
+
+    [Test]
+    public void Build_allocation_samples_are_not_subject_to_the_agent_code_filter()
+    {
+        // includeAgentCode governs the thread sampler's own-thread noise. Allocation samples are attributed to
+        // the allocating call site and are reported as-is; this documents that intent.
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: false,
+            allocationSamples: new[] { Allocation("System.Byte[]", 8UL, 0, "NewRelic.Agent.Core.Foo.Bar()") });
+
+        Assert.That(ProfileOfType(req, "allocated_objects").Samples, Has.Count.EqualTo(1));
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/OtlpProfileBuilderAllocationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/OtlpProfileBuilderAllocationTests.cs
@@ -343,6 +343,92 @@ public class OtlpProfileBuilderAllocationTests
     }
 
     [Test]
+    public void Build_allocation_sample_carries_its_own_capture_timestamp_in_both_profiles()
+    {
+        // Sample.timestamps_unix_nano must round-trip AllocationSample.TimestampMillis (ms -> ns), because the
+        // profile-level [time_unix_nano, +duration_nano) window belongs to the DRAIN: one drain can carry a
+        // backlog batched across many intervals (pre-connect window, send backoff), and without a per-sample
+        // time every one of those samples would be attributed to the moment it was drained.
+        var allocation = new AllocationSample("alloc-thread", 42, 0, 0, 0, 1_700_000_000_123L, 4096UL,
+            "MyApp.Widget", new[] { "MyApp.Widget.Create()" });
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), startUnixNano: 1_800_000_000_000_000_000L,
+            durationNano: 10_000_000_000L, serviceName: "svc", periodNanos: PeriodNanos, includeAgentCode: true,
+            allocationSamples: new[] { allocation });
+
+        Assert.Multiple(() =>
+        {
+            foreach (var sampleTypeName in new[] { "allocated_objects", "allocated_space" })
+            {
+                var sample = ProfileOfType(req, sampleTypeName).Samples.Single();
+                // One timestamp per value: the proto requires equal element counts when both are populated.
+                Assert.That(sample.TimestampsUnixNano, Is.EqualTo(new[] { 1_700_000_000_123_000_000UL }), sampleTypeName);
+                Assert.That(sample.TimestampsUnixNano, Has.Count.EqualTo(sample.Values.Count), sampleTypeName);
+            }
+        });
+    }
+
+    [Test]
+    public void Build_allocation_samples_each_keep_their_own_timestamp_even_when_they_share_a_stack()
+    {
+        // Two samples of the same shape (identical interned stack/attributes) taken at different times: the
+        // timestamp is per-observation data, so it must NOT be collapsed the way the dictionary entries are.
+        var frames = new[] { "MyApp.Widget.Create()" };
+        var allocations = new[]
+        {
+            new AllocationSample("t", 1, 0, 0, 0, 1_700_000_000_000L, 16UL, "MyApp.Widget", frames),
+            new AllocationSample("t", 1, 0, 0, 0, 1_700_000_005_000L, 32UL, "MyApp.Widget", frames),
+        };
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: allocations);
+
+        Assert.That(ProfileOfType(req, "allocated_space").Samples.Select(s => s.TimestampsUnixNano.Single()),
+            Is.EqualTo(new[] { 1_700_000_000_000_000_000UL, 1_700_000_005_000_000_000UL }));
+    }
+
+    [TestCase(0L)]
+    [TestCase(-1L)]
+    public void Build_allocation_sample_with_a_non_positive_timestamp_emits_no_per_sample_timestamp(long timestampMillis)
+    {
+        // Native stamps every sample off the clock, so a non-positive value is malformed/unset. Emitting it
+        // would place the sample at the epoch (0) or, through the unsigned cast, in the year 584 (negative) --
+        // both worse than leaving timestamps_unix_nano empty and letting the consumer fall back to the
+        // profile window. Legal because `values` is always populated.
+        var allocation = new AllocationSample("t", 1, 0, 0, 0, timestampMillis, 8UL, "MyApp.Widget",
+            new[] { "MyApp.Widget.Create()" });
+
+        var req = OtlpProfileBuilder.Build(new List<ManagedThreadSample>(), 0, 0, "svc", PeriodNanos,
+            includeAgentCode: true, allocationSamples: new[] { allocation });
+
+        Assert.Multiple(() =>
+        {
+            foreach (var sampleTypeName in new[] { "allocated_objects", "allocated_space" })
+            {
+                var sample = ProfileOfType(req, sampleTypeName).Samples.Single();
+                Assert.That(sample.TimestampsUnixNano, Is.Empty, sampleTypeName);
+                Assert.That(sample.Values, Has.Count.EqualTo(1), sampleTypeName);
+            }
+        });
+    }
+
+    [Test]
+    public void Build_thread_samples_carry_no_per_sample_timestamps()
+    {
+        // Documents the scope boundary: only allocation samples have a capture time to report. The cpu/off_cpu
+        // samples have none, so their Samples stay timestamp-free and are read against the profile window.
+        var req = OtlpProfileBuilder.Build(new[] { ThreadSample(onCpu: true), ThreadSample(onCpu: false) },
+            1000, 5000, "svc", PeriodNanos, includeAgentCode: true,
+            allocationSamples: new[] { Allocation("MyApp.Widget", 8UL) });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ProfileOfType(req, "cpu").Samples.Single().TimestampsUnixNano, Is.Empty);
+            Assert.That(ProfileOfType(req, "off_cpu").Samples.Single().TimestampsUnixNano, Is.Empty);
+        });
+    }
+
+    [Test]
     public void Build_allocation_samples_are_not_subject_to_the_agent_code_filter()
     {
         // includeAgentCode governs the thread sampler's own-thread noise. Allocation samples are attributed to

--- a/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ProfilesTransportTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/ContinuousProfiling/ProfilesTransportTests.cs
@@ -260,4 +260,153 @@ public class ProfilesTransportTests
         request.ResourceProfiles.Add(resourceProfiles);
         return request;
     }
+
+    #region payload ceiling and diagnostic-dump bounding
+
+    // A request whose serialized size exceeds MaxPayloadBytes, built from one long string-table entry so the
+    // size comes from real payload content rather than a fabricated byte array.
+    private static ExportProfilesServiceRequest BuildOversizedRequest()
+    {
+        var request = BuildNonEmptyRequest();
+        request.Dictionary.StringTable.Add(new string('x', ProfilesTransport.MaxPayloadBytes + 1024));
+        return request;
+    }
+
+    private static ExportProfilesServiceRequest BuildRequestWithSamples(int sampleCount)
+    {
+        var request = BuildNonEmptyRequest();
+        var profile = request.ResourceProfiles[0].ScopeProfiles[0].Profiles[0];
+        while (profile.Samples.Count < sampleCount)
+        {
+            var sample = new Sample { StackIndex = 1 };
+            sample.Values.Add(profile.Samples.Count);
+            profile.Samples.Add(sample);
+        }
+        return request;
+    }
+
+    [Test]
+    public void Send_drops_a_payload_that_exceeds_the_size_ceiling_instead_of_posting_it()
+    {
+        // Removing the allocation-sample delivery ceiling made a drain's payload scale with the configured
+        // budget, so this path needed an upper bound of its own rather than trusting the producer.
+        var dispatched = false;
+        var health = Mock.Create<IAgentHealthReporter>();
+        var transport = new ProfilesTransport((bytes, endpoint) => { dispatched = true; return new ProfilesSendResult(true, 200, string.Empty); }, "http://unused", health);
+
+        var accepted = transport.Send(BuildOversizedRequest());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dispatched, Is.False, "an oversized payload must not be POSTed at all");
+            Assert.That(accepted, Is.False, "reported as a failed send, which is what feeds the service's backoff");
+        });
+        Mock.Assert(() => health.ReportSupportabilityCountMetric("Supportability/DotNET/ContinuousProfiling/PayloadTooLarge", 1), Occurs.Once());
+        Mock.Assert(() => health.ReportSupportabilityDataUsage(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<long>(), Arg.IsAny<long>()), Occurs.Never(),
+            "nothing was sent, so no data usage was incurred");
+    }
+
+    // A request that serializes to EXACTLY `targetBytes`, by padding a string-table entry and correcting for
+    // protobuf's own length-prefix growth until the total lands on the target. Needed for a real boundary
+    // test: a payload merely "under" the ceiling would pass just as happily against a `>=` comparison.
+    private static ExportProfilesServiceRequest BuildRequestOfExactSize(int targetBytes)
+    {
+        var padLength = targetBytes;
+        for (var attempt = 0; attempt < 12; attempt++)
+        {
+            var request = BuildNonEmptyRequest();
+            request.Dictionary.StringTable.Add(new string('x', padLength));
+            var size = request.ToByteArray().Length;
+
+            if (size == targetBytes)
+                return request;
+
+            padLength += targetBytes - size;
+            if (padLength < 0)
+                break;
+        }
+
+        Assert.Fail($"could not build a request of exactly {targetBytes} bytes");
+        return null;
+    }
+
+    [Test]
+    public void Send_posts_a_payload_of_exactly_the_size_ceiling()
+    {
+        // The comparison is strictly-greater, so a payload landing exactly ON the ceiling must still be
+        // POSTed. Asserted at the exact boundary rather than somewhere below it, so a `>=` regression fails
+        // here instead of silently costing one drain per occurrence in the field.
+        var request = BuildRequestOfExactSize(ProfilesTransport.MaxPayloadBytes);
+        var dispatchedBytes = 0;
+        var transport = new ProfilesTransport((bytes, endpoint) => { dispatchedBytes = bytes.Length; return new ProfilesSendResult(true, 200, string.Empty); }, "http://unused", null);
+
+        Assert.That(transport.Send(request), Is.True);
+        Assert.That(dispatchedBytes, Is.EqualTo(ProfilesTransport.MaxPayloadBytes));
+    }
+
+    [Test]
+    public void Send_drops_a_payload_one_byte_over_the_size_ceiling()
+    {
+        // The other side of the same boundary, so the pair pins the comparison exactly.
+        var request = BuildRequestOfExactSize(ProfilesTransport.MaxPayloadBytes + 1);
+        var dispatched = false;
+        var transport = new ProfilesTransport((bytes, endpoint) => { dispatched = true; return new ProfilesSendResult(true, 200, string.Empty); }, "http://unused", null);
+
+        Assert.That(transport.Send(request), Is.False);
+        Assert.That(dispatched, Is.False);
+    }
+
+    [Test]
+    public void TruncateSamplesForDiagnostics_caps_samples_per_profile_and_reports_what_it_omitted()
+    {
+        var request = BuildRequestWithSamples(40);
+
+        var truncated = ProfilesTransport.TruncateSamplesForDiagnostics(request, 25, out var omitted);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(omitted, Is.EqualTo(15));
+            Assert.That(truncated.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Samples, Has.Count.EqualTo(25));
+            // The REAL request must be untouched -- this is a diagnostic-only copy.
+            Assert.That(request.ResourceProfiles[0].ScopeProfiles[0].Profiles[0].Samples, Has.Count.EqualTo(40));
+            // Everything else survives, so the dump stays a valid document with all frame names and links.
+            Assert.That(truncated.Dictionary.StringTable, Is.EqualTo(request.Dictionary.StringTable));
+        });
+    }
+
+    [Test]
+    public void TruncateSamplesForDiagnostics_returns_the_same_instance_when_nothing_needs_truncating()
+    {
+        var request = BuildRequestWithSamples(5);
+
+        var truncated = ProfilesTransport.TruncateSamplesForDiagnostics(request, 25, out var omitted);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(omitted, Is.Zero);
+            Assert.That(truncated, Is.SameAs(request), "the common case must not pay for a clone");
+        });
+    }
+
+    [Test]
+    public void TruncateSamplesForDiagnostics_tolerates_a_null_request()
+    {
+        Assert.That(ProfilesTransport.TruncateSamplesForDiagnostics(null, 25, out var omitted), Is.Null);
+        Assert.That(omitted, Is.Zero);
+    }
+
+    [Test]
+    public void Send_still_posts_every_sample_when_the_diagnostic_dump_is_capped()
+    {
+        // The cap is a LOGGING policy, never a wire policy: the POST must carry the whole payload.
+        byte[] dispatchedBytes = null;
+        var request = BuildRequestWithSamples(ProfilesTransport.MaxDiagnosticSamplesPerProfile * 3);
+        var transport = new ProfilesTransport((bytes, endpoint) => { dispatchedBytes = bytes; return new ProfilesSendResult(true, 200, string.Empty); }, "http://unused", null);
+
+        transport.Send(request);
+
+        Assert.That(dispatchedBytes, Is.EqualTo(request.ToByteArray()));
+    }
+
+    #endregion
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -371,7 +371,9 @@ public class AgentSettingsTests
                                         "hybrid_http_context_storage.enabled":false,
                                         "continuous_profiling.enabled":true,
                                         "continuous_profiling.sampling_interval_ms":30000,
-                                        "continuous_profiling.include_agent_code":true
+                                        "continuous_profiling.include_agent_code":true,
+                                        "continuous_profiling.allocation.enabled":true,
+                                        "continuous_profiling.allocation.max_samples_per_minute":500
                                     }
                                     """;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
@@ -442,7 +442,9 @@ public class ConnectModelTests
                                                     "hybrid_http_context_storage.enabled":false,
                                                     "continuous_profiling.enabled":true,
                                                     "continuous_profiling.sampling_interval_ms":30000,
-                                                    "continuous_profiling.include_agent_code":true
+                                                    "continuous_profiling.include_agent_code":true,
+                                                    "continuous_profiling.allocation.enabled":true,
+                                                    "continuous_profiling.allocation.max_samples_per_minute":500
                                                 },
                                                 "metadata": {
                                                     "hello": "there"

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -549,4 +549,6 @@ public class ExhaustiveTestConfiguration : IConfiguration
     public bool ContinuousProfilingEnabled => true;
     public int ContinuousProfilingSamplingIntervalMs => 30000;
     public bool ContinuousProfilingIncludeAgentCode => true;
+    public bool ContinuousProfilingAllocationEnabled => true;
+    public int ContinuousProfilingAllocationMaxSamplesPerMinute => 500;
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/NativeMethodsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/NativeMethodsTests.cs
@@ -30,6 +30,10 @@ public class NativeMethodsTests
     [TestCase("ContinuousProfilerSetAgentWork", new Type[0], typeof(void))]
     [TestCase("ContinuousProfilerResetAgentWork", new Type[0], typeof(void))]
     [TestCase("ContinuousProfilerShutdown", new Type[0], typeof(void))]
+    [TestCase("ContinuousProfilerReadAllocationSamples", new[] { typeof(int), typeof(byte[]) }, typeof(int))]
+    [TestCase("AllocationSamplerStart", new[] { typeof(int) }, typeof(void))]
+    [TestCase("AllocationSamplerStop", new Type[0], typeof(void))]
+    [TestCase("AllocationSamplerShutdown", new Type[0], typeof(void))]
     public void INativeMethods_DeclaresExpectedContinuousProfilerMember(string methodName, Type[] parameterTypes, Type returnType)
     {
         var method = typeof(INativeMethods).GetMethod(methodName, parameterTypes);
@@ -42,12 +46,13 @@ public class NativeMethodsTests
     [TestCase(typeof(WindowsNativeMethods))]
     public void NativeMethodsImplementation_ImplementsAllContinuousProfilerMembers(Type implementationType)
     {
-        var continuousProfilerMethods = typeof(INativeMethods).GetMethods()
-            .Where(m => m.Name.StartsWith("ContinuousProfiler", StringComparison.Ordinal));
+        var profilingMethods = typeof(INativeMethods).GetMethods()
+            .Where(m => m.Name.StartsWith("ContinuousProfiler", StringComparison.Ordinal)
+                || m.Name.StartsWith("AllocationSampler", StringComparison.Ordinal));
 
-        Assert.That(continuousProfilerMethods, Is.Not.Empty);
+        Assert.That(profilingMethods, Is.Not.Empty);
 
-        foreach (var interfaceMethod in continuousProfilerMethods)
+        foreach (var interfaceMethod in profilingMethods)
         {
             var parameterTypes = interfaceMethod.GetParameters().Select(p => p.ParameterType).ToArray();
             var implementedMethod = implementationType.GetMethod(interfaceMethod.Name, parameterTypes);


### PR DESCRIPTION
# Continuous Profiling: Allocation Sampling (POC)

**Status: Draft / POC - for review and comment.** Off by default. Built on top of #3717 (also still draft/unmerged) - this branch adds allocation sampling as a second, independent sample stream alongside that PR's CPU/thread sampler.

## Summary

Adds allocation-rate sampling to continuous profiling: a native EventPipe-driven sampler that hooks the CLR's own `AllocationTick` event (the same signal `dotnet-counters`/`dotnet-trace` use) on the allocating thread itself, feeding the same managed drain/OTLP pipeline #3717 built for CPU sampling. Emits two more OTLP profile types - `allocated_objects` (count) and `allocated_space` (bytes) - into the same export request the CPU sampler already builds. Off by default, independently toggleable from CPU sampling (own config flag, own `heap` agent-command token).

Where the CPU sampler is a timer that periodically suspends the runtime and snapshots every thread, the allocation sampler is event-driven and needs no suspend at all - a thread walking its own stack doesn't need to freeze itself.

## Prerequisite: extending the native profiler's CLR-callback interface

Before any of this could be built, the profiler's vendored CLR headers and callback interface had to be extended - this is a real dependency change worth calling out clearly, not an incidental detail.

The vendored `corprof.h` was frozen at `dotnet/coreclr`'s `release/3.1` final commit (2023-01-20, the day that repo archived) - the .NET Core 3.1-era CLR profiling surface. That predates `ICorProfilerInfo12` and the EventPipe profiling API entirely. Allocation sampling needs `ICorProfilerInfo12::EventPipeStartSession` to open the `AllocationTick` subscription and `ICorProfilerCallback10::EventPipeEventDelivered` to receive the events - neither exists in the old header, so the vendor bump was a hard prerequisite, not a drive-by dependency refresh.

Bumped to `dotnet/runtime` tag `v5.0.17` specifically (whole-file copy per the vendoring README's own rule, blob SHA verified against upstream) - chosen because it's the *last* release whose `corprof.h` stops exactly at `ICorProfilerCallback10`/`ICorProfilerInfo12`, so the smallest whole-file copy that has the required surface also happens to avoid dragging in later interface versions (`ICorProfilerCallback11`, `ICorProfilerInfo13`+) nothing here uses.

`CorProfilerCallbackImpl` was extended from implementing `ICorProfilerCallback4` to `ICorProfilerCallback10`. Every new pure-virtual method across CB5-CB10 is a `return S_OK;` no-op except `EventPipeEventDelivered` (hot-path-safe by construction - one atomic increment, a one-time log gated on first delivery, no allocation/lock/per-event logging, since it runs on the thread that raised the event inside the runtime's own EventPipe dispatch). This is the *same compiled class* used to attach to both .NET Framework and CoreCLR processes, so the extension applies to both runtimes - verified harmless on .NET Framework via the host integration suite (green both before and after). The one real behavioral side effect on both runtimes: CB8's `DynamicMethodJITCompilationStarted/Finished` now fires for dynamic (`Reflection.Emit`) methods instead of the interface not having that vtable slot at all - the agent already sets `COR_PRF_MONITOR_JIT_COMPILATION`, and the CLR routes no-metadata JIT events to these callbacks *instead of* `JITCompilationStarted`, so existing instrumentation traffic is unchanged; the new callbacks are no-ops.

The event mask gains `COR_PRF_HIGH_MONITOR_EVENT_PIPE` with a non-fatal fallback: if setting it fails, retry without it and mark the allocation sampler unavailable rather than failing agent attach entirely for customers not using this feature.

## Architecture

**Native (profiler):** `AllocationSampler` - no worker thread of its own, driven entirely by `EventPipeEventDelivered` on the allocating thread. Per tick: check the sub-sampler's rate limit, parse the `AllocationTick` v4 ETW-manifest payload (ground-truthed from OTel's own implementation, not guessed - `AllocationAmount`/`AllocationKind`/`InstanceId`/`AllocationAmount64`/`TypeId`/`TypeName`/`HeapIndex`/`Address`/`AllocatedSize`, pointer-sized fields via `sizeof(void*)` so it's correct on x86 too), try-lock against the CPU sampler's suspend mutex (never blocks the allocating thread on a collision), read this thread's own trace/span context (safer than the CPU sampler's cross-thread read - no concurrent writer to race, no seqlock handling needed), `DoStackSnapshot` on the current thread with no `SuspendRuntime` call, then encode.

**Delivery** batches multiple samples into a persistent pending batch under back-pressure (both queue slots full) instead of dropping them, flushing eagerly whenever a slot frees to keep latency low in the common case. No new wire-format opcode range needed beyond the one reserved byte (`0x08`, `AllocationSample`) - the existing decoder already looped over any number of same-batch records. Delivery still rides the *same drain timer* the CPU sampler uses; the managed side loops the native read until empty (bounded) and folds every batch's samples into the same drain's OTLP export.

**Rate limiting** is a native cycle-based sub-sampler (ported from OTel's design, not reinvented) - tracks how many ticks the previous cycle saw and rolls odds against the current cycle's remaining budget, since true reservoir sampling needs to know the total count in advance and this doesn't have it.

**Lifecycle - `Stop()`/`Start()` are cheap; `Shutdown()` is deliberately terminal, and that's what makes them cheap.** `Stop()`/`Start()` never touch the CLR EventPipe session - they just flip a flag and reset the sub-sampler. `EventPipeStartSession`/`EventPipeStopSession` each run *at most once per process, ever*: `Start()` opens the session only the first time (later calls just re-arm it), and `Shutdown()` - the only thing that ever closes it - sets a permanent latch that refuses every future `Start()`. That's not a restriction that costs anything in practice, because nothing in real pause/resume usage (config toggle, agent command, send-failure backoff) ever calls `Shutdown()` in the first place. What it buys: the one CLR API this feature has to trust with a documented shutdown-hang precedent elsewhere in this agent (see below) gets exercised at most once per process instead of once per enable/disable cycle - collapsing the risk surface rather than accepting it repeatedly.

**Managed:** a new `AllocationSample` model + `IAllocationSampleSource`/`NativeContinuousProfilerAllocationSampleSource` adapter (mirrors the existing `ISampleSource` shape, extended with `Start`/`Stop`/`Shutdown` since a plain `ReadBatch` can't express lifecycle). `OtlpProfileBuilder` adds two more `Profile` messages - `allocated_objects`:`count` and `allocated_space`:`bytes` - to the *same* export request the CPU sampler already populates, sharing its dictionary; every allocation sample carries a required trace/span link (not optional/filtered the way CPU's on/off-CPU split is) plus `type.name`/`thread.id`/`thread.name` attributes. `ContinuousProfilingService` gained a second, independently-toggleable lifecycle sharing the one drain timer and one send-failure backoff round with the CPU sampler.

## Was this checked against the .NET runtime's own EventPipe history?

Yes, deliberately, before writing any real code. This agent already has a *closed-but-never-fixed* .NET runtime bug on a related surface: the existing GC-metrics sampler uses a managed `EventListener` on the same `Microsoft-Windows-DotNETRuntime` provider, and tearing it down at shutdown can deadlock against the finalizer thread (three prior support tickets, all closed by disabling the feature - the eventual fix, in a later agent version, was to stop using EventPipe for that feature entirely). Before building on the *native* `EventPipeStartSession`/`EventPipeStopSession` API - a different surface, same underlying CLR subsystem - we ran a standalone spike: 61 real open/close cycles across Windows x64 and Linux x64, including a variant specifically reproducing the managed bug's finalizer-thread-contention mechanism. Zero hangs, zero timeouts. That result is *why* the shutdown path uses a bounded timeout-and-abandon discipline rather than a bare blocking call, and *why* `Shutdown()` is terminal (see above) - the verdict covers one open/close pair tested 61 times, not "safe to repeat arbitrarily."

## Testing

- **Native:** new `ContinuousProfilerTest` CppUnitTest project (first native unit tests for anything under `ContinuousProfiler/`) - the rate limiter's cycle-rollover behavior and the batch accumulator's frame-interning correctness and back-pressure/flush logic, including a regression test that actually distinguishes "batched correctly" from "silently re-interned every frame" (an earlier version of this test would have passed either way).
- **Managed (Core):** wire-format decode, `OtlpProfileBuilder` allocation-profile assembly (both profiles in one shared-dictionary request, trace/span link round-trip, attribute correctness), config surface, and `ContinuousProfilingService`'s independent-lifecycle wiring - including the cross-sampler interactions a shared send-failure backoff round creates once two independently-toggleable samplers exist (a start that clears the backoff gate now resumes *both* samplers if either was paused, not just its own).
- **Integration:** host-run `ContinuousProfilingAllocationTests` (Windows x64/x86, .NET oldest+latest) exercising real sustained allocation load inside an instrumented transaction, asserting the built OTLP payload contains both allocation profile types with real per-sample data and a non-zero trace/span link; plus a `heap` agent-command integration test mirroring the existing `cpu` one.
- Real before/after measurement from the integration test's own load run caught a native delivery-cap defect (below) and confirmed the fix: **1.0 sample/drain with 1577 native drops -> 108.6/drain with 0 drops** at the same configured budget.

## A real defect the integration test found, and the fix

The first working version of the native sampler published one sample per batch, per tick, into a 2-slot queue, and the managed drain read once per tick - which capped delivery at ~1 sample per drain interval *regardless of the configured `maxSamplesPerMinute`*. At shipped defaults (200/min, 10s drain) that's a 6/min deliverable ceiling - 3% of the configured budget - with every excess sub-sampled tick silently dropped. Not just sparse: the one surviving sample per drain was deterministically "whichever tick landed first after the last drain," discarding the sub-sampler's own uniform-selection guarantee.

Fixed by batching multiple samples into a persistent pending batch under back-pressure instead of dropping them (see Architecture above), plus looping the managed drain read until empty, a per-drain sample cap with a new drop-count supportability metric (so a real shortfall is visible, not silent), and a payload-size ceiling on the send path (batching also means one drain's payload can be far larger than the single-sample case the send path was originally sized for).

## Performance

Run on my laptop via `SimpleCP.Perf` (the same harness #3717's numbers came from, extended here with a new
`-AllocCpEnabled` switch so the allocation sampler can be toggled independently of the thread/CPU sampler)
- `alloc` workload, 4 threads, unthrottled, 3 repeats x 20s steady + 5s warmup each. Not a super clean run
(laptop, not a dedicated perf box), but good enough to characterize the feature's marginal cost.

| config | req/s | CPU %core | WorkingSet MB | GC Heap MB | Alloc B/s | LockCont/s |
|---|---|---|---|---|---|---|
| none (uninstrumented) | 90366 | 221.63 | 41.83 | 0.23 | 15030577681 | 0 |
| nr, thread/CPU sampler only | 6570 | 99.22 | 144.52 | 49.83 | 1235847471 | 1379.57 |
| nr, allocation sampler only | 7824 | 141.35 | 137.56 | 46.62 | 1317027457 | 1434.46 |
| nr, both samplers | 6574 | 100.78 | 143.80 | 49.06 | 1242279553 | 928.77 |

- **Allocation sampler adds ~0% marginal overhead once the thread/CPU sampler is already running** - both
  (6574 req/s) vs thread-only (6570 req/s) is a 0.08% delta, within run-to-run noise. Confirms the
  "no `SuspendRuntime` needed" design claim above actually holds in combination, not just in isolation.
- **Allocation sampler alone is ~19% faster than the thread/CPU sampler alone** (7824 vs 6570 req/s) while
  using *more* CPU (141% vs 99%) - the thread sampler's lower throughput isn't a CPU-bound ceiling, it's the
  periodic stop-the-world suspension stalling wall-clock progress beyond what its CPU% shows.
- Agent presence itself (any `nr` config) drops throughput ~13x vs uninstrumented on this tight
  allocation-only microbenchmark, dominated by a LockCont/s jump that appears regardless of CP state - not
  attributable to continuous profiling or this PR, noted so it isn't mistaken for a CP-specific regression.

## Configuration / how to try

- `NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_ENABLED=true` (off by default)
- `NEW_RELIC_CONTINUOUS_PROFILING_ALLOCATION_MAX_SAMPLES_PER_MINUTE` (optional, default 200)
- Independent of CPU sampling's own enable flag - can run either, both, or neither.
- `heap` is a real `start_continuous_profiler`/`stop_continuous_profiler` agent-command token now (previously always reported "not supported").
- CoreCLR only (Windows x64 + Linux x64, matching #3717's platform matrix) - `ICorProfilerInfo12` doesn't exist on .NET Framework, so the feature is a no-op there by construction, not a separate code path.

## Known limitations / follow-ups

- No gzip compression on the profiles POST - the new 1MB payload ceiling bounds the cost; a wire-contract change deserves its own PR.
- The two new caps (2000 samples/drain, 1MB payload) are constants, not exposed config - both sized well above shipped defaults' demand.
- The 1MB payload ceiling is a judgment call against an undocumented real profiles-ingest limit - visible via a new supportability metric if wrong, not silent, but worth confirming against the real endpoint limit.
- A residual, structurally-bounded use-after-free window in the native shutdown path (a tick that already passed the "is the sampler active" check but hasn't yet acquired its own lock can still touch the mutex object after `Shutdown()` returns) - closing it fully would need refcounting the CLR callback dispatch itself; the owning object is a process-lifetime singleton, so the mitigation that matters holds structurally today.
- `stop_continuous_profiler`'s release-then-stop semantics mean a `heap` (or `cpu`) stop command only transiently overrides local/server config - the next config-apply tick (a reconnect, an unrelated SSC push) can silently restart it, because releasing command ownership doesn't durably change what the *configured* value is. Real, pre-existing for `cpu` in #3717, `heap` correctly matches that behavior rather than diverging from it. Needs the same versioned/generation-tagged desired-state model the config replatform work (SSC + agent commands fully replacing XML config) is expected to bring - not something to patch locally in either sampler.
- A pre-existing, unrelated issue in the base branch: the profile's declared time window extends forward from the drain instant rather than backward across the interval actually sampled (affects both CPU and allocation profiles). A `profiles.proto` "SHOULD," not "MUST" - flagged, not fixed here, one-line fix when picked up.
- Linux ARM64 not separately re-verified for the batching change (x64 build+link verified clean; ARM64 build/link not run this pass).
- Everything #3717 already lists as a known limitation (no allocation-**graph**/heap-**snapshot** profiling - this is allocation-*rate* sampling, not a live heap dump; agent-frame exclusion recall ceiling; OTLP proto is Alpha; not yet wired into customer-facing config schema/docs) applies here too, since this branch is built directly on that one.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)

