### PR TITLE
test: Verify per-app agent reporting across two AppDomains in one app pool

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -281,6 +281,7 @@ jobs:
             "Logging.StructuredLogArgContextData",
             "Logging.ZeroMaxSamplesStored",
             "MassTransit",
+            "MultiAppDomain",
             "OpenTelemetry",
             "Owin",
             "ReJit.NetCore",
@@ -651,7 +652,7 @@ jobs:
           matrix.namespace == 'CatInbound' || matrix.namespace == 'CatOutbound' || matrix.namespace == 'CodeLevelMetrics' ||
           matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
           matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HSM' || matrix.namespace == 'HttpClientInstrumentation' || matrix.namespace == 'HybridHttpContextStorage' ||
-          matrix.namespace == 'LLM' || matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
+          matrix.namespace == 'LLM' || matrix.namespace == 'MultiAppDomain' || matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
           matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables' ||
           matrix.namespace == 'RequestHeadersCapture.WCF' || matrix.namespace == 'WCF.Client.IIS.ASPDisabled' ||
           matrix.namespace == 'WCF.Client.IIS.ASPEnabled' || matrix.namespace == 'WCF.Service.IIS.ASPDisabled' ||

--- a/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.csproj
+++ b/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.csproj
@@ -130,6 +130,9 @@
     <None Include="applicationHost.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="applicationHost.MultiApp.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.MultiApp.config
+++ b/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.MultiApp.config
@@ -1,0 +1,895 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- IIS configuration sections. For schema documentation, see %windir%\system32\inetsrv\config\schema\IIS_schema.xml. -->
+<configuration>
+	<configSections>
+		<sectionGroup name="system.applicationHost">
+			<section name="applicationPools" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="configHistory" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="customMetadata" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="listenerAdapters" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="log" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="serviceAutoStartProviders" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="sites" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="webLimits" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+		</sectionGroup>
+		<sectionGroup name="system.webServer">
+			<section name="asp" overrideModeDefault="Deny" />
+			<section name="caching" overrideModeDefault="Allow" />
+			<section name="cgi" overrideModeDefault="Deny" />
+			<section name="defaultDocument" overrideModeDefault="Allow" />
+			<section name="directoryBrowse" overrideModeDefault="Allow" />
+			<section name="fastCgi" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="globalModules" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="handlers" overrideModeDefault="Deny" />
+			<section name="httpCompression" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+			<section name="httpErrors" overrideModeDefault="Allow" />
+			<section name="httpLogging" overrideModeDefault="Deny" />
+			<section name="httpProtocol" overrideModeDefault="Allow" />
+			<section name="httpRedirect" overrideModeDefault="Allow" />
+			<section name="httpTracing" overrideModeDefault="Deny" />
+			<section name="isapiFilters" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+			<section name="modules" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+			<section name="applicationInitialization" allowDefinition="MachineToApplication" overrideModeDefault="Allow" />
+			<section name="odbcLogging" overrideModeDefault="Deny" />
+			<sectionGroup name="security">
+				<section name="access" overrideModeDefault="Deny" />
+				<section name="applicationDependencies" overrideModeDefault="Deny" />
+				<sectionGroup name="authentication">
+					<section name="anonymousAuthentication" overrideModeDefault="Deny" />
+					<section name="basicAuthentication" overrideModeDefault="Deny" />
+					<section name="clientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+					<section name="digestAuthentication" overrideModeDefault="Deny" />
+					<section name="iisClientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+					<section name="windowsAuthentication" overrideModeDefault="Deny" />
+				</sectionGroup>
+				<section name="authorization" overrideModeDefault="Allow" />
+				<section name="ipSecurity" overrideModeDefault="Deny" />
+				<section name="dynamicIpSecurity" overrideModeDefault="Deny" />
+				<section name="isapiCgiRestriction" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+				<section name="requestFiltering" overrideModeDefault="Allow" />
+			</sectionGroup>
+			<section name="serverRuntime" overrideModeDefault="Deny" />
+			<section name="serverSideInclude" overrideModeDefault="Deny" />
+			<section name="staticContent" overrideModeDefault="Allow" />
+			<sectionGroup name="tracing">
+				<section name="traceFailedRequests" overrideModeDefault="Allow" />
+				<section name="traceProviderDefinitions" overrideModeDefault="Deny" />
+			</sectionGroup>
+			<section name="urlCompression" overrideModeDefault="Allow" />
+			<section name="validation" overrideModeDefault="Allow" />
+			<sectionGroup name="webdav">
+				<section name="globalSettings" overrideModeDefault="Deny" />
+				<section name="authoring" overrideModeDefault="Deny" />
+				<section name="authoringRules" overrideModeDefault="Deny" />
+			</sectionGroup>
+			<section name="webSocket" overrideModeDefault="Deny" />
+			<sectionGroup name="wdeploy">
+				<section name="backup" overrideModeDefault="Deny" allowDefinition="MachineToApplication" />
+			</sectionGroup>
+		</sectionGroup>
+		<sectionGroup name="system.ftpServer">
+			<section name="log" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+			<section name="firewallSupport" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+			<section name="caching" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+			<section name="providerDefinitions" overrideModeDefault="Deny" />
+			<sectionGroup name="security">
+				<section name="ipSecurity" overrideModeDefault="Deny" />
+				<section name="requestFiltering" overrideModeDefault="Deny" />
+				<section name="authorization" overrideModeDefault="Deny" />
+				<section name="authentication" overrideModeDefault="Deny" />
+			</sectionGroup>
+			<section name="serverRuntime" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+		</sectionGroup>
+	</configSections>
+	<configProtectedData>
+		<providers>
+			<add name="IISWASOnlyRsaProvider" type="" description="Uses RsaCryptoServiceProvider to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useMachineContainer="true" useOAEP="false" />
+			<add name="AesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisConfigurationKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAAw6hiP6oytVFV5Iq/jCLxhFBKoxe4GJKbxPF6yIN2a4jZ21ZNiQf7748Rh+t1oPIpAWrH1T4UAZ4TQTG3Uhp2nKfgvrqBN61gIi7OFZMKqscuSm4teWszxKFk+5sFLPv03ZStSV2Hil9wM7E/mup49iraehP5woLVyWndPtazAHWyTRB4IyN50/LzFzfg1/rRf6jqRWghn01nHBHi77+GIu0mugZisN2GtcvEHOqh/1rPqTPgpcjbOy2wTPfj8Srn6tlV2+wWQ2AboxJBCqgbEcrvz7Db3K9MNSVv8rMSKkMDfydCACGCTz/hN56nLli7PDj2vAgYveqZQ/7unfCDfQ==" />
+			<add name="IISWASOnlyAesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAA6q15znBEbnVb5EjwH4rrP7GqxbcHEOlmZ5asSYO8R2mUNXKbbxFyTuC37P/k9qkg/xGqkfUj5iH5YuibSYYHHKORZ3Kh3zyZ1qwCbkETD6vkeZM3cOAUSn/JeHpN6qq9DuNIEsF9Wq3HM+jGk47yZiocEguf2t1DHupmXB3bV3Dvl0Bzuoy+6i7B9wX4PO2JQgXeauFM89yq4klznCWuyR6xFn5UOObsKeRcEFvPq0gRDTFU6y+M4wCij9aSMMpAvGv95X3Y8KVHyV5s1FYX+2sMhZJPGW4R9iuewFjtfB0tNcd4xog1/ykLtC8VM8/kroi79jUk9V8MO/YEhglOVQ==" />
+		</providers>
+	</configProtectedData>
+	<system.applicationHost>
+		<applicationPools>
+			<add name="DefaultAppPool"/>
+			<applicationPoolDefaults managedRuntimeVersion="v4.0">
+				<processModel identityType="ApplicationPoolIdentity" />
+			</applicationPoolDefaults>
+		</applicationPools>
+		<!-- The <customMetadata> section is used internally by the Admin Base Objects (ABO) Compatibility component. Please do not modify its content. -->
+		<customMetadata>
+			<key path="LM/W3SVC/INFO">
+				<property id="4012" dataType="String" userType="1" attributes="Inherit" value="NCSA Common Log File Format,Microsoft IIS Log File Format,W3C Extended Log File Format,ODBC Logging" />
+				<property id="2120" dataType="MultiSZ" userType="1" attributes="None" value="400,0,,,0&#xA;" />
+			</key>
+		</customMetadata>
+		<!-- The <listenerAdapters> section defines the protocols with which the Windows Process Activation Service (WAS) binds. -->
+		<listenerAdapters>
+			<add name="http" />
+		</listenerAdapters>
+		<log>
+			<centralBinaryLogFile enabled="true" directory="%SystemDrive%\inetpub\logs\LogFiles" />
+			<centralW3CLogFile enabled="true" directory="%SystemDrive%\inetpub\logs\LogFiles" />
+		</log>
+		<sites>
+			<site name="Default Web Site" id="1">
+				<application path="/">
+					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
+				</application>
+				<application path="/app2">
+					<virtualDirectory path="/" physicalPath="NEWRELIC_APP2_PHYSICAL_PATH" />
+				</application>
+				<bindings>
+					<binding protocol="http" bindingInformation="*:80:" />
+				</bindings>
+			</site>
+			<siteDefaults>
+				<logFile logFormat="W3C" directory="%SystemDrive%\inetpub\logs\LogFiles" />
+				<traceFailedRequestsLogging directory="%SystemDrive%\inetpub\logs\FailedReqLogFiles" />
+			</siteDefaults>
+			<applicationDefaults applicationPool="DefaultAppPool" />
+			<virtualDirectoryDefaults allowSubDirConfig="true" />
+		</sites>
+		<webLimits />
+	</system.applicationHost>
+	<system.webServer>
+		<asp>
+			<cache diskTemplateCacheDirectory="%SystemDrive%\inetpub\temp\ASP Compiled Templates" />
+		</asp>
+		<caching enabled="true" enableKernelCache="true">
+		</caching>
+		<cgi />
+		<defaultDocument enabled="true">
+			<files>
+				<add value="Default.htm" />
+				<add value="Default.asp" />
+				<add value="index.htm" />
+				<add value="index.html" />
+				<add value="iisstart.htm" />
+				<add value="default.aspx" />
+			</files>
+		</defaultDocument>
+		<directoryBrowse enabled="false" />
+		<fastCgi />
+		<!-- The <globalModules> section defines all native-code modules. To enable a module, specify it in the <modules> section. -->
+		<globalModules>
+			<add name="UriCacheModule" image="%windir%\System32\inetsrv\cachuri.dll" />
+			<add name="FileCacheModule" image="%windir%\System32\inetsrv\cachfile.dll" />
+			<add name="TokenCacheModule" image="%windir%\System32\inetsrv\cachtokn.dll" />
+			<add name="HttpCacheModule" image="%windir%\System32\inetsrv\cachhttp.dll" />
+			<add name="StaticCompressionModule" image="%windir%\System32\inetsrv\compstat.dll" />
+			<add name="DefaultDocumentModule" image="%windir%\System32\inetsrv\defdoc.dll" />
+			<add name="DirectoryListingModule" image="%windir%\System32\inetsrv\dirlist.dll" />
+			<add name="ProtocolSupportModule" image="%windir%\System32\inetsrv\protsup.dll" />
+			<add name="StaticFileModule" image="%windir%\System32\inetsrv\static.dll" />
+			<add name="AnonymousAuthenticationModule" image="%windir%\System32\inetsrv\authanon.dll" />
+			<add name="RequestFilteringModule" image="%windir%\System32\inetsrv\modrqflt.dll" />
+			<add name="CustomErrorModule" image="%windir%\System32\inetsrv\custerr.dll" />
+			<add name="HttpLoggingModule" image="%windir%\System32\inetsrv\loghttp.dll" />
+			<add name="IsapiModule" image="%windir%\System32\inetsrv\isapi.dll" />
+			<add name="IsapiFilterModule" image="%windir%\System32\inetsrv\filter.dll" />
+			<add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
+			<add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
+			<add name="ConfigurationValidationModule" image="%windir%\System32\inetsrv\validcfg.dll" />
+			<add name="TracingModule" image="%windir%\System32\inetsrv\iisetw.dll" />
+			<add name="FailedRequestsTracingModule" image="%windir%\System32\inetsrv\iisfreb.dll" />
+			<add name="BasicAuthenticationModule" image="%windir%\System32\inetsrv\authbas.dll" />
+			<add name="IpRestrictionModule" image="%windir%\System32\inetsrv\iprestr.dll" />
+			<add name="UrlAuthorizationModule" image="%windir%\System32\inetsrv\urlauthz.dll" />
+			<add name="WindowsAuthenticationModule" image="%windir%\System32\inetsrv\authsspi.dll" />
+		</globalModules>
+		<httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
+			<scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
+			<dynamicTypes>
+				<add mimeType="text/*" enabled="true" />
+				<add mimeType="message/*" enabled="true" />
+				<add mimeType="application/x-javascript" enabled="true" />
+				<add mimeType="application/javascript" enabled="true" />
+				<add mimeType="*/*" enabled="false" />
+			</dynamicTypes>
+			<staticTypes>
+				<add mimeType="text/*" enabled="true" />
+				<add mimeType="message/*" enabled="true" />
+				<add mimeType="application/javascript" enabled="true" />
+				<add mimeType="application/atom+xml" enabled="true" />
+				<add mimeType="application/xaml+xml" enabled="true" />
+				<add mimeType="*/*" enabled="false" />
+			</staticTypes>
+		</httpCompression>
+		<httpErrors lockAttributes="allowAbsolutePathsWhenDelegated,defaultPath">
+			<error statusCode="401" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="401.htm" />
+			<error statusCode="403" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="403.htm" />
+			<error statusCode="404" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="404.htm" />
+			<error statusCode="405" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="405.htm" />
+			<error statusCode="406" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="406.htm" />
+			<error statusCode="412" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="412.htm" />
+			<error statusCode="500" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="500.htm" />
+			<error statusCode="501" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="501.htm" />
+			<error statusCode="502" prefixLanguageFilePath="%SystemDrive%\inetpub\custerr" path="502.htm" />
+		</httpErrors>
+		<httpLogging dontLog="false" />
+		<httpProtocol>
+			<customHeaders>
+				<clear />
+				<add name="X-Powered-By" value="ASP.NET" />
+			</customHeaders>
+			<redirectHeaders>
+				<clear />
+			</redirectHeaders>
+		</httpProtocol>
+		<httpRedirect enabled="false" />
+		<httpTracing>
+		</httpTracing>
+		<isapiFilters>
+			<filter name="ASP.Net_2.0.50727-64" path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv2.0,bitness64" />
+			<filter name="ASP.Net_2.0.50727.0" path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv2.0,bitness32" />
+			<filter name="ASP.Net_4.0_32bit" path="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv4.0,bitness32" />
+			<filter name="ASP.Net_4.0_64bit" path="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv4.0,bitness64" />
+		</isapiFilters>
+		<odbcLogging />
+		<security>
+			<access sslFlags="None" />
+			<applicationDependencies>
+				<application name="Active Server Pages" groupId="ASP" />
+			</applicationDependencies>
+			<authentication>
+				<anonymousAuthentication enabled="true" userName="IUSR" />
+				<basicAuthentication enabled="false" />
+				<clientCertificateMappingAuthentication enabled="false" />
+				<digestAuthentication enabled="false" />
+				<iisClientCertificateMappingAuthentication enabled="false">
+				</iisClientCertificateMappingAuthentication>
+				<windowsAuthentication enabled="false" authPersistNonNTLM="true">
+					<providers>
+						<add value="Negotiate" />
+						<add value="NTLM" />
+					</providers>
+				</windowsAuthentication>
+			</authentication>
+			<authorization>
+				<add accessType="Allow" users="*" />
+			</authorization>
+			<ipSecurity allowUnlisted="true" />
+			<isapiCgiRestriction>
+				<add path="%windir%\system32\inetsrv\asp.dll" allowed="true" groupId="ASP" description="Active Server Pages" />
+				<add path="%windir%\system32\inetsrv\webdav.dll" allowed="true" groupId="WEBDAV" description="WebDAV" />
+				<add path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+				<add path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+				<add path="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v4.0.30319" description="ASP.NET v4.0.30319" />
+				<add path="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v4.0.30319" description="ASP.NET v4.0.30319" />
+			</isapiCgiRestriction>
+			<requestFiltering>
+				<fileExtensions allowUnlisted="true" applyToWebDAV="true">
+					<add fileExtension=".asa" allowed="false" />
+					<add fileExtension=".asax" allowed="false" />
+					<add fileExtension=".ascx" allowed="false" />
+					<add fileExtension=".master" allowed="false" />
+					<add fileExtension=".skin" allowed="false" />
+					<add fileExtension=".browser" allowed="false" />
+					<add fileExtension=".sitemap" allowed="false" />
+					<add fileExtension=".config" allowed="false" />
+					<add fileExtension=".cs" allowed="false" />
+					<add fileExtension=".csproj" allowed="false" />
+					<add fileExtension=".vb" allowed="false" />
+					<add fileExtension=".vbproj" allowed="false" />
+					<add fileExtension=".webinfo" allowed="false" />
+					<add fileExtension=".licx" allowed="false" />
+					<add fileExtension=".resx" allowed="false" />
+					<add fileExtension=".resources" allowed="false" />
+					<add fileExtension=".mdb" allowed="false" />
+					<add fileExtension=".vjsproj" allowed="false" />
+					<add fileExtension=".java" allowed="false" />
+					<add fileExtension=".jsl" allowed="false" />
+					<add fileExtension=".ldb" allowed="false" />
+					<add fileExtension=".dsdgm" allowed="false" />
+					<add fileExtension=".ssdgm" allowed="false" />
+					<add fileExtension=".lsad" allowed="false" />
+					<add fileExtension=".ssmap" allowed="false" />
+					<add fileExtension=".cd" allowed="false" />
+					<add fileExtension=".dsprototype" allowed="false" />
+					<add fileExtension=".lsaprototype" allowed="false" />
+					<add fileExtension=".sdm" allowed="false" />
+					<add fileExtension=".sdmDocument" allowed="false" />
+					<add fileExtension=".mdf" allowed="false" />
+					<add fileExtension=".ldf" allowed="false" />
+					<add fileExtension=".ad" allowed="false" />
+					<add fileExtension=".dd" allowed="false" />
+					<add fileExtension=".ldd" allowed="false" />
+					<add fileExtension=".sd" allowed="false" />
+					<add fileExtension=".adprototype" allowed="false" />
+					<add fileExtension=".lddprototype" allowed="false" />
+					<add fileExtension=".exclude" allowed="false" />
+					<add fileExtension=".refresh" allowed="false" />
+					<add fileExtension=".compiled" allowed="false" />
+					<add fileExtension=".msgx" allowed="false" />
+					<add fileExtension=".vsdisco" allowed="false" />
+					<add fileExtension=".rules" allowed="false" />
+				</fileExtensions>
+				<verbs allowUnlisted="true" applyToWebDAV="true" />
+				<hiddenSegments applyToWebDAV="true">
+					<add segment="web.config" />
+					<add segment="bin" />
+					<add segment="App_code" />
+					<add segment="App_GlobalResources" />
+					<add segment="App_LocalResources" />
+					<add segment="App_WebReferences" />
+					<add segment="App_Data" />
+					<add segment="App_Browsers" />
+				</hiddenSegments>
+			</requestFiltering>
+		</security>
+		<serverRuntime />
+		<serverSideInclude ssiExecDisable="false" />
+		<staticContent lockAttributes="isDocFooterFileName">
+			<mimeMap fileExtension=".323" mimeType="text/h323" />
+			<mimeMap fileExtension=".3g2" mimeType="video/3gpp2" />
+			<mimeMap fileExtension=".3gp2" mimeType="video/3gpp2" />
+			<mimeMap fileExtension=".3gp" mimeType="video/3gpp" />
+			<mimeMap fileExtension=".3gpp" mimeType="video/3gpp" />
+			<mimeMap fileExtension=".aaf" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".aac" mimeType="audio/aac" />
+			<mimeMap fileExtension=".aca" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".accdb" mimeType="application/msaccess" />
+			<mimeMap fileExtension=".accde" mimeType="application/msaccess" />
+			<mimeMap fileExtension=".accdt" mimeType="application/msaccess" />
+			<mimeMap fileExtension=".acx" mimeType="application/internet-property-stream" />
+			<mimeMap fileExtension=".adt" mimeType="audio/vnd.dlna.adts" />
+			<mimeMap fileExtension=".adts" mimeType="audio/vnd.dlna.adts" />
+			<mimeMap fileExtension=".afm" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".ai" mimeType="application/postscript" />
+			<mimeMap fileExtension=".aif" mimeType="audio/x-aiff" />
+			<mimeMap fileExtension=".aifc" mimeType="audio/aiff" />
+			<mimeMap fileExtension=".aiff" mimeType="audio/aiff" />
+			<mimeMap fileExtension=".application" mimeType="application/x-ms-application" />
+			<mimeMap fileExtension=".art" mimeType="image/x-jg" />
+			<mimeMap fileExtension=".asd" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".asf" mimeType="video/x-ms-asf" />
+			<mimeMap fileExtension=".asi" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".asm" mimeType="text/plain" />
+			<mimeMap fileExtension=".asr" mimeType="video/x-ms-asf" />
+			<mimeMap fileExtension=".asx" mimeType="video/x-ms-asf" />
+			<mimeMap fileExtension=".atom" mimeType="application/atom+xml" />
+			<mimeMap fileExtension=".au" mimeType="audio/basic" />
+			<mimeMap fileExtension=".avi" mimeType="video/avi" />
+			<mimeMap fileExtension=".axs" mimeType="application/olescript" />
+			<mimeMap fileExtension=".bas" mimeType="text/plain" />
+			<mimeMap fileExtension=".bcpio" mimeType="application/x-bcpio" />
+			<mimeMap fileExtension=".bin" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".bmp" mimeType="image/bmp" />
+			<mimeMap fileExtension=".c" mimeType="text/plain" />
+			<mimeMap fileExtension=".cab" mimeType="application/vnd.ms-cab-compressed" />
+			<mimeMap fileExtension=".calx" mimeType="application/vnd.ms-office.calx" />
+			<mimeMap fileExtension=".cat" mimeType="application/vnd.ms-pki.seccat" />
+			<mimeMap fileExtension=".cdf" mimeType="application/x-cdf" />
+			<mimeMap fileExtension=".chm" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".class" mimeType="application/x-java-applet" />
+			<mimeMap fileExtension=".clp" mimeType="application/x-msclip" />
+			<mimeMap fileExtension=".cmx" mimeType="image/x-cmx" />
+			<mimeMap fileExtension=".cnf" mimeType="text/plain" />
+			<mimeMap fileExtension=".cod" mimeType="image/cis-cod" />
+			<mimeMap fileExtension=".cpio" mimeType="application/x-cpio" />
+			<mimeMap fileExtension=".cpp" mimeType="text/plain" />
+			<mimeMap fileExtension=".crd" mimeType="application/x-mscardfile" />
+			<mimeMap fileExtension=".crl" mimeType="application/pkix-crl" />
+			<mimeMap fileExtension=".crt" mimeType="application/x-x509-ca-cert" />
+			<mimeMap fileExtension=".csh" mimeType="application/x-csh" />
+			<mimeMap fileExtension=".css" mimeType="text/css" />
+			<mimeMap fileExtension=".csv" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".cur" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".dcr" mimeType="application/x-director" />
+			<mimeMap fileExtension=".deploy" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".der" mimeType="application/x-x509-ca-cert" />
+			<mimeMap fileExtension=".dib" mimeType="image/bmp" />
+			<mimeMap fileExtension=".dir" mimeType="application/x-director" />
+			<mimeMap fileExtension=".disco" mimeType="text/xml" />
+			<mimeMap fileExtension=".dll" mimeType="application/x-msdownload" />
+			<mimeMap fileExtension=".dll.config" mimeType="text/xml" />
+			<mimeMap fileExtension=".dlm" mimeType="text/dlm" />
+			<mimeMap fileExtension=".doc" mimeType="application/msword" />
+			<mimeMap fileExtension=".docm" mimeType="application/vnd.ms-word.document.macroEnabled.12" />
+			<mimeMap fileExtension=".docx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+			<mimeMap fileExtension=".dot" mimeType="application/msword" />
+			<mimeMap fileExtension=".dotm" mimeType="application/vnd.ms-word.template.macroEnabled.12" />
+			<mimeMap fileExtension=".dotx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.template" />
+			<mimeMap fileExtension=".dsp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".dtd" mimeType="text/xml" />
+			<mimeMap fileExtension=".dvi" mimeType="application/x-dvi" />
+			<mimeMap fileExtension=".dvr-ms" mimeType="video/x-ms-dvr" />
+			<mimeMap fileExtension=".dwf" mimeType="drawing/x-dwf" />
+			<mimeMap fileExtension=".dwp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".dxr" mimeType="application/x-director" />
+			<mimeMap fileExtension=".eml" mimeType="message/rfc822" />
+			<mimeMap fileExtension=".emz" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+			<mimeMap fileExtension=".eps" mimeType="application/postscript" />
+			<mimeMap fileExtension=".etx" mimeType="text/x-setext" />
+			<mimeMap fileExtension=".evy" mimeType="application/envoy" />
+			<mimeMap fileExtension=".exe" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".exe.config" mimeType="text/xml" />
+			<mimeMap fileExtension=".fdf" mimeType="application/vnd.fdf" />
+			<mimeMap fileExtension=".fif" mimeType="application/fractals" />
+			<mimeMap fileExtension=".fla" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".flr" mimeType="x-world/x-vrml" />
+			<mimeMap fileExtension=".flv" mimeType="video/x-flv" />
+			<mimeMap fileExtension=".gif" mimeType="image/gif" />
+			<mimeMap fileExtension=".gtar" mimeType="application/x-gtar" />
+			<mimeMap fileExtension=".gz" mimeType="application/x-gzip" />
+			<mimeMap fileExtension=".h" mimeType="text/plain" />
+			<mimeMap fileExtension=".hdf" mimeType="application/x-hdf" />
+			<mimeMap fileExtension=".hdml" mimeType="text/x-hdml" />
+			<mimeMap fileExtension=".hhc" mimeType="application/x-oleobject" />
+			<mimeMap fileExtension=".hhk" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".hhp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".hlp" mimeType="application/winhlp" />
+			<mimeMap fileExtension=".hqx" mimeType="application/mac-binhex40" />
+			<mimeMap fileExtension=".hta" mimeType="application/hta" />
+			<mimeMap fileExtension=".htc" mimeType="text/x-component" />
+			<mimeMap fileExtension=".htm" mimeType="text/html" />
+			<mimeMap fileExtension=".html" mimeType="text/html" />
+			<mimeMap fileExtension=".htt" mimeType="text/webviewhtml" />
+			<mimeMap fileExtension=".hxt" mimeType="text/html" />
+			<mimeMap fileExtension=".ico" mimeType="image/x-icon" />
+			<mimeMap fileExtension=".ics" mimeType="text/calendar" />
+			<mimeMap fileExtension=".ief" mimeType="image/ief" />
+			<mimeMap fileExtension=".iii" mimeType="application/x-iphone" />
+			<mimeMap fileExtension=".inf" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".ins" mimeType="application/x-internet-signup" />
+			<mimeMap fileExtension=".isp" mimeType="application/x-internet-signup" />
+			<mimeMap fileExtension=".IVF" mimeType="video/x-ivf" />
+			<mimeMap fileExtension=".jar" mimeType="application/java-archive" />
+			<mimeMap fileExtension=".java" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".jck" mimeType="application/liquidmotion" />
+			<mimeMap fileExtension=".jcz" mimeType="application/liquidmotion" />
+			<mimeMap fileExtension=".jfif" mimeType="image/pjpeg" />
+			<mimeMap fileExtension=".jpb" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".jpe" mimeType="image/jpeg" />
+			<mimeMap fileExtension=".jpeg" mimeType="image/jpeg" />
+			<mimeMap fileExtension=".jpg" mimeType="image/jpeg" />
+			<mimeMap fileExtension=".js" mimeType="application/javascript" />
+			<mimeMap fileExtension=".json" mimeType="application/json" />
+			<mimeMap fileExtension=".jsx" mimeType="text/jscript" />
+			<mimeMap fileExtension=".latex" mimeType="application/x-latex" />
+			<mimeMap fileExtension=".lit" mimeType="application/x-ms-reader" />
+			<mimeMap fileExtension=".lpk" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".lsf" mimeType="video/x-la-asf" />
+			<mimeMap fileExtension=".lsx" mimeType="video/x-la-asf" />
+			<mimeMap fileExtension=".lzh" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".m13" mimeType="application/x-msmediaview" />
+			<mimeMap fileExtension=".m14" mimeType="application/x-msmediaview" />
+			<mimeMap fileExtension=".m1v" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".m2ts" mimeType="video/vnd.dlna.mpeg-tts" />
+			<mimeMap fileExtension=".m3u" mimeType="audio/x-mpegurl" />
+			<mimeMap fileExtension=".m4a" mimeType="audio/mp4" />
+			<mimeMap fileExtension=".m4v" mimeType="video/mp4" />
+			<mimeMap fileExtension=".man" mimeType="application/x-troff-man" />
+			<mimeMap fileExtension=".manifest" mimeType="application/x-ms-manifest" />
+			<mimeMap fileExtension=".map" mimeType="text/plain" />
+			<mimeMap fileExtension=".mdb" mimeType="application/x-msaccess" />
+			<mimeMap fileExtension=".mdp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".me" mimeType="application/x-troff-me" />
+			<mimeMap fileExtension=".mht" mimeType="message/rfc822" />
+			<mimeMap fileExtension=".mhtml" mimeType="message/rfc822" />
+			<mimeMap fileExtension=".mid" mimeType="audio/mid" />
+			<mimeMap fileExtension=".midi" mimeType="audio/mid" />
+			<mimeMap fileExtension=".mix" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".mmf" mimeType="application/x-smaf" />
+			<mimeMap fileExtension=".mno" mimeType="text/xml" />
+			<mimeMap fileExtension=".mny" mimeType="application/x-msmoney" />
+			<mimeMap fileExtension=".mov" mimeType="video/quicktime" />
+			<mimeMap fileExtension=".movie" mimeType="video/x-sgi-movie" />
+			<mimeMap fileExtension=".mp2" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".mp3" mimeType="audio/mpeg" />
+			<mimeMap fileExtension=".mp4" mimeType="video/mp4" />
+			<mimeMap fileExtension=".mp4v" mimeType="video/mp4" />
+			<mimeMap fileExtension=".mpa" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".mpe" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".mpeg" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".mpg" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".mpp" mimeType="application/vnd.ms-project" />
+			<mimeMap fileExtension=".mpv2" mimeType="video/mpeg" />
+			<mimeMap fileExtension=".ms" mimeType="application/x-troff-ms" />
+			<mimeMap fileExtension=".msi" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".mso" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".mvb" mimeType="application/x-msmediaview" />
+			<mimeMap fileExtension=".mvc" mimeType="application/x-miva-compiled" />
+			<mimeMap fileExtension=".nc" mimeType="application/x-netcdf" />
+			<mimeMap fileExtension=".nsc" mimeType="video/x-ms-asf" />
+			<mimeMap fileExtension=".nws" mimeType="message/rfc822" />
+			<mimeMap fileExtension=".ocx" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".oda" mimeType="application/oda" />
+			<mimeMap fileExtension=".odc" mimeType="text/x-ms-odc" />
+			<mimeMap fileExtension=".ods" mimeType="application/oleobject" />
+			<mimeMap fileExtension=".oga" mimeType="audio/ogg" />
+			<mimeMap fileExtension=".ogg" mimeType="video/ogg" />
+			<mimeMap fileExtension=".ogv" mimeType="video/ogg" />
+			<mimeMap fileExtension=".one" mimeType="application/onenote" />
+			<mimeMap fileExtension=".onea" mimeType="application/onenote" />
+			<mimeMap fileExtension=".onetoc" mimeType="application/onenote" />
+			<mimeMap fileExtension=".onetoc2" mimeType="application/onenote" />
+			<mimeMap fileExtension=".onetmp" mimeType="application/onenote" />
+			<mimeMap fileExtension=".onepkg" mimeType="application/onenote" />
+			<mimeMap fileExtension=".osdx" mimeType="application/opensearchdescription+xml" />
+			<mimeMap fileExtension=".otf" mimeType="font/otf" />
+			<mimeMap fileExtension=".p10" mimeType="application/pkcs10" />
+			<mimeMap fileExtension=".p12" mimeType="application/x-pkcs12" />
+			<mimeMap fileExtension=".p7b" mimeType="application/x-pkcs7-certificates" />
+			<mimeMap fileExtension=".p7c" mimeType="application/pkcs7-mime" />
+			<mimeMap fileExtension=".p7m" mimeType="application/pkcs7-mime" />
+			<mimeMap fileExtension=".p7r" mimeType="application/x-pkcs7-certreqresp" />
+			<mimeMap fileExtension=".p7s" mimeType="application/pkcs7-signature" />
+			<mimeMap fileExtension=".pbm" mimeType="image/x-portable-bitmap" />
+			<mimeMap fileExtension=".pcx" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".pcz" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".pdf" mimeType="application/pdf" />
+			<mimeMap fileExtension=".pfb" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".pfm" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".pfx" mimeType="application/x-pkcs12" />
+			<mimeMap fileExtension=".pgm" mimeType="image/x-portable-graymap" />
+			<mimeMap fileExtension=".pko" mimeType="application/vnd.ms-pki.pko" />
+			<mimeMap fileExtension=".pma" mimeType="application/x-perfmon" />
+			<mimeMap fileExtension=".pmc" mimeType="application/x-perfmon" />
+			<mimeMap fileExtension=".pml" mimeType="application/x-perfmon" />
+			<mimeMap fileExtension=".pmr" mimeType="application/x-perfmon" />
+			<mimeMap fileExtension=".pmw" mimeType="application/x-perfmon" />
+			<mimeMap fileExtension=".png" mimeType="image/png" />
+			<mimeMap fileExtension=".pnm" mimeType="image/x-portable-anymap" />
+			<mimeMap fileExtension=".pnz" mimeType="image/png" />
+			<mimeMap fileExtension=".pot" mimeType="application/vnd.ms-powerpoint" />
+			<mimeMap fileExtension=".potm" mimeType="application/vnd.ms-powerpoint.template.macroEnabled.12" />
+			<mimeMap fileExtension=".potx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.template" />
+			<mimeMap fileExtension=".ppam" mimeType="application/vnd.ms-powerpoint.addin.macroEnabled.12" />
+			<mimeMap fileExtension=".ppm" mimeType="image/x-portable-pixmap" />
+			<mimeMap fileExtension=".pps" mimeType="application/vnd.ms-powerpoint" />
+			<mimeMap fileExtension=".ppsm" mimeType="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
+			<mimeMap fileExtension=".ppsx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
+			<mimeMap fileExtension=".ppt" mimeType="application/vnd.ms-powerpoint" />
+			<mimeMap fileExtension=".pptm" mimeType="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+			<mimeMap fileExtension=".pptx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
+			<mimeMap fileExtension=".prf" mimeType="application/pics-rules" />
+			<mimeMap fileExtension=".prm" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".prx" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".ps" mimeType="application/postscript" />
+			<mimeMap fileExtension=".psd" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".psm" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".psp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".pub" mimeType="application/x-mspublisher" />
+			<mimeMap fileExtension=".qt" mimeType="video/quicktime" />
+			<mimeMap fileExtension=".qtl" mimeType="application/x-quicktimeplayer" />
+			<mimeMap fileExtension=".qxd" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".ra" mimeType="audio/x-pn-realaudio" />
+			<mimeMap fileExtension=".ram" mimeType="audio/x-pn-realaudio" />
+			<mimeMap fileExtension=".rar" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".ras" mimeType="image/x-cmu-raster" />
+			<mimeMap fileExtension=".rf" mimeType="image/vnd.rn-realflash" />
+			<mimeMap fileExtension=".rgb" mimeType="image/x-rgb" />
+			<mimeMap fileExtension=".rm" mimeType="application/vnd.rn-realmedia" />
+			<mimeMap fileExtension=".rmi" mimeType="audio/mid" />
+			<mimeMap fileExtension=".roff" mimeType="application/x-troff" />
+			<mimeMap fileExtension=".rpm" mimeType="audio/x-pn-realaudio-plugin" />
+			<mimeMap fileExtension=".rtf" mimeType="application/rtf" />
+			<mimeMap fileExtension=".rtx" mimeType="text/richtext" />
+			<mimeMap fileExtension=".scd" mimeType="application/x-msschedule" />
+			<mimeMap fileExtension=".sct" mimeType="text/scriptlet" />
+			<mimeMap fileExtension=".sea" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".setpay" mimeType="application/set-payment-initiation" />
+			<mimeMap fileExtension=".setreg" mimeType="application/set-registration-initiation" />
+			<mimeMap fileExtension=".sgml" mimeType="text/sgml" />
+			<mimeMap fileExtension=".sh" mimeType="application/x-sh" />
+			<mimeMap fileExtension=".shar" mimeType="application/x-shar" />
+			<mimeMap fileExtension=".sit" mimeType="application/x-stuffit" />
+			<mimeMap fileExtension=".sldm" mimeType="application/vnd.ms-powerpoint.slide.macroEnabled.12" />
+			<mimeMap fileExtension=".sldx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slide" />
+			<mimeMap fileExtension=".smd" mimeType="audio/x-smd" />
+			<mimeMap fileExtension=".smi" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".smx" mimeType="audio/x-smd" />
+			<mimeMap fileExtension=".smz" mimeType="audio/x-smd" />
+			<mimeMap fileExtension=".snd" mimeType="audio/basic" />
+			<mimeMap fileExtension=".snp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".spc" mimeType="application/x-pkcs7-certificates" />
+			<mimeMap fileExtension=".spl" mimeType="application/futuresplash" />
+			<mimeMap fileExtension=".spx" mimeType="audio/ogg" />
+			<mimeMap fileExtension=".src" mimeType="application/x-wais-source" />
+			<mimeMap fileExtension=".ssm" mimeType="application/streamingmedia" />
+			<mimeMap fileExtension=".sst" mimeType="application/vnd.ms-pki.certstore" />
+			<mimeMap fileExtension=".stl" mimeType="application/vnd.ms-pki.stl" />
+			<mimeMap fileExtension=".sv4cpio" mimeType="application/x-sv4cpio" />
+			<mimeMap fileExtension=".sv4crc" mimeType="application/x-sv4crc" />
+			<mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+			<mimeMap fileExtension=".svgz" mimeType="image/svg+xml" />
+			<mimeMap fileExtension=".swf" mimeType="application/x-shockwave-flash" />
+			<mimeMap fileExtension=".t" mimeType="application/x-troff" />
+			<mimeMap fileExtension=".tar" mimeType="application/x-tar" />
+			<mimeMap fileExtension=".tcl" mimeType="application/x-tcl" />
+			<mimeMap fileExtension=".tex" mimeType="application/x-tex" />
+			<mimeMap fileExtension=".texi" mimeType="application/x-texinfo" />
+			<mimeMap fileExtension=".texinfo" mimeType="application/x-texinfo" />
+			<mimeMap fileExtension=".tgz" mimeType="application/x-compressed" />
+			<mimeMap fileExtension=".thmx" mimeType="application/vnd.ms-officetheme" />
+			<mimeMap fileExtension=".thn" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".tif" mimeType="image/tiff" />
+			<mimeMap fileExtension=".tiff" mimeType="image/tiff" />
+			<mimeMap fileExtension=".toc" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".tr" mimeType="application/x-troff" />
+			<mimeMap fileExtension=".trm" mimeType="application/x-msterminal" />
+			<mimeMap fileExtension=".ts" mimeType="video/vnd.dlna.mpeg-tts" />
+			<mimeMap fileExtension=".tsv" mimeType="text/tab-separated-values" />
+			<mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".tts" mimeType="video/vnd.dlna.mpeg-tts" />
+			<mimeMap fileExtension=".txt" mimeType="text/plain" />
+			<mimeMap fileExtension=".u32" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".uls" mimeType="text/iuls" />
+			<mimeMap fileExtension=".ustar" mimeType="application/x-ustar" />
+			<mimeMap fileExtension=".vbs" mimeType="text/vbscript" />
+			<mimeMap fileExtension=".vcf" mimeType="text/x-vcard" />
+			<mimeMap fileExtension=".vcs" mimeType="text/plain" />
+			<mimeMap fileExtension=".vdx" mimeType="application/vnd.ms-visio.viewer" />
+			<mimeMap fileExtension=".vml" mimeType="text/xml" />
+			<mimeMap fileExtension=".vsd" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".vss" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".vst" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".vsto" mimeType="application/x-ms-vsto" />
+			<mimeMap fileExtension=".vsw" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".vsx" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".vtx" mimeType="application/vnd.visio" />
+			<mimeMap fileExtension=".wav" mimeType="audio/wav" />
+			<mimeMap fileExtension=".wax" mimeType="audio/x-ms-wax" />
+			<mimeMap fileExtension=".wbmp" mimeType="image/vnd.wap.wbmp" />
+			<mimeMap fileExtension=".wcm" mimeType="application/vnd.ms-works" />
+			<mimeMap fileExtension=".wdb" mimeType="application/vnd.ms-works" />
+			<mimeMap fileExtension=".webm" mimeType="video/webm" />
+			<mimeMap fileExtension=".wks" mimeType="application/vnd.ms-works" />
+			<mimeMap fileExtension=".wm" mimeType="video/x-ms-wm" />
+			<mimeMap fileExtension=".wma" mimeType="audio/x-ms-wma" />
+			<mimeMap fileExtension=".wmd" mimeType="application/x-ms-wmd" />
+			<mimeMap fileExtension=".wmf" mimeType="application/x-msmetafile" />
+			<mimeMap fileExtension=".wml" mimeType="text/vnd.wap.wml" />
+			<mimeMap fileExtension=".wmlc" mimeType="application/vnd.wap.wmlc" />
+			<mimeMap fileExtension=".wmls" mimeType="text/vnd.wap.wmlscript" />
+			<mimeMap fileExtension=".wmlsc" mimeType="application/vnd.wap.wmlscriptc" />
+			<mimeMap fileExtension=".wmp" mimeType="video/x-ms-wmp" />
+			<mimeMap fileExtension=".wmv" mimeType="video/x-ms-wmv" />
+			<mimeMap fileExtension=".wmx" mimeType="video/x-ms-wmx" />
+			<mimeMap fileExtension=".wmz" mimeType="application/x-ms-wmz" />
+			<mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+			<mimeMap fileExtension=".wps" mimeType="application/vnd.ms-works" />
+			<mimeMap fileExtension=".wri" mimeType="application/x-mswrite" />
+			<mimeMap fileExtension=".wrl" mimeType="x-world/x-vrml" />
+			<mimeMap fileExtension=".wrz" mimeType="x-world/x-vrml" />
+			<mimeMap fileExtension=".wsdl" mimeType="text/xml" />
+			<mimeMap fileExtension=".wtv" mimeType="video/x-ms-wtv" />
+			<mimeMap fileExtension=".wvx" mimeType="video/x-ms-wvx" />
+			<mimeMap fileExtension=".x" mimeType="application/directx" />
+			<mimeMap fileExtension=".xaf" mimeType="x-world/x-vrml" />
+			<mimeMap fileExtension=".xaml" mimeType="application/xaml+xml" />
+			<mimeMap fileExtension=".xap" mimeType="application/x-silverlight-app" />
+			<mimeMap fileExtension=".xbap" mimeType="application/x-ms-xbap" />
+			<mimeMap fileExtension=".xbm" mimeType="image/x-xbitmap" />
+			<mimeMap fileExtension=".xdr" mimeType="text/plain" />
+			<mimeMap fileExtension=".xht" mimeType="application/xhtml+xml" />
+			<mimeMap fileExtension=".xhtml" mimeType="application/xhtml+xml" />
+			<mimeMap fileExtension=".xla" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xlam" mimeType="application/vnd.ms-excel.addin.macroEnabled.12" />
+			<mimeMap fileExtension=".xlc" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xlm" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xls" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xlsb" mimeType="application/vnd.ms-excel.sheet.binary.macroEnabled.12" />
+			<mimeMap fileExtension=".xlsm" mimeType="application/vnd.ms-excel.sheet.macroEnabled.12" />
+			<mimeMap fileExtension=".xlsx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+			<mimeMap fileExtension=".xlt" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xltm" mimeType="application/vnd.ms-excel.template.macroEnabled.12" />
+			<mimeMap fileExtension=".xltx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
+			<mimeMap fileExtension=".xlw" mimeType="application/vnd.ms-excel" />
+			<mimeMap fileExtension=".xml" mimeType="text/xml" />
+			<mimeMap fileExtension=".xof" mimeType="x-world/x-vrml" />
+			<mimeMap fileExtension=".xpm" mimeType="image/x-xpixmap" />
+			<mimeMap fileExtension=".xps" mimeType="application/vnd.ms-xpsdocument" />
+			<mimeMap fileExtension=".xsd" mimeType="text/xml" />
+			<mimeMap fileExtension=".xsf" mimeType="text/xml" />
+			<mimeMap fileExtension=".xsl" mimeType="text/xml" />
+			<mimeMap fileExtension=".xslt" mimeType="text/xml" />
+			<mimeMap fileExtension=".xsn" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".xtp" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".xwd" mimeType="image/x-xwindowdump" />
+			<mimeMap fileExtension=".z" mimeType="application/x-compress" />
+			<mimeMap fileExtension=".zip" mimeType="application/x-zip-compressed" />
+		</staticContent>
+		<tracing>
+			<traceFailedRequests />
+			<traceProviderDefinitions>
+				<add name="WWW Server" guid="{3a2a4e84-4c21-4981-ae10-3fda0d9b0f83}">
+					<areas>
+						<clear />
+						<add name="Authentication" value="2" />
+						<add name="Security" value="4" />
+						<add name="Filter" value="8" />
+						<add name="StaticFile" value="16" />
+						<add name="CGI" value="32" />
+						<add name="Compression" value="64" />
+						<add name="Cache" value="128" />
+						<add name="RequestNotifications" value="256" />
+						<add name="Module" value="512" />
+						<add name="FastCGI" value="4096" />
+						<add name="WebSocket" value="16384" />
+					</areas>
+				</add>
+				<add name="ASP" guid="{06b94d9a-b15e-456e-a4ef-37c984a2cb4b}">
+					<areas>
+						<clear />
+					</areas>
+				</add>
+				<add name="ISAPI Extension" guid="{a1c2040e-8840-4c31-ba11-9871031a19ea}">
+					<areas>
+						<clear />
+					</areas>
+				</add>
+				<add name="ASPNET" guid="{AFF081FE-0247-4275-9C4E-021F3DC1DA35}">
+					<areas>
+						<add name="Infrastructure" value="1" />
+						<add name="Module" value="2" />
+						<add name="Page" value="4" />
+						<add name="AppServices" value="8" />
+					</areas>
+				</add>
+			</traceProviderDefinitions>
+		</tracing>
+		<urlCompression />
+		<validation />
+		<webdav>
+			<globalSettings>
+				<propertyStores>
+					<add name="webdav_simple_prop" image="%windir%\system32\inetsrv\webdav_simple_prop.dll" image32="%windir%\syswow64\inetsrv\webdav_simple_prop.dll" />
+				</propertyStores>
+				<lockStores>
+					<add name="webdav_simple_lock" image="%windir%\system32\inetsrv\webdav_simple_lock.dll" image32="%windir%\syswow64\inetsrv\webdav_simple_lock.dll" />
+				</lockStores>
+			</globalSettings>
+			<authoring>
+				<locks enabled="true" lockStore="webdav_simple_lock" />
+			</authoring>
+			<authoringRules />
+		</webdav>
+		<applicationInitialization />
+		<webSocket />
+	</system.webServer>
+	<system.ftpServer>
+		<providerDefinitions>
+			<add name="IisManagerAuth" type="Microsoft.Web.FtpServer.Security.IisManagerAuthenticationProvider,Microsoft.Web.FtpServer,version=7.5.0.0,Culture=neutral,PublicKeyToken=31bf3856ad364e35" />
+			<add name="AspNetAuth" type="Microsoft.Web.FtpServer.Security.AspNetFtpMembershipProvider,Microsoft.Web.FtpServer,version=7.5.0.0,Culture=neutral,PublicKeyToken=31bf3856ad364e35" />
+		</providerDefinitions>
+		<log>
+		</log>
+		<firewallSupport />
+		<caching>
+		</caching>
+		<security>
+			<ipSecurity />
+			<requestFiltering>
+				<hiddenSegments>
+					<add segment="_vti_bin" />
+				</hiddenSegments>
+			</requestFiltering>
+			<authorization />
+		</security>
+	</system.ftpServer>
+	<location path="" overrideMode="Allow">
+		<system.webServer>
+			<handlers accessPolicy="Read, Script">
+				<add name="svc-Integrated-4.0" path="*.svc" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="svc-Integrated" path="*.svc" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="svc-ISAPI-4.0_64bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+				<add name="svc-ISAPI-4.0_32bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+				<add name="svc-ISAPI-2.0-64" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+				<add name="svc-ISAPI-2.0" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+				<add name="rules-Integrated-4.0" path="*.rules" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="xoml-Integrated-4.0" path="*.xoml" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="rules-Integrated" path="*.rules" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="xoml-Integrated" path="*.xoml" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" />
+				<add name="ASPClassic" path="*.asp" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%windir%\system32\inetsrv\asp.dll" resourceType="File" />
+				<add name="SecurityCertificate" path="*.cer" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%windir%\system32\inetsrv\asp.dll" resourceType="File" />
+				<add name="ISAPI-dll" path="*.dll" verb="*" modules="IsapiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+				<add name="AXD-ISAPI-4.0_64bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="PageHandlerFactory-ISAPI-4.0_64bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="SimpleHandlerFactory-ISAPI-4.0_64bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="WebServiceHandlerFactory-ISAPI-4.0_64bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_64bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_64bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="aspq-ISAPI-4.0_64bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="cshtm-ISAPI-4.0_64bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="cshtml-ISAPI-4.0_64bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="vbhtm-ISAPI-4.0_64bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="vbhtml-ISAPI-4.0_64bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="TraceHandler-Integrated-4.0" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="WebAdminHandler-Integrated-4.0" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="AssemblyResourceLoader-Integrated-4.0" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="PageHandlerFactory-Integrated-4.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="SimpleHandlerFactory-Integrated-4.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="WebServiceHandlerFactory-Integrated-4.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="HttpRemotingHandlerFactory-rem-Integrated-4.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="HttpRemotingHandlerFactory-soap-Integrated-4.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="aspq-Integrated-4.0" path="*.aspq" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="cshtm-Integrated-4.0" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="cshtml-Integrated-4.0" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="vbhtm-Integrated-4.0" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="vbhtml-Integrated-4.0" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="ScriptHandlerFactoryAppServices-Integrated-4.0" path="*_AppService.axd" verb="*" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="ScriptResourceIntegrated-4.0" path="*ScriptResource.axd" verb="GET,HEAD" type="System.Web.Handlers.ScriptResourceHandler, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+				<add name="AXD-ISAPI-4.0_32bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="PageHandlerFactory-ISAPI-4.0_32bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="SimpleHandlerFactory-ISAPI-4.0_32bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="WebServiceHandlerFactory-ISAPI-4.0_32bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_32bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_32bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="aspq-ISAPI-4.0_32bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="cshtm-ISAPI-4.0_32bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="cshtml-ISAPI-4.0_32bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="vbhtm-ISAPI-4.0_32bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="vbhtml-ISAPI-4.0_32bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="TraceHandler-Integrated" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="WebAdminHandler-Integrated" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="AssemblyResourceLoader-Integrated" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="PageHandlerFactory-Integrated" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="SimpleHandlerFactory-Integrated" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="WebServiceHandlerFactory-Integrated" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Services.Protocols.WebServiceHandlerFactory, System.Web.Services, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="HttpRemotingHandlerFactory-rem-Integrated" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="HttpRemotingHandlerFactory-soap-Integrated" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+				<add name="AXD-ISAPI-2.0" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="PageHandlerFactory-ISAPI-2.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="SimpleHandlerFactory-ISAPI-2.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="WebServiceHandlerFactory-ISAPI-2.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+				<add name="AXD-ISAPI-2.0-64" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="PageHandlerFactory-ISAPI-2.0-64" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="SimpleHandlerFactory-ISAPI-2.0-64" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="WebServiceHandlerFactory-ISAPI-2.0-64" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0-64" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0-64" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+				<add name="CGI-exe" path="*.exe" verb="*" modules="CgiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+				<add name="SSINC-stm" path="*.stm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+				<add name="SSINC-shtm" path="*.shtm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+				<add name="SSINC-shtml" path="*.shtml" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+				<add name="TRACEVerbHandler" path="*" verb="TRACE" modules="ProtocolSupportModule" requireAccess="None" />
+				<add name="OPTIONSVerbHandler" path="*" verb="OPTIONS" modules="ProtocolSupportModule" requireAccess="None" />
+				<add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+				<add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+				<add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" responseBufferLimit="0" />
+				<add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
+			</handlers>
+			<modules>
+				<add name="HttpCacheModule" lockItem="true" />
+				<add name="StaticCompressionModule" lockItem="true" />
+				<add name="DefaultDocumentModule" lockItem="true" />
+				<add name="DirectoryListingModule" lockItem="true" />
+				<add name="IsapiFilterModule" lockItem="true" />
+				<add name="ProtocolSupportModule" lockItem="true" />
+				<add name="StaticFileModule" lockItem="true" />
+				<add name="AnonymousAuthenticationModule" lockItem="true" />
+				<add name="UrlAuthorizationModule" lockItem="true" />
+				<add name="BasicAuthenticationModule" lockItem="true" />
+				<add name="WindowsAuthenticationModule" lockItem="true" />
+				<add name="IpRestrictionModule" lockItem="true" />
+				<add name="RequestFilteringModule" lockItem="true" />
+				<add name="CustomErrorModule" lockItem="true" />
+				<add name="IsapiModule" lockItem="true" />
+				<add name="HttpLoggingModule" lockItem="true" />
+				<add name="FailedRequestsTracingModule" lockItem="true" />
+				<add name="ConfigurationValidationModule" lockItem="true" />
+				<add name="OutputCache" type="System.Web.Caching.OutputCacheModule" preCondition="managedHandler" />
+				<add name="Session" type="System.Web.SessionState.SessionStateModule" preCondition="managedHandler" />
+				<add name="WindowsAuthentication" type="System.Web.Security.WindowsAuthenticationModule" preCondition="managedHandler" />
+				<add name="FormsAuthentication" type="System.Web.Security.FormsAuthenticationModule" preCondition="managedHandler" />
+				<add name="DefaultAuthentication" type="System.Web.Security.DefaultAuthenticationModule" preCondition="managedHandler" />
+				<add name="RoleManager" type="System.Web.Security.RoleManagerModule" preCondition="managedHandler" />
+				<add name="UrlAuthorization" type="System.Web.Security.UrlAuthorizationModule" preCondition="managedHandler" />
+				<add name="FileAuthorization" type="System.Web.Security.FileAuthorizationModule" preCondition="managedHandler" />
+				<add name="AnonymousIdentification" type="System.Web.Security.AnonymousIdentificationModule" preCondition="managedHandler" />
+				<add name="Profile" type="System.Web.Profile.ProfileModule" preCondition="managedHandler" />
+				<add name="UrlMappingsModule" type="System.Web.UrlMappingsModule" preCondition="managedHandler" />
+				<add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
+				<add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+				<add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
+				<add name="ServiceModel-4.0" type="System.ServiceModel.Activation.ServiceHttpModule, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+			</modules>
+		</system.webServer>
+	</location>
+</configuration>

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteMultiAppWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteMultiAppWebApplication.cs
@@ -1,0 +1,115 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+
+/// <summary>
+/// Hosts two copies of one ASP.NET Framework application as two application elements under a single
+/// Hosted Web Core site and application pool: one process, two AppDomains, two agents. Application
+/// one stays the site root ("/") and is staged entirely by the base class; this class adds only the
+/// second application, mounted at SecondAppUrlPath.
+/// </summary>
+public class RemoteMultiAppWebApplication : RemoteWebApplication
+{
+    private const string MultiApplicationHostConfigFileName = @"applicationHost.MultiApp.config";
+
+    private const string SecondAppPhysicalPathToken = "NEWRELIC_APP2_PHYSICAL_PATH";
+
+    private readonly string _secondApplicationDirectoryName;
+
+    /// <summary>
+    /// The name the second application reports to the collector. Written into that copy's own
+    /// Web.config, mirroring what the base class does with AppName for application one.
+    /// </summary>
+    public string SecondAppName { get; set; }
+
+    /// <summary>
+    /// URL path the second application is mounted at, with no leading slash. Must match the path
+    /// attribute of the second application element in applicationHost.MultiApp.config.
+    /// </summary>
+    public string SecondAppUrlPath { get { return "app2"; } }
+
+    public string DestinationSecondApplicationDirectoryPath { get { return Path.Combine(DestinationRootDirectoryPath, _secondApplicationDirectoryName); } }
+
+    private string DestinationSecondApplicationWebConfigFilePath { get { return Path.Combine(DestinationSecondApplicationDirectoryPath, "Web.config"); } }
+
+    private string DestinationMultiApplicationHostConfigFilePath { get { return Path.Combine(Path.GetDirectoryName(DestinationApplicationHostConfigFilePath), MultiApplicationHostConfigFileName); } }
+
+    public RemoteMultiAppWebApplication(string applicationDirectoryName, ApplicationType applicationType)
+        : base(applicationDirectoryName, applicationType)
+    {
+        _secondApplicationDirectoryName = applicationDirectoryName + "_app2";
+        SecondAppName = _secondApplicationDirectoryName;
+    }
+
+    public override void CopyToRemote()
+    {
+        // Stages application one, copies the Hosted Web Core host directory (which brings
+        // applicationHost.MultiApp.config with it), and reaches the override below through virtual
+        // dispatch. Also appends HostedWebCore.exe to the newrelic.config process allow-list, which
+        // is per-process and so is already correct for two applications.
+        base.CopyToRemote();
+
+        StageSecondApplication();
+    }
+
+    protected override void SetUpApplicationHostConfig()
+    {
+        InstallMultiApplicationHostConfig();
+
+        // Sets application one's virtualDirectory physicalPath, the site binding, and the pool name.
+        // Unchanged from the base behavior: the XmlUtils node walk lands on the FIRST matching child,
+        // which is the root application, and the port and pool writes walk to different children.
+        base.SetUpApplicationHostConfig();
+
+        SetSecondApplicationPhysicalPath();
+    }
+
+    /// <summary>
+    /// HostedWebCore.exe resolves its host config as AssemblyDirectory + "\applicationHost.config"
+    /// (HostedWebCore.cs:35-42), so the two-application variant has to replace that file rather than
+    /// be pointed at.
+    /// </summary>
+    private void InstallMultiApplicationHostConfig()
+    {
+        File.Copy(DestinationMultiApplicationHostConfigFilePath, DestinationApplicationHostConfigFilePath, true);
+    }
+
+    /// <summary>
+    /// A token replace rather than an XML edit, because XmlUtils.ModifyOrCreateXmlAttributes can only
+    /// reach the first matching node and so cannot target the second application element.
+    /// </summary>
+    private void SetSecondApplicationPhysicalPath()
+    {
+        var contents = File.ReadAllText(DestinationApplicationHostConfigFilePath);
+        contents = contents.Replace(SecondAppPhysicalPathToken, DestinationSecondApplicationDirectoryPath);
+        File.WriteAllText(DestinationApplicationHostConfigFilePath, contents);
+    }
+
+    private void StageSecondApplication()
+    {
+        Directory.CreateDirectory(DestinationSecondApplicationDirectoryPath);
+        CommonUtils.CopyDirectory(SourceApplicationDirectoryPath, DestinationSecondApplicationDirectoryPath);
+
+        SetSecondAppNameInWebConfig();
+    }
+
+    private void SetSecondAppNameInWebConfig()
+    {
+        var nodes = new[]
+        {
+            "configuration",
+            "appSettings",
+            "add",
+        };
+        var attributes = new[]
+        {
+            new KeyValuePair<string, string>("key", "NewRelic.AppName"),
+            new KeyValuePair<string, string>("value", SecondAppName),
+        };
+        XmlUtils.ModifyOrCreateXmlAttributes(DestinationSecondApplicationWebConfigFilePath, string.Empty, nodes, attributes);
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
@@ -28,7 +28,7 @@ public class RemoteWebApplication : RemoteApplication
 
     private string DestinationHostedWebCoreExecutablePath { get { return Path.Combine(DestinationHostedWebCoreDirectoryPath, HostedWebCoreProcessName); } }
 
-    private string DestinationApplicationHostConfigFilePath { get { return Path.Combine(DestinationHostedWebCoreDirectoryPath, "applicationHost.config"); } }
+    protected string DestinationApplicationHostConfigFilePath { get { return Path.Combine(DestinationHostedWebCoreDirectoryPath, "applicationHost.config"); } }
 
     private string DestinationApplicationWebConfigFilePath { get { return Path.Combine(DestinationApplicationDirectoryPath, "Web.config"); } }
 
@@ -117,7 +117,7 @@ public class RemoteWebApplication : RemoteApplication
         XmlUtils.ModifyOrCreateXmlAttributes(DestinationApplicationWebConfigFilePath, string.Empty, nodes, attributes);
     }
 
-    private void SetUpApplicationHostConfig()
+    protected virtual void SetUpApplicationHostConfig()
     {
         SetSiteVirtualDirectoryInApplicationHostConfig();
         SetSitePortInApplicationHostConfig();

--- a/tests/Agent/IntegrationTests/IntegrationTests/MultiAppDomain/MultiAppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/MultiAppDomain/MultiAppDomainCachingTests.cs
@@ -1,0 +1,301 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.MultiAppDomain;
+
+/// <summary>
+/// Two ASP.NET Framework applications in one Hosted Web Core process: one application pool, one
+/// process, two AppDomains, two agents. Verifies that neither agent's state leaks into the other
+/// under both AppDomain-caching arms.
+///
+/// This matters on this branch specifically. The AppDomain-caching fast path here reads and writes
+/// static fields on a profiler-injected type (__NRInitializer__), and on .NET Framework mscorlib is
+/// always loaded domain-neutral, so there is one field definition and one shared JIT'd helper body
+/// but a separate field VALUE per AppDomain. The design is correct by construction; nothing in this
+/// repository exercised it, because the storage that ships on main is AppDomain.GetData/SetData,
+/// which is per-domain by API contract rather than by runtime indirection.
+/// </summary>
+public abstract class MultiAppDomainCachingTestsBase : NewRelicIntegrationTest<MultiAppDomainWebApplicationFixture>
+{
+    // Generous relative to the sibling AppDomainCachingTestsBase, which allows 2 minutes total for a
+    // console fixture. Two agents connect behind one Hosted Web Core cold start here.
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromMinutes(3);
+    private static readonly TimeSpan MetricHarvestTimeout = TimeSpan.FromMinutes(2);
+
+    protected readonly MultiAppDomainWebApplicationFixture _fixture;
+
+    private readonly bool _appDomainCachingDisabled;
+
+    private readonly string _expectedCallingStrategy;
+
+    protected MultiAppDomainCachingTestsBase(
+        MultiAppDomainWebApplicationFixture fixture,
+        ITestOutputHelper output,
+        bool appDomainCachingDisabled,
+        string expectedCallingStrategy) : base(fixture)
+    {
+        _fixture = fixture;
+        _appDomainCachingDisabled = appDomainCachingDisabled;
+        _expectedCallingStrategy = expectedCallingStrategy;
+        _fixture.TestLogger = output;
+
+        // Arm A leaves the variable completely UNSET, which is the state every real customer runs and
+        // a different parse path from an explicitly present "false". This diverges deliberately from
+        // AppDomainCachingTestsBase, which sets the variable in both of its arms.
+        if (_appDomainCachingDisabled)
+        {
+            _fixture.SetAdditionalEnvironmentVariable("NEW_RELIC_DISABLE_APPDOMAIN_CACHING", "true");
+        }
+
+        _fixture.Actions(
+            setupConfiguration: () =>
+            {
+                // One newrelic.config serves both AppDomains, so one modifier covers both.
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);   // assertions 1 and 5
+                configModifier.ForceTransactionTraces();                 // assertion 2
+                configModifier.SetLogLevel("debug");
+            },
+            exerciseApplication: () =>
+            {
+                // Four steps, each killing a distinct failure mode. Do not reorder or drop any.
+
+                // 1. Cold start cannot be allowed to eat a counted request.
+                _fixture.WarmUpRootApp();
+                _fixture.WarmUpSecondApp();
+
+                // 2. Both agents connected before any counted request removes the init race.
+                _fixture.RootAppAgentLog.WaitForConnect(ConnectTimeout);
+                _fixture.SecondAppAgentLog.WaitForConnect(ConnectTimeout);
+
+                // 3. Asymmetric load, so a leak cannot hide behind equal counts.
+                for (var i = 0; i < MultiAppDomainWebApplicationFixture.RootAppRequestCount; i++)
+                {
+                    _fixture.GetRootAppCustomAttributes();
+                }
+
+                for (var i = 0; i < MultiAppDomainWebApplicationFixture.SecondAppRequestCount; i++)
+                {
+                    _fixture.GetSecondAppCustomAttributes();
+                }
+
+                // 4. Gate on the harvested aggregate rather than on a sleep, so harvest lag cannot
+                //    produce a short count that looks like a leak.
+                _fixture.RootAppAgentLog.WaitForMetricAggregateCallCount(
+                    MultiAppDomainWebApplicationFixture.ExpectedTransactionMetricName,
+                    MultiAppDomainWebApplicationFixture.RootAppRequestCount,
+                    MetricHarvestTimeout);
+
+                _fixture.SecondAppAgentLog.WaitForMetricAggregateCallCount(
+                    MultiAppDomainWebApplicationFixture.ExpectedTransactionMetricName,
+                    MultiAppDomainWebApplicationFixture.SecondAppRequestCount,
+                    MetricHarvestTimeout);
+            });
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void EachAppReportsOnlyItsOwnTransactions()
+    {
+        var rootCallCount = GetUnscopedCallCount(_fixture.RootAppAgentLog, MultiAppDomainWebApplicationFixture.ExpectedTransactionMetricName);
+        var secondCallCount = GetUnscopedCallCount(_fixture.SecondAppAgentLog, MultiAppDomainWebApplicationFixture.ExpectedTransactionMetricName);
+
+        // EXACT, never >=. A >= comparison would pass while a leak inflated the other app's count.
+        Assert.Multiple(
+            () => Assert.Equal((ulong)MultiAppDomainWebApplicationFixture.RootAppRequestCount, rootCallCount),
+            () => Assert.Equal((ulong)MultiAppDomainWebApplicationFixture.SecondAppRequestCount, secondCallCount));
+    }
+
+    private static ulong GetUnscopedCallCount(AgentLogFile agentLog, string metricName)
+    {
+        ulong total = 0;
+
+        var matches = agentLog.GetMetrics()
+            .Where(metric => metric.MetricSpec.Name == metricName && string.IsNullOrEmpty(metric.MetricSpec.Scope));
+
+        foreach (var metric in matches)
+        {
+            total += metric.Values.CallCount;
+        }
+
+        return total;
+    }
+
+    [Fact]
+    public void EachAppReportsOnlyItsOwnCustomAttributes()
+    {
+        AssertEveryMarkedTraceCarries(
+            _fixture.RootAppAgentLog,
+            MultiAppDomainWebApplicationFixture.RootAppMarkerValue,
+            MultiAppDomainWebApplicationFixture.SecondAppMarkerValue);
+
+        AssertEveryMarkedTraceCarries(
+            _fixture.SecondAppAgentLog,
+            MultiAppDomainWebApplicationFixture.SecondAppMarkerValue,
+            MultiAppDomainWebApplicationFixture.RootAppMarkerValue);
+    }
+
+    private static void AssertEveryMarkedTraceCarries(AgentLogFile agentLog, string expectedValue, string forbiddenValue)
+    {
+        var markedSamples = agentLog.GetTransactionSamples()
+            .Where(sample => sample.TraceData.Attributes
+                .GetByType(TransactionTraceAttributeType.User)
+                .ContainsKey(MultiAppDomainWebApplicationFixture.AppMarkerAttributeName))
+            .ToList();
+
+        // Traces yield roughly one sample per application per harvest rather than one per request,
+        // which is enough for a presence/absence assertion but means the count is not asserted here.
+        Assert.NotEmpty(markedSamples);
+
+        foreach (var sample in markedSamples)
+        {
+            Assertions.TransactionTraceHasAttributes(
+                new Dictionary<string, string> { { MultiAppDomainWebApplicationFixture.AppMarkerAttributeName, expectedValue } },
+                TransactionTraceAttributeType.User,
+                sample);
+
+            var userAttributes = sample.TraceData.Attributes.GetByType(TransactionTraceAttributeType.User);
+            Assert.NotEqual(forbiddenValue, userAttributes[MultiAppDomainWebApplicationFixture.AppMarkerAttributeName]?.ToString());
+        }
+    }
+
+    [Fact]
+    public void TwoIndependentAgentsStartOnePerAppDomain()
+    {
+        // AgentManager.cs:238 logs: "The New Relic .NET Agent v<version> started (pid <n>) on app
+        // domain '<AppDomainAppVirtualPath ?? AppDomainName>'". Asserting the virtual path also
+        // exercises HttpRuntime.AppDomainAppVirtualPath reaching the agent, without the test
+        // depending on it for naming.
+        var rootStartLines = _fixture.RootAppAgentLog.TryGetLogLines(AgentStartedOnAppDomainRegex("/")).ToList();
+        var secondStartLines = _fixture.SecondAppAgentLog.TryGetLogLines(AgentStartedOnAppDomainRegex("/app2")).ToList();
+
+        // Single, not NotEmpty: exactly one agent per AppDomain is part of what is being asserted.
+        Assert.Multiple(
+            () => Assert.Single(rootStartLines),
+            () => Assert.Single(secondStartLines));
+    }
+
+    private static string AgentStartedOnAppDomainRegex(string appDomainVirtualPath)
+    {
+        return AgentLogBase.InfoLogLinePrefixRegex
+            + @"The New Relic .NET Agent v.* started \(pid \d+\) on app domain '"
+            + Regex.Escape(appDomainVirtualPath)
+            + @"'";
+    }
+
+    [Fact]
+    public void EachAppConnectsUnderItsOwnApplicationName()
+    {
+        var rootAppNames = _fixture.RootAppAgentLog.GetConnectData().AppNames.ToList();
+        var secondAppNames = _fixture.SecondAppAgentLog.GetConnectData().AppNames.ToList();
+
+        Assert.Multiple(
+            () => Assert.Contains(MultiAppDomainWebApplicationFixture.RootAppReportedName, rootAppNames),
+            () => Assert.DoesNotContain(MultiAppDomainWebApplicationFixture.SecondAppReportedName, rootAppNames),
+            () => Assert.Contains(MultiAppDomainWebApplicationFixture.SecondAppReportedName, secondAppNames),
+            () => Assert.DoesNotContain(MultiAppDomainWebApplicationFixture.RootAppReportedName, secondAppNames));
+    }
+
+    [Fact]
+    public void AppDomainCachingSupportabilityMetricAgreesWithArmInBothLogs()
+    {
+        const string metricName = "Supportability/DotNET/AppDomainCaching/Disabled";
+
+        var rootMetrics = _fixture.RootAppAgentLog.GetMetrics().ToList();
+        var secondMetrics = _fixture.SecondAppAgentLog.GetMetrics().ToList();
+
+        if (_appDomainCachingDisabled)
+        {
+            Assert.Multiple(
+                () => Assert.Contains(rootMetrics, metric => metric.MetricSpec.Name == metricName),
+                () => Assert.Contains(secondMetrics, metric => metric.MetricSpec.Name == metricName));
+        }
+        else
+        {
+            Assert.Multiple(
+                () => Assert.DoesNotContain(rootMetrics, metric => metric.MetricSpec.Name == metricName),
+                () => Assert.DoesNotContain(secondMetrics, metric => metric.MetricSpec.Name == metricName));
+        }
+    }
+
+    [Fact]
+    public void BothAgentsStartAndStopCleanly()
+    {
+        // Verified strings, not guesses:
+        //   AgentManager.cs:68  Log.Error(exception, "There was an error initializing the agent")
+        //   AgentManager.cs:427 Log.Info(e, "Unexpected exception during agent shutdown")  <- INFO,
+        //                       not ERROR, so it must be matched at the INFO prefix.
+        // The two exception type names are scenario-specific cross-domain failures that would appear
+        // in a logged stack trace; they are matched level-agnostically.
+        var forbiddenPatterns = new[]
+        {
+            AgentLogBase.ErrorLogLinePrefixRegex + @"There was an error initializing the agent",
+            AgentLogBase.InfoLogLinePrefixRegex + @"Unexpected exception during agent shutdown",
+            @"AppDomainUnloadedException",
+            @"RemotingException",
+        };
+
+        var logs = new Dictionary<string, AgentLogFile>
+        {
+            { "/", _fixture.RootAppAgentLog },
+            { "/app2", _fixture.SecondAppAgentLog },
+        };
+
+        foreach (var log in logs)
+        {
+            foreach (var pattern in forbiddenPatterns)
+            {
+                Assert.Empty(log.Value.TryGetLogLines(pattern));
+            }
+
+            // Positive half: each agent reached its own clean shutdown line
+            // (AgentManager.cs:436), which is what proves two teardowns both completed.
+            Assert.Single(log.Value.TryGetLogLines(AgentShutdownOnAppDomainRegex(log.Key)).ToList());
+        }
+    }
+
+    private static string AgentShutdownOnAppDomainRegex(string appDomainVirtualPath)
+    {
+        return AgentLogBase.InfoLogLinePrefixRegex
+            + @"The New Relic .NET Agent v.* has shutdown \(pid \d+\) on app domain '"
+            + Regex.Escape(appDomainVirtualPath)
+            + @"'";
+    }
+
+    [Fact]
+    public void ProfilerUsesTheCallingStrategyThisArmSelected()
+    {
+        // LOAD-BEARING. This is the only assertion that proves the two arms take different paths.
+        // Every other assertion in this class would pass identically under either strategy, so if the
+        // environment variable stopped reaching the child process both arms would go green while the
+        // disabled path went uncovered.
+        Assert.Contains(
+            $"Calls to the managed agent will use the calling strategy - {_expectedCallingStrategy}",
+            _fixture.ProfilerLog.GetFullLogAsString());
+    }
+}
+
+public class MultiAppDomainCachingEnabledTests : MultiAppDomainCachingTestsBase
+{
+    public MultiAppDomainCachingEnabledTests(MultiAppDomainWebApplicationFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, false, "AppDomain Fallback Cache")
+    {
+    }
+}
+
+public class MultiAppDomainCachingDisabledTests : MultiAppDomainCachingTestsBase
+{
+    public MultiAppDomainCachingDisabledTests(MultiAppDomainWebApplicationFixture fixture, ITestOutputHelper output)
+        : base(fixture, output, true, "Reflection")
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/MultiAppDomain/MultiAppDomainWebApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/MultiAppDomain/MultiAppDomainWebApplicationFixture.cs
@@ -1,0 +1,115 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.MultiAppDomain;
+
+public class MultiAppDomainWebApplicationFixture : RemoteApplicationFixture
+{
+    public const string RootAppReportedName = "MultiAppDomainTestAppRoot";
+    public const string SecondAppReportedName = "MultiAppDomainTestAppTwo";
+
+    public const string ExpectedTransactionMetricName = @"WebTransaction/MVC/DefaultController/CustomParameters";
+
+    public const string AppMarkerAttributeName = "appMarker";
+    public const string RootAppMarkerValue = "app_one";
+    public const string SecondAppMarkerValue = "app_two";
+
+    // Asymmetric on purpose, so a leak cannot hide behind equal counts.
+    public const int RootAppRequestCount = 3;
+    public const int SecondAppRequestCount = 1;
+
+    // Explicit and DISJOINT. Without them AgentLogFile falls back to the "newrelic_agent_*.log" glob
+    // (AgentLogFile.cs:36-46), which silently returns whichever of the two files was written most
+    // recently instead of throwing, making every assertion nondeterministic.
+    private const string RootAppLogFileNamePattern = "newrelic_agent_*ROOT.log";
+    private const string SecondAppLogFileNamePattern = "newrelic_agent_*app2.log";
+
+    private static readonly TimeSpan WarmUpTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan WarmUpRetryInterval = TimeSpan.FromSeconds(5);
+
+    private AgentLogFile _rootAppAgentLog;
+    private AgentLogFile _secondAppAgentLog;
+
+    private RemoteMultiAppWebApplication MultiAppApplication => (RemoteMultiAppWebApplication)RemoteApplication;
+
+    public AgentLogFile RootAppAgentLog => _rootAppAgentLog ??
+        (_rootAppAgentLog = new AgentLogFile(DestinationNewRelicLogFileDirectoryPath, TestLogger, RootAppLogFileNamePattern, Timing.TimeToWaitForLog));
+
+    public AgentLogFile SecondAppAgentLog => _secondAppAgentLog ??
+        (_secondAppAgentLog = new AgentLogFile(DestinationNewRelicLogFileDirectoryPath, TestLogger, SecondAppLogFileNamePattern, Timing.TimeToWaitForLog));
+
+    public MultiAppDomainWebApplicationFixture()
+        : base(new RemoteMultiAppWebApplication("BasicMvcApplication", ApplicationType.Bounded))
+    {
+        // Set BOTH names explicitly. RemoteApplication.AppName otherwise defaults to the
+        // CI_NEW_RELIC_APP_NAME environment variable when set and to the literal
+        // "IntegrationTestAppName" when not (RemoteApplication.cs:216-235), so the root application's
+        // reported name would vary between local and CI runs and assertion 4 could not know it.
+        MultiAppApplication.AppName = RootAppReportedName;
+        MultiAppApplication.SecondAppName = SecondAppReportedName;
+
+        // Assertion 6 reads the profiler log.
+        ProfilerLogExpected = true;
+    }
+
+    /// <summary>
+    /// Warms an application up on an endpoint that costs no metric: Default/Ignored calls
+    /// NewRelic.Api.Agent.NewRelic.IgnoreTransaction() (DefaultController.cs:38-42). This absorbs
+    /// ASP.NET compilation and agent initialization so that cold start cannot swallow a counted
+    /// request, which would yield 2 instead of 3 and read exactly like a leak.
+    /// </summary>
+    public void WarmUpRootApp()
+    {
+        WarmUp($"http://{DestinationServerName}:{Port}/Default/Ignored?data=warmup");
+    }
+
+    public void WarmUpSecondApp()
+    {
+        WarmUp($"http://{DestinationServerName}:{Port}/{MultiAppApplication.SecondAppUrlPath}/Default/Ignored?data=warmup");
+    }
+
+    public void GetRootAppCustomAttributes()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Default/CustomParameters"
+            + $"?key1={AppMarkerAttributeName}&value1={RootAppMarkerValue}&key2=k2&value2=v2";
+        GetStringAndAssertContains(address, "Worked");
+    }
+
+    public void GetSecondAppCustomAttributes()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/{MultiAppApplication.SecondAppUrlPath}/Default/CustomParameters"
+            + $"?key1={AppMarkerAttributeName}&value1={SecondAppMarkerValue}&key2=k2&value2=v2";
+        GetStringAndAssertContains(address, "Worked");
+    }
+
+    /// <summary>
+    /// Retries rather than issuing one request, following the BasicMvcApplicationTestFixture
+    /// .WaitForStartup precedent: a cold ASP.NET Framework application behind Hosted Web Core can
+    /// exceed the default HttpClient timeout on its very first request.
+    /// </summary>
+    private void WarmUp(string address)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < WarmUpTimeout)
+        {
+            try
+            {
+                GetStringAndAssertEqual(address, "warmup");
+                return;
+            }
+            catch (Exception)
+            {
+                Thread.Sleep(WarmUpRetryInterval);
+            }
+        }
+
+        Assert.Fail($"Application at {address} did not respond within {WarmUpTimeout.TotalMinutes:N0} minutes.");
+    }
+}


### PR DESCRIPTION
Adds a .NET Framework integration test that runs two ASP.NET applications in one IIS application pool (one Hosted Web Core process, two AppDomains) and asserts each application gets its own agent, connect, log file, transaction counts, and custom attributes, under both AppDomain-caching arms. Covers the profiler-injected static introduced on this branch from NR-602576, which nothing previously exercised across AppDomains.

Verified locally: both arms pass 7 assertions each (14 total, run concurrently with no interference). The calling-strategy assertion was mutation-tested to confirm it can actually fail. Regression check on the one shared-code edit (a visibility widening in `RemoteWebApplication`): `CustomAttributes` 16/16 and `BasicInstrumentation` 24/24 pass unchanged.