### PR TITLE
ci: harden the Dependabot CI trigger against branch-name script injection

### DIFF
--- a/.github/workflows/dependabot_ci_trigger.yml
+++ b/.github/workflows/dependabot_ci_trigger.yml
@@ -30,8 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Record pull request details
+        # Pass the event fields through env vars and reference them as shell
+        # variables, so a branch name can never be treated as shell syntax.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "Dependabot pull request #${{ github.event.pull_request.number }}"
-          echo "Head branch: ${{ github.event.pull_request.head.ref }}"
-          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "Dependabot pull request #$PR_NUMBER"
+          echo "Head branch: $HEAD_REF"
+          echo "Head SHA: $HEAD_SHA"
           echo "Dependabot Full CI Dispatch will launch All Solutions Build and Unit Tests for this branch."


### PR DESCRIPTION
Clears the Scorecard Dangerous-Workflow alert (script injection via `github.event.pull_request.head.ref`) in `dependabot_ci_trigger.yml` by passing the event fields through `env:` and reading them as shell variables. Same pattern already used in `dependabot_ci_dispatch.yml`. Logging output is unchanged.

The finding was not exploitable -- the job has `permissions: {}`, no checkout, no secrets, and is gated on `github.actor == 'dependabot[bot]'` -- but the fix is free and the alert is public.
