### PR TITLE
fix: skip SQL metadata comment injection for CommandType.StoredProcedure

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlMetadataCommentBuilder.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlMetadataCommentBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Data;
+
 namespace NewRelic.Agent.Extensions.Parsing;
 
 public static class SqlMetadataCommentBuilder
@@ -19,5 +21,13 @@ public static class SqlMetadataCommentBuilder
             return sql;
 
         return comment + sql;
+    }
+
+    public static bool ShouldSkipCommentForCommandType(CommandType commandType)
+    {
+        // CommandType.StoredProcedure means CommandText is a literal object identifier passed
+        // straight to the driver's RPC call, not parsed SQL. Prepending a comment corrupts the
+        // identifier and breaks the call ("Could not find stored procedure").
+        return commandType == CommandType.StoredProcedure;
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/SqlCommandWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/SqlCommandWrapper.cs
@@ -83,7 +83,8 @@ public abstract class SqlCommandWrapperBase : IWrapper
 
         var sql = sqlCommand.CommandText ?? string.Empty;
 
-        if (agent.Configuration.TransactionTracerSqlMetadataCommentsEnabled)
+        if (agent.Configuration.TransactionTracerSqlMetadataCommentsEnabled &&
+            !SqlMetadataCommentBuilder.ShouldSkipCommentForCommandType(sqlCommand.CommandType))
         {
             var comment = SqlMetadataCommentBuilder.BuildComment(agent.Configuration.EntityGuid);
             var commentedSql = SqlMetadataCommentBuilder.PrependCommentToSql(sql, comment);

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlMetadataCommentTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlMetadataCommentTests.cs
@@ -123,11 +123,144 @@ public abstract class MsSqlMetadataCommentTestsBase<TFixture> : NewRelicIntegrat
     }
 }
 
+public abstract class MsSqlMetadataCommentTestsStoredProcBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
+{
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _procedureNameWith;
+    private readonly string _procedureNameWithout;
+
+    public MsSqlMetadataCommentTestsStoredProcBase(TFixture fixture, ITestOutputHelper output, string exerciserName) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{exerciserName}/MsSqlParameterizedStoredProcedure";
+        _procedureNameWith = Utilities.GenerateProcedureName();
+        _procedureNameWithout = Utilities.GenerateProcedureName();
+
+        _fixture.AddCommand($"{exerciserName} MsSqlParameterizedStoredProcedure {_procedureNameWith} {_procedureNameWithout}");
+        _fixture.AddCommand($"{exerciserName} DropProcedure {_procedureNameWith}");
+        _fixture.AddCommand($"{exerciserName} DropProcedure {_procedureNameWithout}");
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+
+                configModifier.SetTransactionTracerExplainEnabled(true);
+                configModifier.ForceSqlTraces();
+                configModifier.SetTransactionTracerRecordSql("raw");
+                configModifier.SetTransactionTracerSqlMetadataCommentsEnabled(true);
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        const string commentPrefix = "/*nr_service_guid=\"";
+
+        // MsSqlParameterizedStoredProcedure also runs a CREATE OR ALTER PROCEDURE statement via
+        // EnsureProcedure (CommandType.Text) to set up the procedure before calling it. That setup
+        // statement is expected to still carry the comment -- it's not the CommandType.StoredProcedure
+        // call under test here, so it must be excluded from the "no comment" assertions below.
+        bool IsSetupStatement(string sql) => sql != null && sql.Contains("CREATE OR ALTER PROCEDURE", StringComparison.OrdinalIgnoreCase);
+
+        // SQL traces
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var tracesForTransaction = sqlTraces
+            .Where(t => t.TransactionName == _expectedTransactionName)
+            .Where(t => !IsSetupStatement(t.Sql))
+            .ToList();
+
+        Assert.True(tracesForTransaction.Count > 0, $"No stored procedure SQL traces found for transaction {_expectedTransactionName}");
+
+        foreach (var trace in tracesForTransaction)
+        {
+            Assert.False(
+                trace.Sql.StartsWith(commentPrefix, StringComparison.Ordinal),
+                $"Expected SQL trace for a stored procedure call to NOT have the SQL metadata comment, but was: {trace.Sql}");
+        }
+
+        // Transaction trace segments
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        Assert.NotNull(transactionSample);
+
+        var sqlSegments = GetAllSegments(transactionSample.TraceData.RootSegment)
+            .Where(s => s.Parameters != null && s.Parameters.ContainsKey("sql"))
+            .Where(s => !IsSetupStatement(s.Parameters["sql"] as string))
+            .ToList();
+
+        Assert.True(sqlSegments.Count > 0, "No stored procedure SQL segments found in transaction trace");
+
+        foreach (var segment in sqlSegments)
+        {
+            var sql = segment.Parameters["sql"] as string;
+            Assert.False(
+                sql?.StartsWith(commentPrefix, StringComparison.Ordinal) == true,
+                $"Expected transaction trace segment SQL for a stored procedure call to NOT have the SQL metadata comment, but was: {sql}");
+        }
+
+        // Span events
+        var dbSpans = _fixture.AgentLog.GetSpanEvents()
+            .Where(s => s.AgentAttributes.ContainsKey("db.statement"))
+            .Where(s => !IsSetupStatement(s.AgentAttributes["db.statement"] as string))
+            .ToList();
+
+        Assert.True(dbSpans.Count > 0, "No stored procedure span events with db.statement found");
+
+        foreach (var span in dbSpans)
+        {
+            var sql = span.AgentAttributes["db.statement"] as string;
+            Assert.False(
+                sql?.StartsWith(commentPrefix, StringComparison.Ordinal) == true,
+                $"Expected span event db.statement for a stored procedure call to NOT have the SQL metadata comment, but was: {sql}");
+        }
+    }
+
+    private static IEnumerable<TransactionTraceSegment> GetAllSegments(TransactionTraceSegment segment)
+    {
+        yield return segment;
+        if (segment.ChildSegments == null)
+            yield break;
+        foreach (var child in segment.ChildSegments)
+            foreach (var descendant in GetAllSegments(child))
+                yield return descendant;
+    }
+}
+
 #region System.Data.SqlClient
 
 public class MsSqlMetadataCommentTests_SystemData_FWLatest : MsSqlMetadataCommentTestsBase<ConsoleDynamicMethodFixtureFWLatest>
 {
     public MsSqlMetadataCommentTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, "SystemDataExerciser")
+    {
+    }
+}
+
+public class MsSqlMetadataCommentTestsStoredProc_SystemData_FWLatest : MsSqlMetadataCommentTestsStoredProcBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlMetadataCommentTestsStoredProc_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
         : base(fixture, output, "SystemDataExerciser")
     {
     }
@@ -164,6 +297,38 @@ public class MsSqlMetadataCommentTests_MicrosoftDataSqlClient_CoreOldest : MsSql
 public class MsSqlMetadataCommentTests_MicrosoftDataSqlClient_CoreLatest : MsSqlMetadataCommentTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
 {
     public MsSqlMetadataCommentTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_FWLatest : MsSqlMetadataCommentTestsStoredProcBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_FW462 : MsSqlMetadataCommentTestsStoredProcBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output, "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_CoreOldest : MsSqlMetadataCommentTestsStoredProcBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_CoreLatest : MsSqlMetadataCommentTestsStoredProcBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlMetadataCommentTestsStoredProc_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
         : base(fixture, output, "MicrosoftDataSqlClientExerciser")
     {
     }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlMetadataCommentBuilderTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlMetadataCommentBuilderTests.cs
@@ -1,0 +1,21 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Data;
+using NewRelic.Agent.Extensions.Parsing;
+using NUnit.Framework;
+
+namespace ParsingTests;
+
+[TestFixture]
+public class SqlMetadataCommentBuilderTests
+{
+    [Test]
+    [TestCase(CommandType.StoredProcedure, ExpectedResult = true)]
+    [TestCase(CommandType.Text, ExpectedResult = false)]
+    [TestCase(CommandType.TableDirect, ExpectedResult = false)]
+    public bool ShouldSkipCommentForCommandType_ReturnsExpectedResult(CommandType commandType)
+    {
+        return SqlMetadataCommentBuilder.ShouldSkipCommentForCommandType(commandType);
+    }
+}


### PR DESCRIPTION
## Description

When `sqlMetadataCommentsEnabled="true"`, the agent prepends `/*nr_service_guid="<guid>"*/` to `CommandText` before execution. For calls using `CommandType.StoredProcedure` with a bare procedure name, the ADO.NET driver treats `CommandText` as a literal object identifier (not parsed SQL) when building the RPC call. Prepending a comment corrupts that identifier, producing `Could not find stored procedure ''` — reported against agent v10.53 in a customer support case (NR-604930).

This was reproduced and confirmed via a standalone repro app exercising both `Microsoft.Data.SqlClient` and `System.Data.SqlClient`: every `CommandType.StoredProcedure` call failed with the exact customer-reported error when the feature was enabled, while `CommandType.Text` calls (including literal `EXEC proc ...` syntax) were unaffected.

**Fix:** skip comment injection specifically when `CommandType.StoredProcedure` is set, via a new `SqlMetadataCommentBuilder.ShouldSkipCommentForCommandType` guard checked in `SqlCommandWrapper.BeforeWrappedMethod`. Since `SqlCommandWrapper` is shared across vendors (MSSQL, MySQL, Oracle, Postgres), the fix applies uniformly — all of them have the same underlying problem with `CommandType.StoredProcedure`. No other instrumentation behavior changes for stored proc calls (segment creation, explain plans, SQL traces still work as before, just against the original unmodified `CommandText`).

## Testing

- New unit tests (`SqlMetadataCommentBuilderTests.cs`) cover the new guard method directly.
- Existing cross-agent tests (`SqlMetadataCommentsCrossAgentTests`) confirmed unaffected — `BuildComment`/`PrependCommentToSql` were not touched.
- New integration test coverage added to `MsSqlMetadataCommentTests.cs`, asserting the inverse of the existing test (no comment on stored proc calls, while the `CREATE OR ALTER PROCEDURE` setup statement — a `CommandType.Text` call — still correctly gets commented). Run locally against the unbounded Docker SQL Server services and confirmed passing.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)