### PR TITLE
ci: Scope actions:write permission to the job level in dependabot_ci_dispatch

### DIFF
--- a/.github/workflows/dependabot_ci_dispatch.yml
+++ b/.github/workflows/dependabot_ci_dispatch.yml
@@ -38,12 +38,14 @@ on:
     types: [completed]
 
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   dispatch:
     name: Dispatch All Solutions Build for the Dependabot branch
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.actor.login == 'dependabot[bot]' &&


### PR DESCRIPTION
CodeQL flags top-level write permissions; move actions:write onto the dispatch job (the only job, and the only one that needs it) and set a read-only default at the workflow level.  This should resolve https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/677

