### PR TITLE
test: Gate Azure Function trigger tests on the metric they assert

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
@@ -35,6 +35,13 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
                 _fixture.PostToAzureFuncTool("QueueTriggerFunction", "test message");
 
                 _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(2));
+
+                // The test asserts on metrics, so wait for the metric the trigger function records rather than for
+                // any metric harvest. A harvest that fired before the function ran does not contain these metrics.
+                if (_fixture.AzureFunctionModeEnabled)
+                {
+                    _fixture.AgentLog.WaitForMetricAggregateCallCount("Supportability/Dotnet/AzureFunction/Trigger/Queue", 1, TimeSpan.FromMinutes(2));
+                }
             }
         );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
@@ -62,7 +62,12 @@ public abstract class AzureFunctionServiceBusTriggerTestsBase<TFixture> : NewRel
                 _fixture.Post("api/HttpTrigger_SendServiceBusMessage", "test message");
 
                 _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
+
+                // The Service Bus trigger function runs asynchronously, after the message has made a round trip
+                // through the Service Bus. Waiting for the first metric harvest is not enough: that harvest can
+                // complete while only the HTTP send side has been recorded. Wait for the receive-side supportability
+                // metric instead, which proves the trigger function ran and its metrics reached the log.
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("Supportability/Dotnet/AzureFunction/Trigger/ServiceBus", 1, TimeSpan.FromMinutes(2));
             }
         );
 


### PR DESCRIPTION
Fixes a recurring flake in the `AzureFunction` integration test namespace, seen most recently as `AzureFunctionServiceBusTriggerTestInProcCoreOldest.ServiceBusTriggerFunctionTest` failing with `Metric named Supportability/Dotnet/AzureFunction/Trigger/ServiceBus scoped to nothing was not found in the metric payload`.

Both tests waited on `WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, ...)` or on nothing at all before asserting on metrics. That helper defaults to `minimumCount = 1`, so it is satisfied by the first `metric_data` harvest anywhere in the log - which can complete while only the HTTP send side has been recorded, before the Service Bus round trip finishes and the trigger function runs. The two tests now wait on the trigger's own supportability metric via `WaitForMetricAggregateCallCount`, which proves the trigger function ran and its metrics reached the log.

`AzureFunctionHttpTriggerTests` has the same weak wait but its invocations are synchronous; left unchanged.
