### PR TITLE
ci: Add hysteresis to markdown link check ticketing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thank you for submitting a pull request.  Please review our [contributing guidelines](../CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).
+Thank you for submitting a pull request.  Please review our [contributing guidelines](../CONTRIBUTING.md) and [code of conduct](https://docs.newrelic.com/docs/licenses/open-source/code-of-conduct/).
 
 ## Description
 

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -44,7 +44,6 @@ jobs:
           fail: false
           args: >-
             --cache
-            --cache-exclude-status '403,429,500..599'
             --max-cache-age 1d
             --max-retries 3
             --retry-wait-time 5
@@ -68,41 +67,144 @@ jobs:
           script: |
             const exitCode = '${{ steps.lychee.outputs.exit_code }}';
             const fs = require('fs');
-            const label = 'linkcheck';
-            const title = 'Broken links detected in documentation';
 
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: label,
-              state: 'open'
-            });
+            const TITLE = 'Broken links detected in documentation';
+            const LABEL_CONFIRMED = 'linkcheck';
+            const LABEL_PENDING = 'linkcheck-pending';
+            const CLEAN_MARKER = 'Clean run on';
+            const FAIL_MARKER = 'Failing run on';
+            const MAX_BODY = 60000; // GitHub issue body/comment limit is 65536
+            const REOPEN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
-            if (exitCode !== '0') {
-              const body = fs.readFileSync('lychee/out.md', 'utf8');
-              if (issues.length > 0) {
-                await github.rest.issues.update({
+            function truncate(body) {
+              if (body.length <= MAX_BODY) {
+                return body;
+              }
+              return body.slice(0, MAX_BODY) + '\n\n... (truncated, see workflow run for full report)';
+            }
+
+            function hasLabel(issue, label) {
+              return issue.labels.some(l => (typeof l === 'string' ? l : l.name) === label);
+            }
+
+            function withLinkcheckLabel(issue, label) {
+              const others = issue.labels
+                .map(l => (typeof l === 'string' ? l : l.name))
+                .filter(name => name !== LABEL_CONFIRMED && name !== LABEL_PENDING);
+              return [...others, label];
+            }
+
+            async function lastCommentIsCleanMarker(issueNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 1,
+                sort: 'created',
+                direction: 'desc'
+              });
+              return comments.length > 0 && comments[0].body.startsWith(CLEAN_MARKER);
+            }
+
+            async function findTrackingIssue() {
+              for (const label of [LABEL_CONFIRMED, LABEL_PENDING]) {
+                const { data: issues } = await github.rest.issues.listForRepo({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issues[0].number,
-                  body
+                  labels: label,
+                  state: 'all',
+                  sort: 'created',
+                  direction: 'desc',
+                  per_page: 5
                 });
-              } else {
+                // listForRepo returns pull requests too; they share the issues API.
+                const found = issues.find(issue => !issue.pull_request && issue.title === TITLE);
+                if (found) {
+                  return found;
+                }
+              }
+              return null;
+            }
+
+            if (exitCode !== '0') {
+              const body = truncate(fs.readFileSync('lychee/out.md', 'utf8'));
+              const issue = await findTrackingIssue();
+              const closedTooLongAgo = issue
+                && issue.state === 'closed'
+                && (Date.now() - new Date(issue.closed_at).getTime()) > REOPEN_WINDOW_MS;
+
+              if (!issue || closedTooLongAgo) {
                 await github.rest.issues.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  title,
+                  title: TITLE,
                   body,
-                  labels: [label]
+                  labels: [LABEL_PENDING]
                 });
-              }
-            } else if (issues.length > 0) {
-              for (const issue of issues) {
+              } else if (issue.state === 'closed') {
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  state: 'closed'
+                  state: 'open',
+                  labels: withLinkcheckLabel(issue, LABEL_PENDING),
+                  body
                 });
+              } else if (hasLabel(issue, LABEL_CONFIRMED)) {
+                // A failing night must invalidate a stale clean marker, or the
+                // next clean night reads it as the second consecutive one.
+                const mustInvalidateCleanMarker = await lastCommentIsCleanMarker(issue.number);
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body
+                });
+
+                if (mustInvalidateCleanMarker) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `${FAIL_MARKER} ${new Date().toISOString().slice(0, 10)}. Clean-run streak reset.`
+                  });
+                }
+              } else {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: withLinkcheckLabel(issue, LABEL_CONFIRMED),
+                  body
+                });
+              }
+            } else {
+              const issue = await findTrackingIssue();
+              if (issue && issue.state === 'open') {
+                if (hasLabel(issue, LABEL_PENDING)) {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    state: 'closed'
+                  });
+                } else {
+                  if (await lastCommentIsCleanMarker(issue.number)) {
+                    await github.rest.issues.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      state: 'closed'
+                    });
+                  } else {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      body: `${CLEAN_MARKER} ${new Date().toISOString().slice(0, 10)}. Closing automatically if tomorrow's run is also clean.`
+                    });
+                  }
+                }
               }
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](https://opensource.newrelic.com/code-of-conduct/) and [search the issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues); your issue may have already been discussed or fixed in `master`. To contribute,
+[code of conduct](https://docs.newrelic.com/docs/licenses/open-source/code-of-conduct/) and [search the issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues); your issue may have already been discussed or fixed in `master`. To contribute,
 [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repository, commit your changes, and [send a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
-Note that our [code of conduct](https://opensource.newrelic.com/code-of-conduct/) applies to all platforms and venues related to this project; please follow it in all yo ur interactions with the project and its participants.
+Note that our [code of conduct](https://docs.newrelic.com/docs/licenses/open-source/code-of-conduct/) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
 ## Feature Requests
 
-Feature requests should be submitted in the [Issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://docs.github.com/en/get-started/quickstart/communicating-on-github), has been [shown by the community](https://github.com/newrelic/newrelic-dotnet-agent/issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
+Feature requests should be submitted in the [Issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues), with a description of the expected behavior & use case, where they'll remain closed until sufficient interest, [e.g. :+1: reactions](https://docs.github.com/en/get-started/quickstart/communicating-on-github), has been [shown by the community](https://github.com/newrelic/newrelic-dotnet-agent/issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
 Before submitting an Issue, please search for similar ones in the
 [closed issues](https://github.com/newrelic/newrelic-dotnet-agent/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
 
@@ -20,11 +20,11 @@ When contributing, please keep in mind that New Relic customers (that's you!) ar
 
 Be aware that the instrumentation needs to work with a wide range of versions of the instrumented modules, and that code that looks nonsensical or overcomplicated may be that way for compatibility-related reasons. Read all the comments and check the related tests before deciding whether existing code is incorrect.
 
-If you’re planning on contributing a new feature or an otherwise complex contribution, we kindly ask you to start a conversation with the maintainer team by opening up a GitHub issue first.
+If you're planning on contributing a new feature or an otherwise complex contribution, we kindly ask you to start a conversation with the maintainer team by opening up a GitHub issue first.
 
 ### General Guidelines
 
-A primary goal of the agent is to adhere to the Hippocratic oath for the applications it instruments: “first, do no harm”.  The code in the agent will execute inside the process space of our customers’ applications and must not crash them, destabilize them, change their behavior, or significantly degrade their performance.  Another important consideration is that the data the agent gathers must not leak any personally identifying information (PII) from customer apps, e.g. usernames or credit card numbers.
+A primary goal of the agent is to adhere to the Hippocratic oath for the applications it instruments: "first, do no harm".  The code in the agent will execute inside the process space of our customers' applications and must not crash them, destabilize them, change their behavior, or significantly degrade their performance.  Another important consideration is that the data the agent gathers must not leak any personally identifying information (PII) from customer apps, e.g. usernames or credit card numbers.
 
 This project is licensed under the Apache-2.0 license.  Any third party libraries added as dependencies of the project must have a similarly permissive open source license, e.g. MIT.
 
@@ -75,5 +75,5 @@ Integration tests are used to test the functionality of [agent instrumentation](
 
 Keep in mind that when you submit your Pull Request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.
 
-For more information about CLAs, please check out Alex Russell’s excellent post,
-[“Why Do I Need to Sign This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
+For more information about CLAs, please check out Alex Russell's excellent post,
+["Why Do I Need to Sign This?"](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).


### PR DESCRIPTION
The nightly link check filed a ticket on any single failing night and closed it on the next clean one, which produced a run of tickets that opened and closed a day later. It now confirms a failure over two consecutive nights before escalating, and reuses one tracking issue instead of opening a new one each time.

Also drops the `--cache-exclude-status` flag, which only controlled cache writes and never affected pass/fail, repoints the three defunct `opensource.newrelic.com` code-of-conduct links to `docs.newrelic.com`, and makes `CONTRIBUTING.md` strict ASCII.
