### PR TITLE
test: Cleanup ServiceBus entities after tests

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/AzureServiceBusConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/AzureServiceBusConfiguration.cs
@@ -8,6 +8,8 @@ namespace NewRelic.Agent.IntegrationTests.Shared;
 public class AzureServiceBusConfiguration
 {
     public const string FuncTestQueueName = "azure_func_test_queue";
+    // The exerciser and the fixture-owned scope must agree on the topic subscription name.
+    public const string SubscriptionName = "test";
     private static string _connectionString;
 
     public static string ConnectionString

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
-using Azure.Messaging.ServiceBus.Administration;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
@@ -17,32 +16,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus;
 [Library]
 internal class AzureServiceBusExerciser
 {
-    private const string Subscription = "test";
+    private const string Subscription = AzureServiceBusConfiguration.SubscriptionName;
 
     #region Queue
-
-    [LibraryMethod]
-    public static async Task InitializeQueue(string queueName)
-    {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        // if the queue exists, delete it and re-create it
-        if (await adminClient.QueueExistsAsync(queueName))
-        {
-            await adminClient.DeleteQueueAsync(queueName);
-        }
-
-        await adminClient.CreateQueueAsync(queueName);
-    }
-
-    [LibraryMethod]
-    public static async Task DeleteQueue(string queueName)
-    {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        if (await adminClient.QueueExistsAsync(queueName))
-        {
-            await adminClient.DeleteQueueAsync(queueName);
-        }
-    }
 
     [LibraryMethod]
     [Transaction]
@@ -212,30 +188,6 @@ internal class AzureServiceBusExerciser
     #endregion Queue
 
     #region Topic
-
-    [LibraryMethod]
-    public static async Task InitializeTopic(string topicName)
-    {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        // if the topic exists, delete it and re-create it
-        if (await adminClient.TopicExistsAsync(topicName))
-        {
-            await adminClient.DeleteTopicAsync(topicName);
-        }
-
-        await adminClient.CreateTopicAsync(topicName);
-        await adminClient.CreateSubscriptionAsync(topicName, Subscription);
-    }
-
-    [LibraryMethod]
-    public static async Task DeleteTopic(string topicName)
-    {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        if (await adminClient.TopicExistsAsync(topicName))
-        {
-            await adminClient.DeleteTopicAsync(topicName);
-        }
-    }
 
     [LibraryMethod]
     [Transaction]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
@@ -6,16 +6,18 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using Xunit;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
 
-public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>, IDisposable
     where TFixture : ConsoleDynamicMethodFixture
 {
     private readonly TFixture _fixture;
     private readonly string _queueOrTopicName;
     private readonly string _destinationType;
+    private ServiceBusEntityScope _entityScope;
 
     private readonly string _processMetricNameBase;
     private readonly string _settleMetricNameBase;
@@ -29,8 +31,8 @@ public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicInte
         _fixture.SetTimeout(TimeSpan.FromMinutes(1));
         _fixture.TestLogger = output;
 
-        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
         _destinationType = destinationType;
+        _queueOrTopicName = $"test-{_destinationType.ToLowerInvariant()}-{Guid.NewGuid()}";
 
         _topicScopeSuffix = null;
         if (_destinationType == "Topic")
@@ -43,15 +45,18 @@ public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicInte
         _settleMetricNameBase = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named";
         _transactionNameBase = $"OtherTransaction/Message/ServiceBus/{_destinationType}/Named";
 
-        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_SendMessagesFor{_destinationType} {_queueOrTopicName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_ReceiveMessagesFor{_destinationType} {_queueOrTopicName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
         _fixture.AddActions
         (
             setupConfiguration: () =>
             {
+                // The fixture owns the entity, not the application under test. Recreating it per attempt
+                // keeps a retry from seeing messages the previous attempt left behind.
+                _entityScope?.Dispose();
+                _entityScope = ServiceBusEntityScope.Create(_destinationType, _queueOrTopicName);
+
                 var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                 configModifier
@@ -69,6 +74,11 @@ public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicInte
         );
 
         _fixture.Initialize();
+    }
+
+    public void Dispose()
+    {
+        _entityScope?.Dispose();
     }
 
     [Fact]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
@@ -6,17 +6,19 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
 
-public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>, IDisposable
     where TFixture : ConsoleDynamicMethodFixture
 {
     private readonly TFixture _fixture;
     private readonly string _queueOrTopicName;
     private readonly string _destinationType;
+    private ServiceBusEntityScope _entityScope;
 
     protected AzureServiceBusTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
         base(fixture)
@@ -25,24 +27,27 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
         _fixture.SetTimeout(TimeSpan.FromMinutes(1));
         _fixture.TestLogger = output;
 
-        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
         _destinationType = destinationType;
+        _queueOrTopicName = $"test-{_destinationType.ToLowerInvariant()}-{Guid.NewGuid()}";
 
-        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType} {_queueOrTopicName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ScheduleAndCancelAMessage {_queueOrTopicName}");
         if (_destinationType == "Queue")
         {
             _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndDeadLetterAMessageForQueue {_queueOrTopicName}");
         }
-            
+
         _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndAbandonAMessageFor{_destinationType} {_queueOrTopicName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
         _fixture.AddActions
         (
             setupConfiguration: () =>
             {
+                // The fixture owns the entity, not the application under test. Recreating it per attempt
+                // keeps a retry from seeing messages the previous attempt left behind.
+                _entityScope?.Dispose();
+                _entityScope = ServiceBusEntityScope.Create(_destinationType, _queueOrTopicName);
+
                 var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                 configModifier
@@ -59,6 +64,11 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
 
     private readonly string _metricScopeBase =
         "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
+
+    public void Dispose()
+    {
+        _entityScope?.Dispose();
+    }
 
     [Fact]
     public void Test()

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
@@ -6,17 +6,19 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
 
-public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>, IDisposable
     where TFixture : ConsoleDynamicMethodFixture
 {
     private readonly TFixture _fixture;
     private readonly string _queueOrTopicName;
     private readonly string _destinationType;
+    private ServiceBusEntityScope _entityScope;
 
     protected AzureServiceBusW3CTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
         base(fixture)
@@ -25,20 +27,22 @@ public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegratio
         _fixture.SetTimeout(TimeSpan.FromMinutes(1));
         _fixture.TestLogger = output;
 
-        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
         _destinationType = destinationType;
+        _queueOrTopicName = $"test-{_destinationType.ToLowerInvariant()}-{Guid.NewGuid()}";
 
-
-        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
         // send and receive on separate transactions to validate DT propagation
         _fixture.AddCommand($"AzureServiceBusExerciser SendAMessageFor{_destinationType} {_queueOrTopicName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAMessageFor{_destinationType} {_queueOrTopicName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
         _fixture.AddActions
         (
             setupConfiguration: () =>
             {
+                // The fixture owns the entity, not the application under test. Recreating it per attempt
+                // keeps a retry from seeing messages the previous attempt left behind.
+                _entityScope?.Dispose();
+                _entityScope = ServiceBusEntityScope.Create(_destinationType, _queueOrTopicName);
+
                 var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                 configModifier
@@ -58,6 +62,11 @@ public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegratio
 
     private readonly string _metricScopeBase =
         "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
+
+    public void Dispose()
+    {
+        _entityScope?.Dispose();
+    }
 
     [Fact]
     public void Test()
@@ -220,11 +229,12 @@ public class
 /// Verifies that when a ServiceBusMessage already has DT headers in ApplicationProperties,
 /// the agent replaces them rather than duplicating or erroring.
 /// </summary>
-public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>, IDisposable
     where TFixture : ConsoleDynamicMethodFixture
 {
     private readonly TFixture _fixture;
     private readonly string _queueName;
+    private ServiceBusEntityScope _entityScope;
 
     protected AzureServiceBusW3CDTHeaderReplacementTestsBase(TFixture fixture, ITestOutputHelper output) :
         base(fixture)
@@ -235,15 +245,16 @@ public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> :
 
         _queueName = $"test-dtheader-{Guid.NewGuid()}";
 
-        _fixture.AddCommand($"AzureServiceBusExerciser InitializeQueue {_queueName}");
         _fixture.AddCommand($"AzureServiceBusExerciser SendAndReceiveWithExistingDTHeadersForQueue {_queueName}");
         _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAMessageForQueue {_queueName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser DeleteQueue {_queueName}");
 
         _fixture.AddActions
         (
             setupConfiguration: () =>
             {
+                _entityScope?.Dispose();
+                _entityScope = ServiceBusEntityScope.Create("Queue", _queueName);
+
                 var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                 configModifier
@@ -259,6 +270,11 @@ public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> :
         );
 
         _fixture.Initialize();
+    }
+
+    public void Dispose()
+    {
+        _entityScope?.Dispose();
     }
 
     [Fact]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/ServiceBusEntityScope.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/ServiceBusEntityScope.cs
@@ -1,0 +1,106 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using NewRelic.Agent.IntegrationTests.Shared;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
+
+/// <summary>
+/// Creates a Service Bus queue or topic for the lifetime of one fixture and deletes it afterward, so a
+/// test run that leaves the entity behind cannot leak it.
+/// </summary>
+public class ServiceBusEntityScope : IDisposable
+{
+    // Backstop for a run that dies before Dispose. The lowest value the service accepts is 5 minutes,
+    // which is close to the waits these tests use, so this allows more headroom.
+    private static readonly TimeSpan EntityAutoDeleteOnIdle = TimeSpan.FromMinutes(15);
+
+    private readonly ServiceBusAdministrationClient _client;
+    private readonly bool _isTopic;
+    private bool _disposed;
+
+    public string EntityName { get; }
+
+    private ServiceBusEntityScope(ServiceBusAdministrationClient client, string entityName, bool isTopic)
+    {
+        _client = client;
+        EntityName = entityName;
+        _isTopic = isTopic;
+    }
+
+    /// <summary>
+    /// Creates the queue or topic named by destinationType ("Queue" or "Topic"). The caller supplies the
+    /// name so that name generation, which needs no I/O, can happen in a fixture constructor while
+    /// creation happens in Initialize.
+    /// </summary>
+    public static ServiceBusEntityScope Create(string destinationType, string entityName)
+    {
+        var isTopic = destinationType switch
+        {
+            "Queue" => false,
+            "Topic" => true,
+            _ => throw new ArgumentException($"Unknown destination type '{destinationType}'.", nameof(destinationType))
+        };
+
+        var client = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
+
+        try
+        {
+            if (isTopic)
+            {
+                var options = new CreateTopicOptions(entityName) { AutoDeleteOnIdle = EntityAutoDeleteOnIdle };
+                client.CreateTopicAsync(options).GetAwaiter().GetResult();
+                client.CreateSubscriptionAsync(entityName, AzureServiceBusConfiguration.SubscriptionName).GetAwaiter().GetResult();
+            }
+            else
+            {
+                var options = new CreateQueueOptions(entityName) { AutoDeleteOnIdle = EntityAutoDeleteOnIdle };
+                client.CreateQueueAsync(options).GetAwaiter().GetResult();
+            }
+        }
+        catch (ServiceBusException exception) when (exception.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+        {
+            // Treat an existing entity as created. The name carries a GUID, so the only way to reach this
+            // is a repeated create for the same run, and the scope still owns the entity either way.
+        }
+        catch (Exception exception)
+        {
+            throw new Exception(
+                $"Could not create Service Bus {destinationType.ToLowerInvariant()} '{entityName}'. The connection string in the AzureServiceBusTests test configuration needs Manage rights on the namespace.",
+                exception);
+        }
+
+        return new ServiceBusEntityScope(client, entityName, isTopic);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            if (_isTopic)
+            {
+                // Deleting the topic also removes its subscriptions.
+                _client.DeleteTopicAsync(EntityName).GetAwaiter().GetResult();
+            }
+            else
+            {
+                _client.DeleteQueueAsync(EntityName).GetAwaiter().GetResult();
+            }
+        }
+        catch (Exception)
+        {
+            // Throwing here would replace the test result with a cleanup failure. AutoDeleteOnIdle
+            // removes the entity if this delete does not.
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -28,6 +28,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
The unbounded Azure Service Bus tests created and deleted their queue or topic from inside the application under test, so a command that threw or a timeout kill skipped the delete and leaked the entity in Azure. A new fixture-owned `ServiceBusEntityScope` creates the entity in setup and deletes it in `Dispose`, with `AutoDeleteOnIdle` as the backstop.

All 25 `AzureServiceBus` unbounded test classes pass, and the namespace holds no test entities afterward.
