### PR TITLE
chore: Add agent-log analysis and test-failure triage skills

### DIFF
--- a/.claude/skills/analyze-dotnet-agent-logs/SKILL.md
+++ b/.claude/skills/analyze-dotnet-agent-logs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: analyze-dotnet-agent-logs
+description: Parse and diagnose New Relic .NET agent logs (newrelic_agent_*.log) and profiler logs (NewRelic.Profiler.<pid>.log) from a support ticket. Use when handed a log file or a logs directory, or when asked why the agent is not reporting, not connecting, not instrumenting a library, or why custom instrumentation XML has no effect.
+---
+
+# Analyze .NET agent logs
+
+A support log is evidence, not prose. It is large, it holds more than one agent
+run, and it is written by a process you cannot interview. Work it in this order.
+
+## Hard rules
+
+- Work only from a **slim** file. `nrlog.py extract` writes one; every later
+  step reads that.
+- Never `Read`, `tail`, or wide-grep a raw log. A customer log runs to hundreds
+  of MB with single lines tens of KB wide, and those bytes stay in context for
+  the rest of the session.
+- Lead with counts. `sessions`, `payloads`, and `profiler` all answer in
+  summary form. Reach for a body only when a count has told you which body.
+- Keep analysis local. Log content goes to no artifact, no ticket comment, and
+  no web request unless the engineer asks for that in the moment, and then only
+  from a slim file.
+- Delegate to a subagent when the source file exceeds 50 MB, or when the answer
+  needs a sweep across many sessions or many files. Give the subagent the exact
+  question and the exact commands, and require a verdict back, not log content.
+
+## Workflow
+
+1. **Inventory.** Run `nrlog.py sessions <path>` on the file or directory. It
+   accepts a rolled set and merges a run that spans siblings. A customer dump
+   holds dozens of applications, so above 40 sessions it prints a per-file
+   summary instead: pick a file with `--file <name>`, then add `--all`.
+2. **Pick the session.** Show the rows. When more than one session is in scope,
+   ask the engineer which one before going further. A support question is
+   almost always about one run, and the wrong run wastes the whole analysis.
+   Session numbers are relative to the `--file` filter, so pass the same
+   `--file` to every later command.
+3. **Slim it.** Run `nrlog.py extract <path> --session N`. Read the slim file
+   from here on. When it reports more than a few MB, narrow with `--level`,
+   `--since`, `--until`, or `--grep` and extract again. A 7-hour FINEST session
+   slims to 125 MB, which is no more readable than the original.
+4. **Read the level from the counts, not the banner.** `extract` prints both
+   `stated log level` and `observed levels`. They disagree whenever the level
+   changed at runtime, which the agent records as `The log level was updated to
+   {new} from {previous}`. Trust the observed counts. The level bounds every
+   conclusion: INFO hides all collector payloads, and FINEST is the only level
+   that shows a skipped wrapper.
+5. **Correlate the profiler.** Point `nrlog.py profiler` at the directory
+   first. A dump routinely holds thousands of profiler logs, so above 8 files
+   it groups them by signature: most are processes the .NET Framework
+   allow-list rejected, which is expected noise, and the group carrying
+   `initialized` is the short list worth reading. Then match one
+   `NewRelic.Profiler.<pid>.log` to the session by pid **and** overlapping UTC
+   range. When the ranges do not overlap the pid was reused and the files are
+   unrelated, so say that rather than pairing them.
+6. **Route.** Take the engineer's symptom to
+   [references/playbooks.md](references/playbooks.md). Answer from the slim
+   file when no playbook fits.
+7. **Report.** Short verdict in chat with the evidence lines quoted verbatim.
+   Long form to a markdown file beside the slim file. A ticket-ready block only
+   when the engineer asks.
+
+Every verdict names its evidence and its limit. "Consistent with X; not proven,
+because that path logs nothing" is a finished answer. A guess dressed as a
+finding is not.
+
+## The script
+
+`scripts/nrlog.py`, Python 3 standard library only. Run `--help` for flags.
+
+| Command | Use it to |
+|---|---|
+| `sessions` | List runs in a file or directory, with truncation and interleaving flags |
+| `extract` | Write the slim, redacted, payload-stripped file for one session |
+| `payloads` | Index collector calls: time, endpoint, direction, size, status, request guid |
+| `body` | Print one request or response body, so a payload enters context on purpose |
+| `decode` | Turn a base64 distributed-trace payload into JSON |
+| `profiler` | Summarize a profiler log: init, config, extensions, XML failures, method count |
+| `instrumented` | List the methods the profiler rewrote, for checking custom instrumentation |
+
+Launcher: `python` on Windows, `python3` elsewhere.
+
+Derived files land in `nrlog-work/` beside the source log unless `--out` says
+otherwise. The source log is never modified.
+
+## Changing this skill
+
+Regenerate the fixtures and re-run the checks before trusting an edit to
+`nrlog.py`:
+
+```
+python tests/make_fixtures.py && python tests/make_merge_fixtures.py
+```
+
+They cover a restart, a rolled sibling, a truncated session, interleaved pids,
+one pid hosting three app domains, a runtime level change, DEBUG payload lines,
+exception continuation lines, and a planted license key for the redaction check.
+Generated fixtures are gitignored.
+
+## References
+
+- [references/log-formats.md](references/log-formats.md) - line layouts, level
+  names, session identity, what each file is named and where it lives. Read
+  before hand-parsing anything the script does not cover.
+- [references/collector-protocol.md](references/collector-protocol.md) -
+  endpoints, the healthy call sequence, connect request and response fields,
+  positional array keys. Read when interpreting a payload or a response.
+- [references/playbooks.md](references/playbooks.md) - eight symptoms, each
+  with its verified signature, its verdict, and the next ask for the customer.

--- a/.claude/skills/analyze-dotnet-agent-logs/references/collector-protocol.md
+++ b/.claude/skills/analyze-dotnet-agent-logs/references/collector-protocol.md
@@ -1,0 +1,167 @@
+# Collector protocol as it appears in the log
+
+Field names and log lines below come from agent source. Sample lines are
+synthetic, built to match the verified format.
+
+## How one call looks
+
+Every call is keyed by a request guid, so a request and its response can be
+paired even when other threads interleave between them.
+
+| Line | Level | Source |
+|---|---|---|
+| `Request({guid}): Invoking "{method}"` | FINEST | `HttpCollectorWire.cs:48` |
+| `Request({guid}): Invoked "{method}" with : {payload}` | DEBUG | `HttpCollectorWire.cs:84` |
+| `Request({guid}): Invocation of "{method}" yielded response : {response}` | DEBUG | `HttpCollectorWire.cs:85` |
+| `Request({guid}): Invocation of "{method}" returned response headers : {headers}` | DEBUG | `HttpCollectorWire.cs:73,87` |
+| `Request({guid}): Received a {code} {status} response invoking method "{method}" with payload "{payload}"` | DEBUG | `ConnectionHandler.cs:361` |
+| `Request({guid}): An error occurred invoking method "{method}" with payload "{payload}": {exception}` | DEBUG | `ConnectionHandler.cs:372` |
+| `Request({guid}): Dropped large payload: size: {n}, max_payload_size_bytes={m}` | ERROR | `HttpCollectorWire.cs:96` |
+
+At INFO none of these appear. A log with no `Invoked` lines is not a log with no
+traffic; it is a log at the wrong level.
+
+The request URI never appears in these lines. It carries the license key and the
+`run_id`, and it shows up only inside exception text.
+
+## Endpoints
+
+| Method | Purpose |
+|---|---|
+| `preconnect` | Ask which collector host to use for this license key |
+| `connect` | Register the run, send settings and environment, get server config |
+| `agent_settings` | Report the settings the agent ended up with, after server config |
+| `metric_data` | Timeslice metrics, every harvest |
+| `analytic_event_data` | Transaction events |
+| `span_event_data` | Span events |
+| `error_event_data` | Error events |
+| `custom_event_data` | Custom events |
+| `log_event_data` | Forwarded application logs |
+| `transaction_sample_data` | Transaction traces |
+| `sql_trace_data` | Slow SQL traces |
+| `error_data` | Error traces |
+| `get_agent_commands` | Poll for commands, for example a thread profile request |
+| `agent_command_results` | Report command outcomes |
+| `profile_data` | Thread profile results |
+| `update_loaded_modules` | Assembly inventory |
+| `shutdown` | End the run cleanly |
+
+Healthy sequence: `preconnect`, `connect`, `agent_settings`, then repeating
+harvests of `metric_data` plus whichever data types have samples, with
+`get_agent_commands` polling alongside, and `shutdown` at the end. A run that
+stops after `preconnect` or `connect` never reported anything.
+
+## connect request
+
+Top-level fields (`ConnectModel.cs`): `pid`, `language`, `host`,
+`display_host`, `app_name`, `agent_version`, `agent_version_timestamp`,
+`security_settings`, `high_security`, `event_harvest_config`, `identifier`,
+`labels`, `settings`, `metadata`, `utilization`, `environment`.
+
+The ones that answer support questions:
+
+- `app_name` - where the data will land. Compare against what the customer
+  expects to see in the UI.
+- `host` and `display_host` - the entity name the customer will look for.
+- `settings` - the full effective configuration, one flat key per setting
+  (`agent.*`). This is the fastest way to see what the agent actually resolved,
+  including `agent.license_key.configured`, which is a boolean. The key itself
+  is never in here.
+- `high_security` - when true, request parameters are dropped and SQL is
+  obfuscated regardless of local config.
+- `event_harvest_config.harvest_limits` - the per-type reservoir sizes the agent
+  asked for: `analytic_event_data`, `custom_event_data`, `error_event_data`,
+  `span_event_data`, `log_event_data`.
+- `utilization` - cloud and container detection. Wrong entity grouping usually
+  starts here.
+
+## connect response
+
+Fields the agent reads (`ServerConfiguration.cs`). `agent_run_id` is required;
+everything else is optional and absent means "keep the local value".
+
+| Field | Effect |
+|---|---|
+| `agent_run_id` | Identifies the run. A new one after a restart means the agent reconnected. |
+| `collect_errors`, `collect_traces`, `collect_analytics_events`, `collect_error_events`, `collect_span_events`, `collect_custom_events`, `collect_ai` | Server-side kill switches. A `false` here explains missing data of exactly that type. |
+| `agent_config` | Server-side configuration, which overrides local config unless the agent is set to ignore it. |
+| `event_harvest_config`, `span_event_harvest_config` | Faster harvest cycles and reservoir sizes the server assigned. |
+| `data_report_period` | Harvest interval. |
+| `max_payload_size_in_bytes` | The ceiling behind `Dropped large payload`. |
+| `high_security` | Server-side high security. |
+| `sampling_target`, `sampling_target_period_in_seconds` | Span sampling budget. |
+| `entity_guid`, `account_id`, `primary_application_id`, `trusted_account_key`, `cross_process_id` | Identity and distributed-tracing trust. |
+| `messages` | Server messages, which the agent logs at their stated level. |
+| `metric_name_rules`, `transaction_name_rules`, `url_rules` | Renaming rules. Unexpected transaction names often come from here, not from the agent. |
+| `request_headers_map` | Headers the agent must attach to later requests. |
+
+## Response status handling
+
+`DataTransportService.cs` maps the HTTP status to an action:
+
+| Status | Action |
+|---|---|
+| 400, 401, 403, 404, 405, 407, 409, 410, 411, 414, 415, 417, 431 | Discard the payload |
+| 408, 429, 500, 503 | Retain and retry on the next harvest |
+| 413 | Reduce size if possible, otherwise discard |
+| anything else | Discard |
+
+Two statuses also change the agent's life cycle:
+
+- 401 or 409 triggers a restart, which produces a fresh `preconnect` and
+  `connect` inside the same session.
+- 410 triggers shutdown, logged as `Shutting down: {message}` at INFO, preceded
+  by `The server has requested that the agent disconnect. The agent is shutting
+  down.`
+
+So a session that keeps reconnecting points at 401 or 409, and a session that
+ends without a customer-initiated stop points at 410.
+
+## Positional payloads
+
+Several payloads serialize as positional JSON arrays, not objects, so a field
+key is the only way to read them.
+
+`transaction_sample_data` trace, per trace
+(`TransactionTraceWireModel.cs`):
+
+| Index | Field |
+|---|---|
+| 0 | start time, Unix milliseconds |
+| 1 | duration, milliseconds |
+| 2 | transaction metric name |
+| 3 | request URI |
+| 4 | trace data (the nested segment tree) |
+| 5 | transaction guid |
+| 6 | unused, always null |
+| 7 | unused, always false |
+| 8 | xray session id, never set by the .NET agent |
+| 9 | synthetics resource id |
+
+`metric_data` metric values (`MetricDataWireModel.cs`):
+
+| Index | Field |
+|---|---|
+| 0 | call count |
+| 1 | total time, seconds |
+| 2 | exclusive time, seconds |
+| 3 | minimum time, seconds |
+| 4 | maximum time, seconds |
+| 5 | sum of squares |
+
+Indexes 3 and 4: the doc comments on the fields name them the other way round,
+but `BuildAggregateData` folds index 3 with `Math.Min` from a `float.MaxValue`
+seed and index 4 with `Math.Max` from a `float.MinValue` seed. The aggregation
+decides the semantics, so index 3 is the minimum. Treat the field comments as
+wrong.
+
+Nothing in a .NET agent payload is gzip-plus-base64. Other agents compress the
+trace tree into an encoded string; this one sends plain nested arrays.
+
+## Base64 in the log
+
+Distributed-trace payloads are base64-encoded JSON, and they appear in wrapper
+and distributed-tracing lines rather than in collector payloads. `nrlog.py
+decode` turns one into JSON. Legacy cross-application-tracing headers are also
+base64 but are XOR-obfuscated with the `encoding_key` from the connect
+response, so decoding one needs that key.

--- a/.claude/skills/analyze-dotnet-agent-logs/references/log-formats.md
+++ b/.claude/skills/analyze-dotnet-agent-logs/references/log-formats.md
@@ -1,0 +1,180 @@
+# Log formats and session identity
+
+Every line layout, level name, and file-naming rule below is taken from agent
+source. Sample lines are synthetic, built to match the verified format.
+
+## The files
+
+| File | Written by | Holds |
+|---|---|---|
+| `newrelic_agent_<name>.log` | managed agent | config, connect, harvests, wrapper activity |
+| `newrelic_agent_<name>_NNN.log` | managed agent | an older slice of the same log, after size rolling |
+| `NewRelic.Profiler.<pid>.log` | native profiler | process decision, instrumentation XML, rewritten methods |
+| `newrelic_audit.log` | managed agent | collector traffic, only when `auditLog` is enabled |
+
+`<name>` resolves in this order: `NEW_RELIC_LOG`, then the `fileName` in
+`newrelic.config`, then on .NET Framework the IIS `AppDomainAppId`, then the
+app-domain name or process name. So one IIS site gets one file, and a console
+host gets `newrelic_agent_MyApp.log`.
+
+Managed log directory: `NEW_RELIC_LOG_DIRECTORY` or `NEWRELIC_LOG_DIRECTORY`,
+else the `logs` directory under the agent home.
+
+Profiler log directory, in precedence order:
+`NEW_RELIC_PROFILER_LOG_DIRECTORY`, `NEW_RELIC_LOG_DIRECTORY`, an Azure App
+Service special case, `<NEW_RELIC_HOME>/Logs` (`logs` on Linux), then the
+platform default under common application data.
+
+The audit log carries nothing a DEBUG-level managed log lacks, so it is out of
+scope. Recognize it by its layout and move on:
+`2026-08-18 14:03:11,123 NewRelic Audit: Data Sent from the Collector : ...`
+
+## Managed log line
+
+Layout (`LoggerBootstrapper.cs`):
+
+```
+{UTCTimestamp} NewRelic {NRLogLevel,6}: [pid: {pid}, tid: {tid}] {Message}
+{Exception}
+```
+
+Sample:
+
+```
+2026-08-18 14:03:11,123 NewRelic   INFO: [pid: 8412, tid: 1] The New Relic .NET Agent v10.44.0 started (pid 8412) on app domain '/LM/W3SVC/2/ROOT'
+```
+
+- Timestamp is `yyy-MM-dd HH:mm:ss,fff` from `DateTimeOffset.UtcNow`. Always
+  UTC. Comma before the milliseconds.
+- The level token is right-aligned in six characters, so `  INFO`, ` DEBUG`,
+  `FINEST`, `  WARN`, ` ERROR`, ` Audit`. Match it with `\s*` on the left.
+- Anchor regex:
+  `^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) NewRelic\s+(\w+): \[pid: (\d+), tid: (\d+)\] (.*)$`
+- A line that fails the anchor is a **continuation**: an exception message or
+  stack frame appended to the entry above it. Attach it to the preceding entry
+  of the same stream.
+
+### Levels
+
+In-file tokens are `FINEST`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `Audit`.
+
+`Log level set to {level}` is written once, at startup. The level can change
+later: `ConfigurationService` compares the old and new value, logs `The log
+level was updated to {new} from {previous}` at INFO, and swaps the Serilog
+level switch. So the startup line goes stale, and a session can state INFO
+while holding hundreds of thousands of FINEST lines. Count the level tokens
+rather than believing the banner - `nrlog.py sessions` and `extract` both
+report stated and observed side by side.
+
+Configured values map to those, including deprecated aliases
+(`LogLevelExtensions.cs`): `VERBOSE`, `FINE`, `FINER`, `FINEST`, `TRACE`, `ALL`
+all mean FINEST. `NOTICE` means INFO. `ALERT` means WARN. `CRITICAL`,
+`EMERGENCY`, `FATAL`, `SEVERE` all mean ERROR. `OFF` disables the log. An
+unrecognized value falls back to INFO with a warning line.
+
+What each level unlocks:
+
+| Level | Adds |
+|---|---|
+| INFO | startup banner, app names, connect success, high security, app-name-in-use, warnings |
+| DEBUG | environment variables, full collector request and response bodies, response headers, runtime version |
+| FINEST | per-request `Invoking`, skipped wrappers, segment detail |
+
+DEBUG is the level most support questions need. FINEST is the only level that
+shows a wrapper skipped for lack of a transaction.
+
+## Profiler log line
+
+Layout (`Logger.h`):
+
+```
+[{Level}] {timestamp} {message}
+```
+
+Sample:
+
+```
+[Info ] 2026-08-18 14:03:09 Profiler initialized
+```
+
+- Level strings are `Trace`, `Debug`, `Info `, `Warn `, `Error`. `Info ` and
+  `Warn ` carry a trailing space inside the brackets.
+- Timestamp is `%Y-%m-%d %X` over `gmtime_s`: UTC, whole seconds, no
+  milliseconds and no zone marker.
+- No pid and no tid on the line. The pid is in the file name only.
+- Anchor regex: `^\[(\w+)\s*\] (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (.*)$`
+- Level comes from the same `NEW_RELIC_LOG_LEVEL` value as the managed agent.
+  It is clamped to INFO whenever console logging is on, or in Azure Functions
+  mode without `NEW_RELIC_AZURE_FUNCTION_LOG_LEVEL_OVERRIDE`. A customer can
+  therefore set `finest` and still hand you an INFO-only profiler log.
+
+## Rolling and concurrent writers
+
+The Serilog file sink is configured with `shared: true`
+(`LoggerBootstrapper.cs:280`). Two consequences:
+
+- **Interleaving.** Concurrent processes writing the same file name - an IIS web
+  garden, an overlapped recycle - interleave their lines. Lines are not in
+  per-run order, so read each pid as its own stream.
+- **Rolling.** Size rolling (`maxLogFileSizeMB`, `maxLogFiles`) appends a
+  numeric suffix; daily rolling appends a date. Order rolled siblings by their
+  first parsed timestamp rather than by file name, so neither naming pattern
+  matters.
+
+## Session identity
+
+A **session** is one agent run: a pid plus a contiguous UTC range.
+
+Anchors:
+
+- Start: `The New Relic .NET Agent v{version} started (pid {pid}) on app domain '{domain}'` (INFO)
+- End: `The New Relic .NET Agent v{version} has shutdown (pid {pid}) on app domain '{domain}'` (INFO)
+
+Rules:
+
+- Count banners; do not split on the first one. On .NET Framework one
+  `w3wp.exe` hosts several IIS applications at once, and every app domain
+  writes its own `started` banner into the same file. Nine app domains in one
+  pid is ordinary. Treat the pid as one session that hosts N app domains, and
+  split only when the shutdown banners balance the start banners, which is the
+  point where nothing is left running.
+- Merge across rolled files when the pid matches, no `started` banner
+  intervenes, and the gap between the last and first timestamp is under five
+  minutes. Report the gap when it is larger, and do not merge.
+- The app domain appears **only** in the banner. Nothing on an ordinary line
+  identifies it.
+
+Flags, because the file often cannot prove what you want:
+
+| Flag | Means |
+|---|---|
+| `head-truncated` | no `started` banner; agent version and app domain unknown |
+| `tail-truncated` | no `shutdown` banner; indistinguishable from still running |
+| `appdomain-unknown` | no banner in range, so only the pid is known |
+| `appdomain-ambiguous` | this pid hosted several app domains, so no line can be attributed to one |
+| `interleaved` | another pid wrote into the same range |
+
+Each app domain in a shared pid has its own configuration, so they can run at
+different log levels and change level independently. A single `newrelic.config`
+edit shows up as one `The log level was updated to ...` line per app domain,
+within a few seconds of each other.
+
+Per-line app-domain attribution is impossible in a shared pid: the app domain
+appears only in the banner, never on an ordinary line. Report
+`appdomain-ambiguous` and name the app domains rather than choosing one.
+
+## Redaction
+
+Derived files are written with these removed: license key, security policies
+token, proxy user and password, config obscuring key, `Authorization` header
+values.
+
+Host names, application names, SQL text, and request parameters pass through
+unchanged. They are evidence, and removing them would break the playbooks.
+
+The license key is normally absent from a managed log. It travels in the request
+URI (`HttpRequest.cs`), which no DEBUG line prints, and the reported settings
+expose only `agent.license_key.configured` as a boolean because
+`ReportedConfiguration.AgentLicenseKey` is `[JsonIgnore]`. The realistic leak
+path is exception text that quotes the failing URI, which is why the redaction
+runs anyway.

--- a/.claude/skills/analyze-dotnet-agent-logs/references/playbooks.md
+++ b/.claude/skills/analyze-dotnet-agent-logs/references/playbooks.md
@@ -1,0 +1,275 @@
+# Playbooks
+
+Nine symptoms. Every signature is a string taken from agent source, quoted as
+the agent writes it. Each playbook ends with a **next ask**: what to request from
+the customer when the log cannot settle the question.
+
+Read [log-formats.md](log-formats.md) for the level each signature needs. Start
+with playbook 7 when the level is unknown, because it bounds all the others.
+
+## 1. Profiler never loaded
+
+**Symptom.** No data at all, and no managed agent log.
+
+**Check.** Run `nrlog.py profiler` on the log directory. Above 8 files it groups
+them by signature, so a dump of thousands collapses to a handful of groups.
+
+**Signatures.**
+
+- No profiler log file at all: the CLR never loaded the profiler DLL.
+- `Profiler initialized` present: the profiler loaded. Move to another playbook.
+- `Error initializing CLR profiler info: {hr}`
+- `.NET Core 3.1 or greater required. Profiler not attaching.`
+- `The global newrelic.config file was not found at: {path}`
+
+**Verdict.** Absent log means the CLR never called the profiler. The usual causes
+are a missing or mistyped `*_PROFILER_PATH`, a GUID mismatch, a bitness
+mismatch, or missing native dependencies. None of those can write a log, which is
+why the absence is the finding.
+
+**Limit.** The absence proves only that the profiler did not run. It does not
+say which of those causes applies.
+
+**Next ask.** The Windows Event Viewer entries under Applications and Services
+Logs, then Application, at the time the process started. Also the full
+environment of the process: `COR_ENABLE_PROFILING`, `COR_PROFILER`,
+`COR_PROFILER_PATH`, `NEWRELIC_HOME` for .NET Framework, and the `CORECLR_`
+equivalents for .NET.
+
+## 2. .NET Framework allow-list rejection
+
+**Symptom.** A profiler log exists, no managed agent log exists, and the app is
+.NET Framework and not hosted in IIS. In a whole-directory dump this is the
+largest group by far and it is expected noise: one rejected process per
+short-lived executable on the host.
+
+**Signatures.**
+
+```
+[Info ] ... This process (C:\Apps\MyApp\MyApp.exe) is not configured to be instrumented.
+[Info ] ... This process should not be instrumented, unloading profiler.
+```
+
+**Verdict.** Proven. On .NET Framework the profiler instruments only an
+allow-listed set of process names: `w3wp.exe` and its children,
+`WebDev.WebServer40.exe`, `WebDev.WebServer20.exe`, `inetinfo.exe`,
+`WaWorkerHost.exe`, `WaWebHost.exe`, `WcfSvcHost.exe`. Everything else unloads
+the profiler before the managed agent starts, so no managed log is ever created.
+
+**Fix to give the customer.** Either
+`NEW_RELIC_INCLUDED_APPLICATION_NAMES=MyApp.exe`, or an `<application
+name="MyApp.exe" />` entry under `<instrumentation><applications>` in
+`newrelic.config`. The environment variable wins: when it is set, the config
+list is not read. Matching is a suffix match on the full process path, so a bare
+executable name works.
+
+**Limit.** .NET Framework only. .NET Core and .NET have no allow-list, so this
+playbook never applies there.
+
+**Next ask.** None. The log settles it.
+
+## 3. Connect failure
+
+**Symptom.** The agent starts, then no data arrives.
+
+**Check.** `nrlog.py payloads --session N` and look at what follows
+`preconnect`.
+
+**Signatures.**
+
+- Success: `Agent {identifier} connected to {host}:{port}` then `Agent fully
+  connected.`
+- Rejected credentials: `Received a 401 Unauthorized response invoking method
+  "connect"`. 401 and 409 trigger a restart, so the session shows repeating
+  `preconnect` and `connect` attempts.
+- Server-requested stop: `The server has requested that the agent disconnect.
+  The agent is shutting down.` then `Shutting down: {message}` on a 410.
+- Proxy: exception text carrying `Check your proxy settings ({proxy})`.
+- TLS: `Current TLS Configuration
+  (System.Net.ServicePointManager.SecurityProtocol): {protocols}` at INFO,
+  logged on every connect. On .NET Framework a value without TLS 1.2 explains a
+  handshake failure.
+
+**Verdict.** Read the status code, then the table in
+[collector-protocol.md](collector-protocol.md). 401 means the license key is
+wrong for that host. 407 means the proxy demands authentication. A DNS or socket
+error means the collector host is unreachable.
+
+**Limit.** The URI never appears in a DEBUG line, so the log usually does not
+show which collector host was tried unless an exception quoted it.
+
+**Next ask.** `newrelic.config` for the proxy and host settings, and confirmation
+of which region the account is in.
+
+## 4. Connected but no data of one type
+
+**Symptom.** The agent connects, some data appears in the UI, one kind does not.
+
+Work the three branches in order.
+
+**Branch A: the server turned it off.** In the `connect` response, look for
+`collect_span_events`, `collect_analytics_events`, `collect_error_events`,
+`collect_custom_events`, `collect_traces`, `collect_errors`, `collect_ai` set to
+`false`. A `false` here fully explains the absence, and no agent-side change will
+fix it.
+
+**Branch B: nothing was ever sent.** In `nrlog.py payloads`, check whether the
+endpoint for that data type appears at all. When `span_event_data` never appears,
+the aggregator was empty every harvest, which means the instrumentation never
+produced the data. Then check the profiler side:
+
+- `nrlog.py instrumented <profiler log>` and look for the customer's type or
+  method. `Instrumenting method: {signature}` at INFO is proof the profiler
+  rewrote it.
+- `Unable to find {ClassName} for rejit. HR:{hr}` at INFO means the
+  instrumentation XML names a class the profiler cannot find. Paired with a
+  missing `Instrumenting method:` line, this is the signature of custom
+  instrumentation XML that names a class or method wrongly.
+- `An exception was thrown while reading instrumentation file: {path} - ignoring
+  this file.` at ERROR means that XML file was skipped entirely.
+- `Unable to parse one or more instrumentation files.` means the same for the
+  live-reload path.
+- `Unable to find the New Relic Agent extensions directory ({dir}).` at WARN
+  means almost nothing will be instrumented.
+
+**Branch C: it was sent and rejected.** The endpoint appears, and the response is
+a 4xx. Read the status table in [collector-protocol.md](collector-protocol.md).
+
+**Limit.** Branch B cannot distinguish "wrapper matched but produced nothing"
+from "wrapper never ran" without FINEST. Playbook 8 covers the common reason.
+
+**Next ask.** The customer's custom instrumentation XML file and the contents of
+`<agent-home>/extensions/`, plus a FINEST-level log if branches A and C are
+ruled out.
+
+## 5. Server-side configuration surprise
+
+**Symptom.** The agent behaves in a way the local `newrelic.config` does not
+explain.
+
+**Signatures.**
+
+```
+The agent is in high security mode.  No request parameters will be collected and sql obfuscation is enabled.
+Server-Side Configuration is enabled.
+Server-Side Configuration is enabled, but the agent is configured to ignore it.
+The following events will be harvested every {ms}ms: {types}
+```
+
+Note the double space after `mode.` in the high-security line.
+
+**Verdict.** When server-side configuration is enabled, `agent_config` in the
+connect response overrides local settings. High security mode drops request
+parameters and forces SQL obfuscation regardless of local config. Server
+`messages` are logged at the level the server assigns, so an unexplained INFO or
+WARN line with no agent-side origin is likely one of those.
+
+**Limit.** Needs DEBUG to see `agent_config` itself. At INFO you get only the
+three announcement lines.
+
+**Next ask.** A DEBUG log, plus what the customer has set in the UI for that
+application.
+
+## 6. Unsupported runtime version
+
+**Symptom.** Partial or absent instrumentation on an old runtime.
+
+**Signatures.**
+
+```
+Unsupported installed .NET Framework version {version} detected. Please use a version of .NET Framework >= 4.6.2.
+.NET version {version} has reached EOL, and support will be removed in the next major release of the .NET Agent. Please use net8 or newer.
+```
+
+**Verdict.** The first is a hard floor. The second is a warning, not a failure,
+so it explains nothing on its own. Use it as context, not as a cause.
+
+**Limit.** Both are informational. Neither proves the reported symptom.
+
+**Next ask.** None.
+
+## 7. Log level too low to diagnose
+
+**Symptom.** The log looks healthy and answers nothing.
+
+**Signatures.**
+
+```
+Log level set to {level}
+Invalid log level '{value}' specified. Using log level 'Info' by default.
+The log level, {value}, set in your configuration file has been deprecated...
+Log level was set to "Audit" which is not a valid log level. ... Log level will be treated as INFO for this run.
+```
+
+**Verdict.** At INFO there are no collector payloads, no environment variables,
+and no wrapper decisions. Report the level and stop rather than reading absence
+as evidence.
+
+Read the level from the observed token counts, not from `Log level set to`. That
+banner is written once at startup and goes stale as soon as the level changes
+(see playbook 9).
+
+**Limit.** This is the playbook that tells you the others cannot run yet.
+
+**Next ask.** `NEW_RELIC_LOG_LEVEL=debug` and a fresh log covering a restart plus
+at least two harvest cycles, which is about two minutes at the default interval.
+Ask for `finest` only when playbook 8 is in play, because it is very large.
+
+## 8. Wrapper skipped for lack of an active transaction
+
+**Symptom.** Instrumentation looks correct, the profiler rewrote the method, and
+no segment or transaction appears for it. Common with custom instrumentation on
+background work, message consumers, and timers.
+
+**Signature (FINEST only).**
+
+```
+No transaction, skipping method MyNamespace.MyClass.MyMethod(System.String)
+```
+
+**Verdict.** A wrapper whose `IsTransactionRequired` is true is skipped when no
+transaction is active at the call. The instrumented method still gets rewritten,
+so the profiler log looks perfect while nothing is recorded. The fix is to
+instrument an entry point that starts a transaction, or to have the customer wrap
+the work with the public API.
+
+**Limit.** Two other paths in the same method return without recording anything
+and log nothing at all: the current segment being a leaf, and a detach that
+leaves no valid transaction. When the FINEST line is absent you cannot separate
+those from a wrapper that never ran.
+
+Indirect evidence when FINEST is unavailable: `Instrumenting method:` present in
+the profiler log, and no transaction or segment activity for that method in the
+managed log. Word the verdict as consistent with the wrapper being skipped, and
+say that the path logs nothing.
+
+**Next ask.** A FINEST-level log covering one execution of the code path, and a
+description of what invokes the method - a request, a timer, a queue consumer, or
+application startup.
+
+## 9. Runaway log volume
+
+**Symptom.** The agent log fills the disk, or a support dump arrives as several
+files sitting exactly at the rolling limit.
+
+**Check.** `nrlog.py sessions`. Compare `stated=` against `observed=`, and read
+the `level change:` lines.
+
+**Signature.**
+
+```
+The log level was updated to FINEST from INFO
+```
+
+**Verdict.** The level was raised at runtime, so the startup banner still says
+INFO while the file fills with FINEST. One `newrelic.config` edit produces one of
+these lines per app domain in the process, within seconds of each other. Give the
+engineer the timestamp of the change and the line count on each side of it: that
+pair is the whole diagnosis.
+
+**Limit.** The line records that the configuration changed, not who changed it.
+
+**Next ask.** Whether anyone raised the log level for troubleshooting and forgot
+to lower it, and the current `<log level="..." />` value in `newrelic.config`.
+Rolling limits (`maxLogFileSizeMB`, `maxLogFiles`) bound the damage but do not
+stop it.

--- a/.claude/skills/analyze-dotnet-agent-logs/scripts/nrlog.py
+++ b/.claude/skills/analyze-dotnet-agent-logs/scripts/nrlog.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+"""Parse New Relic .NET agent logs and profiler logs for support diagnosis.
+
+Standard library only. Every command streams its input and prints a summary,
+so a large log never has to be read whole.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta
+
+MANAGED_RE = re.compile(
+    r'^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) NewRelic\s+(\S+): '
+    r'\[pid: (\d+), tid: (\d+)\] (.*)$'
+)
+PROFILER_RE = re.compile(r'^\[(\w+)\s*\] (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (.*)$')
+
+START_RE = re.compile(
+    r"The New Relic \.NET Agent v(\S+) started \(pid (\d+)\) on app domain '(.*)'"
+)
+STOP_RE = re.compile(
+    r"The New Relic \.NET Agent v(\S+) has shutdown \(pid (\d+)\) on app domain '(.*)'"
+)
+LEVEL_RE = re.compile(r'Log level set to (\S+)')
+LEVEL_CHANGE_RE = re.compile(r'The log level was updated to (\S+) from (\S+)')
+
+REQ_RE = re.compile(r'^Request\(([^)]+)\): (.*)$', re.S)
+INVOKING_RE = re.compile(r'^Invoking "([^"]+)"')
+INVOKED_RE = re.compile(r'^Invoked "([^"]+)" with : (.*)$', re.S)
+YIELDED_RE = re.compile(r'^Invocation of "([^"]+)" yielded response : (.*)$', re.S)
+HEADERS_RE = re.compile(r'^Invocation of "([^"]+)" returned response headers : (.*)$', re.S)
+RECEIVED_RE = re.compile(
+    r'^Received a (\d+) (\S+) response invoking method "([^"]+)" with payload "(.*)"$', re.S
+)
+ERRORED_RE = re.compile(
+    r'^An error occurred invoking method "([^"]+)" with payload "(.*)": (.*)$', re.S
+)
+DROPPED_RE = re.compile(r'^Dropped large payload: size: (\d+), max_payload_size_bytes=(\d+)')
+
+REDACTIONS = [
+    (re.compile(r'(license[_.]?key["\s]*[:=]\s*"?)([^&"\s,}]+)', re.I), r'\1[REDACTED]'),
+    (re.compile(r'(LICENSE_KEY\b[^:\n]{0,20}:\s*)(\S+)', re.I), r'\1[REDACTED]'),
+    (re.compile(r'\b[0-9a-zA-Z]{36}NRAL\b'), '[REDACTED]'),
+    (re.compile(r'\b(NRAK|NRJS|NRII|NRRA|NRBR)-[0-9A-Za-z]{20,}\b'), '[REDACTED]'),
+    (re.compile(r'(security[_.]?policies[_.]?token["\s]*[:=]\s*"?)([^&"\s,}]+)', re.I),
+     r'\1[REDACTED]'),
+    (re.compile(r'(proxy[_.]?(?:user|pass|password)(?:[_.]?obfuscated)?["\s]*[:=]\s*"?)'
+                r'([^&"\s,}]+)', re.I), r'\1[REDACTED]'),
+    (re.compile(r'(obscuring[_.]?key["\s]*[:=]\s*"?)([^&"\s,}]+)', re.I), r'\1[REDACTED]'),
+    (re.compile(r'(Authorization["\s]*[:=]\s*"?)([^"\r\n,}]+)', re.I), r'\1[REDACTED]'),
+]
+
+PROFILER_SIGNATURES = [
+    ('initialized', 'Profiler initialized'),
+    ('process-rejected', 'is not configured to be instrumented'),
+    ('unloading', 'should not be instrumented, unloading profiler'),
+    ('config-found', 'Found newrelic.config at:'),
+    ('config-missing', 'The global newrelic.config file was not found at:'),
+    ('extensions-loaded', 'Loading instrumentation from'),
+    ('extensions-missing', 'Unable to find the New Relic Agent extensions directory'),
+    ('xml-read-failed', 'An exception was thrown while reading instrumentation file:'),
+    ('xml-parse-failed', 'Unable to parse one or more instrumentation files'),
+    ('rejit-class-missing', 'for rejit. HR:'),
+    ('runtime-too-old', 'or greater required. Profiler not attaching.'),
+    ('clr-init-failed', 'Error initializing CLR profiler info:'),
+    ('live-instrumentation', 'Applying live instrumentation'),
+]
+
+INSTRUMENTING_RE = re.compile(r'^Instrumenting (?:API |helper )?method: (.*)$')
+
+MERGE_GAP = timedelta(minutes=5)
+
+
+def redact(text):
+    for pattern, replacement in REDACTIONS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def parse_arg_ts(value):
+    for shape in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d'):
+        try:
+            return datetime.strptime(value, shape)
+        except ValueError:
+            continue
+    sys.exit('bad timestamp %r; use "YYYY-MM-DD HH:MM:SS"' % value)
+
+
+def parse_ts(value):
+    return datetime.strptime(value, '%Y-%m-%d %H:%M:%S,%f')
+
+
+def fmt_ts(value):
+    return value.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+
+class Session:
+    def __init__(self, pid, start, source):
+        self.pid = pid
+        self.start = start
+        self.end = start
+        self.version = None
+        self.appdomains = []
+        self.log_level = None
+        self.level_counts = {}
+        self.level_changes = []
+        self.lines = 0
+        self.files = [source]
+        self.starts = 0
+        self.stops = 0
+        self.interleaved = False
+        self.gap_note = None
+
+    @property
+    def all_closed(self):
+        return self.stops > 0 and self.stops >= self.starts
+
+    def add_appdomain(self, name):
+        if name not in self.appdomains:
+            self.appdomains.append(name)
+
+    def appdomain_label(self):
+        if not self.appdomains:
+            return '?'
+        if len(self.appdomains) == 1:
+            return self.appdomains[0]
+        return '%d app domains' % len(self.appdomains)
+
+    def level_label(self):
+        if not self.level_counts:
+            return 'not stated'
+        order = sorted(self.level_counts, key=lambda k: -self.level_counts[k])
+        return ','.join('%s:%d' % (k, self.level_counts[k]) for k in order)
+
+    def flags(self):
+        out = []
+        if self.starts == 0:
+            out.append('head-truncated')
+        if not self.all_closed:
+            out.append('tail-truncated')
+        if self.starts > 1:
+            out.append('appdomain-ambiguous')
+        elif not self.appdomains:
+            out.append('appdomain-unknown')
+        if self.interleaved:
+            out.append('interleaved')
+        if self.gap_note:
+            out.append('gap-split')
+        return out
+
+
+def is_managed_log(name):
+    lower = name.lower()
+    return (lower.startswith('newrelic_agent') and lower.endswith('.log')
+            and 'audit' not in lower)
+
+
+def is_profiler_log(name):
+    lower = name.lower()
+    return lower.startswith('newrelic.profiler.') and lower.endswith('.log')
+
+
+def first_timestamp(path):
+    try:
+        with open(path, 'r', encoding='utf-8', errors='replace') as handle:
+            for _ in range(500):
+                line = handle.readline()
+                if not line:
+                    break
+                match = MANAGED_RE.match(line.rstrip('\n'))
+                if match:
+                    return parse_ts(match.group(1))
+    except OSError:
+        pass
+    return None
+
+
+def collect_managed(path, name_filter=None):
+    if os.path.isfile(path):
+        found = [path]
+    elif os.path.isdir(path):
+        found = [os.path.join(path, n) for n in sorted(os.listdir(path)) if is_managed_log(n)]
+        if not found:
+            sys.exit('no newrelic_agent*.log files in %s' % path)
+    else:
+        sys.exit('not found: %s' % path)
+    if name_filter:
+        needle = name_filter.lower()
+        found = [p for p in found if needle in os.path.basename(p).lower()]
+        if not found:
+            sys.exit('no managed log matching --file %s' % name_filter)
+    return sorted(found, key=lambda p: (first_timestamp(p) or datetime.max, p))
+
+
+def iter_entries(paths):
+    """Yield (path, lineno, timestamp, level, pid, tid, message, raw) per parsed line.
+
+    Continuation lines yield timestamp None and inherit nothing; the caller
+    decides how to attach them.
+    """
+    for path in paths:
+        with open(path, 'r', encoding='utf-8', errors='replace') as handle:
+            for lineno, raw in enumerate(handle, 1):
+                raw = raw.rstrip('\n')
+                match = MANAGED_RE.match(raw)
+                if match:
+                    yield (path, lineno, parse_ts(match.group(1)), match.group(2),
+                           int(match.group(3)), int(match.group(4)), match.group(5), raw)
+                else:
+                    yield (path, lineno, None, None, None, None, None, raw)
+
+
+def build_sessions(paths):
+    open_sessions = {}
+    finished = []
+    last_file = {}
+
+    def close(pid):
+        session = open_sessions.pop(pid, None)
+        if session:
+            finished.append(session)
+
+    for path, _lineno, ts, _level, pid, _tid, message, _raw in iter_entries(paths):
+        if ts is None:
+            continue
+
+        start = START_RE.search(message)
+        stop = STOP_RE.search(message)
+        current = open_sessions.get(pid)
+
+        if current and last_file.get(pid) != path:
+            if ts - current.end > MERGE_GAP:
+                gap = ts - current.end
+                close(pid)
+                current = None
+                pending_gap = gap
+            else:
+                pending_gap = None
+                if path not in current.files:
+                    current.files.append(path)
+        else:
+            pending_gap = None
+
+        if start:
+            if current and current.all_closed:
+                close(pid)
+                current = None
+            if current is None:
+                current = Session(pid, ts, path)
+                open_sessions[pid] = current
+            current.starts += 1
+            current.version = current.version or start.group(1)
+            current.add_appdomain(start.group(3))
+        elif current is None:
+            current = Session(pid, ts, path)
+            if pending_gap:
+                current.gap_note = pending_gap
+            open_sessions[pid] = current
+
+        for other_pid, other in open_sessions.items():
+            if other_pid != pid:
+                other.interleaved = True
+
+        last_file[pid] = path
+        current.end = ts
+        current.lines += 1
+        token = _level.rstrip(':')
+        current.level_counts[token] = current.level_counts.get(token, 0) + 1
+        change = LEVEL_CHANGE_RE.search(message)
+        if change:
+            current.level_changes.append((ts, change.group(2), change.group(1)))
+        if stop:
+            current.stops += 1
+            current.version = current.version or stop.group(1)
+            current.add_appdomain(stop.group(3))
+        level = LEVEL_RE.search(message)
+        if level and not current.log_level:
+            current.log_level = level.group(1)
+
+    for pid in list(open_sessions):
+        close(pid)
+
+    finished.sort(key=lambda s: (s.start, s.pid))
+    return finished
+
+
+def print_session_rows(sessions):
+    print('%-4s %-8s %-23s %-23s %9s %-10s %s' %
+          ('#', 'pid', 'start (UTC)', 'end (UTC)', 'lines', 'version', 'app domain'))
+    for index, session in enumerate(sessions, 1):
+        print('%-4d %-8d %-23s %-23s %9d %-10s %s' % (
+            index, session.pid, fmt_ts(session.start), fmt_ts(session.end),
+            session.lines, session.version or '?', session.appdomain_label()))
+        detail = ['file=%s' % ','.join(os.path.basename(f) for f in session.files)]
+        detail.append('stated=%s' % (session.log_level or '?'))
+        detail.append('observed=%s' % session.level_label())
+        flags = session.flags()
+        if flags:
+            detail.append('flags=%s' % ','.join(flags))
+        if session.gap_note:
+            detail.append('gap-before=%s' % session.gap_note)
+        print('     %s' % '  '.join(detail))
+        for ts, was, now in session.level_changes[:4]:
+            print('     level change: %s %s -> %s' % (fmt_ts(ts), was, now))
+        if len(session.level_changes) > 4:
+            print('     ... %d more level changes' % (len(session.level_changes) - 4))
+        if len(session.appdomains) > 1:
+            print('     app domains: %s' % ', '.join(session.appdomains[:12]) +
+                  (' ...' if len(session.appdomains) > 12 else ''))
+
+
+def print_file_summary(sessions, paths):
+    print('%-52s %9s %6s %-23s %-23s' %
+          ('file', 'sessions', 'pids', 'first (UTC)', 'last (UTC)'))
+    by_file = {}
+    for session in sessions:
+        by_file.setdefault(os.path.basename(session.files[0]), []).append(session)
+    for name in sorted(by_file, key=lambda n: -len(by_file[n])):
+        group = by_file[name]
+        print('%-52s %9d %6d %-23s %-23s' % (
+            name[:52], len(group), len({s.pid for s in group}),
+            fmt_ts(min(s.start for s in group)), fmt_ts(max(s.end for s in group))))
+        levels = {}
+        for session in group:
+            for token, count in session.level_counts.items():
+                levels[token] = levels.get(token, 0) + count
+        busiest = max(group, key=lambda s: s.lines)
+        changes = sum(len(s.level_changes) for s in group)
+        print('     observed=%s  busiest=pid %d with %d lines%s' % (
+            ','.join('%s:%d' % (k, levels[k]) for k in sorted(levels, key=lambda k: -levels[k]))
+            or 'none', busiest.pid, busiest.lines,
+            '  level-changes=%d' % changes if changes else ''))
+    print()
+    print('%d session(s) across %d file(s). Narrow with --file <name>, '
+          'or list every session with --all.' % (len(sessions), len(paths)))
+
+
+def cmd_sessions(args):
+    paths = collect_managed(args.path, args.file)
+    sessions = build_sessions(paths)
+    if not sessions:
+        print('no parseable agent log lines found')
+        return
+    if len(sessions) > args.limit and not args.all:
+        print_file_summary(sessions, paths)
+        return
+    print_session_rows(sessions)
+    print()
+    print('%d session(s) across %d file(s)' % (len(sessions), len(paths)))
+
+
+def pick_session(paths, number):
+    sessions = build_sessions(paths)
+    if not sessions:
+        sys.exit('no parseable agent log lines found')
+    if number is None:
+        if len(sessions) > 1:
+            sys.exit('%d sessions found; pass --session N (run "sessions" first)'
+                     % len(sessions))
+        return sessions[0]
+    if number < 1 or number > len(sessions):
+        sys.exit('session %d out of range (1..%d)' % (number, len(sessions)))
+    return sessions[number - 1]
+
+
+def slim_message(message, max_width):
+    request = REQ_RE.match(message)
+    if request:
+        guid, rest = request.group(1), request.group(2)
+        invoked = INVOKED_RE.match(rest)
+        if invoked:
+            return ('Request(%s): Invoked "%s" with : <request body %d bytes; '
+                    'nrlog.py body --request %s --direction request>'
+                    % (guid, invoked.group(1), len(invoked.group(2)), guid))
+        yielded = YIELDED_RE.match(rest)
+        if yielded:
+            return ('Request(%s): Invocation of "%s" yielded response : '
+                    '<response body %d bytes; nrlog.py body --request %s '
+                    '--direction response>'
+                    % (guid, yielded.group(1), len(yielded.group(2)), guid))
+        received = RECEIVED_RE.match(rest)
+        if received:
+            return ('Request(%s): Received a %s %s response invoking method "%s" '
+                    'with payload <%d bytes>'
+                    % (guid, received.group(1), received.group(2), received.group(3),
+                       len(received.group(4))))
+    if len(message) > max_width:
+        return '%s ... [+%d chars elided]' % (message[:max_width], len(message) - max_width)
+    return message
+
+
+def out_dir_for(paths, override):
+    if override:
+        target = override
+    else:
+        base = os.path.dirname(os.path.abspath(paths[0]))
+        target = os.path.join(base, 'nrlog-work')
+    os.makedirs(target, exist_ok=True)
+    return target
+
+
+def cmd_extract(args):
+    paths = collect_managed(args.path, args.file)
+    session = pick_session(paths, args.session)
+    target_dir = out_dir_for(paths, args.out)
+    suffix = ''
+    for label, value in (('lvl', args.level), ('since', args.since),
+                         ('until', args.until), ('grep', args.grep)):
+        if value:
+            suffix += '-%s_%s' % (label, re.sub(r'[^A-Za-z0-9]+', '', value)[:20])
+    name = 'session-%s-pid%d-%s%s.slim.log' % (
+        args.session or 1, session.pid, session.start.strftime('%Y%m%dT%H%M%S'), suffix)
+    target = os.path.join(target_dir, name)
+
+    levels = {v.upper() for v in args.level.split(',')} if args.level else None
+    since = parse_arg_ts(args.since) if args.since else None
+    until = parse_arg_ts(args.until) if args.until else None
+    needle = re.compile(args.grep) if args.grep else None
+
+    kept = 0
+    with open(target, 'w', encoding='utf-8') as sink:
+        sink.write('# nrlog.py slim extract: pid %d, %s .. %s, flags: %s\n'
+                   % (session.pid, fmt_ts(session.start), fmt_ts(session.end),
+                      ','.join(session.flags()) or 'none'))
+        sink.write('# source: %s\n' % ', '.join(os.path.basename(f) for f in session.files))
+        sink.write('# payload bodies stripped; secrets redacted\n')
+        ours = False
+        for path, _lineno, ts, level, pid, tid, message, raw in iter_entries(session.files):
+            if ts is None:
+                if ours:
+                    sink.write(redact(raw[:args.max_width]) + '\n')
+                continue
+            ours = pid == session.pid and session.start <= ts <= session.end
+            if ours and levels and level.rstrip(':').upper() not in levels:
+                ours = False
+            if ours and since and ts < since:
+                ours = False
+            if ours and until and ts > until:
+                ours = False
+            if ours and needle and not needle.search(message):
+                ours = False
+            if not ours:
+                continue
+            sink.write('%s NewRelic %6s: [pid: %d, tid: %d] %s\n' % (
+                ts.strftime('%Y-%m-%d %H:%M:%S,') + '%03d' % (ts.microsecond // 1000),
+                level, pid, tid, redact(slim_message(message, args.max_width))))
+            kept += 1
+    size = os.path.getsize(target)
+    print('wrote %s' % target)
+    print('%d entries, %.1f MB, pid %d, %s .. %s'
+          % (kept, size / 1048576.0, session.pid,
+             fmt_ts(session.start), fmt_ts(session.end)))
+    if size > 5 * 1048576:
+        print('This slim file is still too large to read whole. Narrow it with '
+              '--level, --since, --until, or --grep, or grep it for counts first.')
+    if session.flags():
+        print('flags: %s' % ','.join(session.flags()))
+    if session.log_level:
+        print('stated log level: %s' % session.log_level)
+    else:
+        print('stated log level: not stated in this window')
+    print('observed levels: %s' % session.level_label())
+    for ts, was, now in session.level_changes:
+        print('level change: %s %s -> %s' % (fmt_ts(ts), was, now))
+
+
+def classify_request(rest):
+    invoking = INVOKING_RE.match(rest)
+    if invoking:
+        return ('invoking', invoking.group(1), 0, '')
+    invoked = INVOKED_RE.match(rest)
+    if invoked:
+        return ('request', invoked.group(1), len(invoked.group(2)), '')
+    yielded = YIELDED_RE.match(rest)
+    if yielded:
+        return ('response', yielded.group(1), len(yielded.group(2)), '200')
+    headers = HEADERS_RE.match(rest)
+    if headers:
+        return ('headers', headers.group(1), len(headers.group(2)), '')
+    received = RECEIVED_RE.match(rest)
+    if received:
+        return ('error', received.group(3), len(received.group(4)),
+                '%s %s' % (received.group(1), received.group(2)))
+    errored = ERRORED_RE.match(rest)
+    if errored:
+        return ('exception', errored.group(1), len(errored.group(2)), 'exception')
+    dropped = DROPPED_RE.match(rest)
+    if dropped:
+        return ('dropped', '?', int(dropped.group(1)),
+                'over %s bytes' % dropped.group(2))
+    return None
+
+
+def cmd_payloads(args):
+    paths = collect_managed(args.path, args.file)
+    session = pick_session(paths, args.session) if args.session else None
+    rows = []
+    counts = {}
+    for _path, _lineno, ts, _level, pid, _tid, message, _raw in iter_entries(paths):
+        if ts is None:
+            continue
+        if session and (pid != session.pid or not
+                        (session.start <= ts <= session.end)):
+            continue
+        request = REQ_RE.match(message)
+        if not request:
+            continue
+        found = classify_request(request.group(2))
+        if not found:
+            continue
+        kind, endpoint, size, status = found
+        if kind == 'invoking' and not args.all:
+            continue
+        rows.append((ts, request.group(1), endpoint, kind, size, status))
+        counts[endpoint] = counts.get(endpoint, 0) + (1 if kind == 'request' else 0)
+
+    if not rows:
+        print('no collector calls in scope. At INFO level the agent logs none of them.')
+        return
+    print('%-23s %-38s %-24s %-9s %9s %s' %
+          ('time (UTC)', 'request guid', 'endpoint', 'kind', 'bytes', 'status'))
+    for ts, guid, endpoint, kind, size, status in rows[:args.limit]:
+        print('%-23s %-38s %-24s %-9s %9d %s' %
+              (fmt_ts(ts), guid, endpoint, kind, size, status))
+    if len(rows) > args.limit:
+        print('... %d more (raise --limit)' % (len(rows) - args.limit))
+    print()
+    print('requests by endpoint:')
+    for endpoint in sorted(counts):
+        if counts[endpoint]:
+            print('  %-24s %d' % (endpoint, counts[endpoint]))
+
+
+def cmd_body(args):
+    paths = collect_managed(args.path, args.file)
+    wanted = {'request': INVOKED_RE, 'response': YIELDED_RE, 'headers': HEADERS_RE}
+    pattern = wanted[args.direction]
+    for _path, _lineno, ts, _level, _pid, _tid, message, _raw in iter_entries(paths):
+        if ts is None:
+            continue
+        request = REQ_RE.match(message)
+        if not request or request.group(1) != args.request:
+            continue
+        match = pattern.match(request.group(2))
+        if not match:
+            continue
+        body = redact(match.group(2))
+        print('# %s %s %s (%d bytes)' % (fmt_ts(ts), args.direction, match.group(1),
+                                         len(body)))
+        if len(body) > args.max_bytes:
+            print('# truncated to %d bytes; raise --max-bytes to see more'
+                  % args.max_bytes)
+            body = body[:args.max_bytes]
+        if args.raw:
+            print(body)
+            return
+        try:
+            print(json.dumps(json.loads(body), indent=2)[:args.max_bytes])
+        except ValueError:
+            print(body)
+        return
+    sys.exit('no %s body found for request %s' % (args.direction, args.request))
+
+
+def cmd_decode(args):
+    value = args.value if args.value else sys.stdin.read()
+    value = value.strip()
+    padded = value + '=' * (-len(value) % 4)
+    try:
+        raw = base64.b64decode(padded)
+    except Exception as error:
+        sys.exit('not base64: %s' % error)
+    if args.key:
+        key = args.key.encode('utf-8')
+        raw = bytes(b ^ key[i % len(key)] for i, b in enumerate(raw))
+    text = raw.decode('utf-8', errors='replace')
+    try:
+        print(json.dumps(json.loads(text), indent=2))
+    except ValueError:
+        print(text)
+
+
+def read_profiler(path):
+    entries = []
+    with open(path, 'r', encoding='utf-8', errors='replace') as handle:
+        for raw in handle:
+            match = PROFILER_RE.match(raw.rstrip('\n'))
+            if match:
+                entries.append((match.group(1).strip(), match.group(2), match.group(3)))
+    return entries
+
+
+def resolve_profiler_path(path):
+    if os.path.isfile(path):
+        return [path]
+    if os.path.isdir(path):
+        found = [os.path.join(path, n) for n in sorted(os.listdir(path))
+                 if is_profiler_log(n)]
+        if found:
+            return found
+    sys.exit('no NewRelic.Profiler.<pid>.log found at %s' % path)
+
+
+def profiler_roster(paths, args):
+    """Aggregate view for a directory of profiler logs, of which most are noise."""
+    groups = {}
+    empty = []
+    total_instrumented = 0
+    for path in paths:
+        entries = read_profiler(path)
+        if not entries:
+            empty.append(path)
+            continue
+        names = set()
+        for _level, _ts, message in entries:
+            for name, needle in PROFILER_SIGNATURES:
+                if needle in message:
+                    names.add(name)
+        instrumented = sum(1 for _l, _t, m in entries if INSTRUMENTING_RE.match(m))
+        total_instrumented += instrumented
+        key = tuple(sorted(names)) or ('no-known-signature',)
+        groups.setdefault(key, []).append((path, entries[0][1], entries[-1][1], instrumented))
+
+    print('%d profiler log(s), %d with no parseable lines' % (len(paths), len(empty)))
+    print()
+    def rank(key):
+        return (0 if 'initialized' in key else 1,
+                0 if 'rejit-class-missing' in key or 'xml-read-failed' in key else 1,
+                -len(groups[key]))
+
+    for key in sorted(groups, key=rank):
+        members = groups[key]
+        print('%d file(s): %s' % (len(members), ', '.join(key)))
+        interesting = 'initialized' in key
+        shown = sorted(members, key=lambda m: -m[3])[:args.limit if interesting else 3]
+        for path, first, last, instrumented in shown:
+            print('   %-34s %s .. %s  instrumented=%d'
+                  % (os.path.basename(path), first, last, instrumented))
+        if len(members) > len(shown):
+            print('   ... %d more' % (len(members) - len(shown)))
+    print()
+    print('total instrumented-method lines across all files: %d' % total_instrumented)
+    print('Pass a single NewRelic.Profiler.<pid>.log for the full per-file view.')
+
+
+def cmd_profiler(args):
+    paths = resolve_profiler_path(args.path)
+    if len(paths) > args.roster_above:
+        profiler_roster(paths, args)
+        return
+    for path in paths:
+        entries = read_profiler(path)
+        print('== %s' % os.path.basename(path))
+        if not entries:
+            print('   no parseable profiler lines. The file exists but the profiler '
+                  'wrote nothing readable.')
+            continue
+        pid_match = re.search(r'NewRelic\.Profiler\.(\d+)\.log', os.path.basename(path))
+        print('   pid %s, %s .. %s, %d lines'
+              % (pid_match.group(1) if pid_match else '?', entries[0][1],
+                 entries[-1][1], len(entries)))
+        levels = {}
+        for level, _ts, _msg in entries:
+            levels[level] = levels.get(level, 0) + 1
+        print('   levels: %s' % ', '.join('%s=%d' % (k, levels[k]) for k in sorted(levels)))
+
+        hits = {}
+        for _level, ts, message in entries:
+            for name, needle in PROFILER_SIGNATURES:
+                if needle in message:
+                    hits.setdefault(name, []).append((ts, message))
+        for name, _needle in PROFILER_SIGNATURES:
+            found = hits.get(name)
+            if not found:
+                continue
+            print('   [%s] x%d' % (name, len(found)))
+            for ts, message in found[:args.limit]:
+                print('      %s %s' % (ts, message.strip()))
+            if len(found) > args.limit:
+                print('      ... %d more' % (len(found) - args.limit))
+        if 'initialized' not in hits:
+            print('   [initialized] MISSING - the profiler did not finish loading')
+
+        instrumented = {m for _l, _t, m in entries if INSTRUMENTING_RE.match(m)}
+        print('   instrumented methods: %d (see "instrumented" command)' % len(instrumented))
+        problems = [(l, t, m) for l, t, m in entries if l in ('Error', 'Warn')]
+        if problems:
+            print('   warnings and errors: %d' % len(problems))
+            for level, ts, message in problems[:args.limit]:
+                print('      [%s] %s %s' % (level, ts, message.strip()))
+            if len(problems) > args.limit:
+                print('      ... %d more' % (len(problems) - args.limit))
+
+
+def cmd_instrumented(args):
+    pattern = re.compile(args.filter) if args.filter else None
+    for path in resolve_profiler_path(args.path):
+        names = set()
+        for _level, _ts, message in read_profiler(path):
+            match = INSTRUMENTING_RE.match(message)
+            if match:
+                name = match.group(1).strip()
+                if pattern is None or pattern.search(name):
+                    names.add(name)
+        print('== %s: %d method(s)%s' % (os.path.basename(path), len(names),
+                                         ' matching filter' if pattern else ''))
+        for name in sorted(names)[:args.limit]:
+            print('   %s' % name)
+        if len(names) > args.limit:
+            print('   ... %d more (raise --limit)' % (len(names) - args.limit))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    sessions = subparsers.add_parser('sessions', help='list agent runs in a file or directory')
+    sessions.add_argument('path')
+    sessions.add_argument('--file', help='only files whose name contains this text')
+    sessions.add_argument('--all', action='store_true',
+                          help='list every session instead of the per-file summary')
+    sessions.add_argument('--limit', type=int, default=40,
+                          help='summarize per file above this many sessions (default 40)')
+    sessions.set_defaults(func=cmd_sessions)
+
+    extract = subparsers.add_parser('extract', help='write a slim redacted file for one session')
+    extract.add_argument('path')
+    extract.add_argument('--file', help='only files whose name contains this text')
+    extract.add_argument('--session', type=int, help='session number from "sessions"')
+    extract.add_argument('--out', help='output directory (default: nrlog-work beside the log)')
+    extract.add_argument('--level', help='comma-separated levels to keep, e.g. WARN,ERROR')
+    extract.add_argument('--since', help='keep entries at or after this UTC time')
+    extract.add_argument('--until', help='keep entries at or before this UTC time')
+    extract.add_argument('--grep', help='keep entries whose message matches this regex')
+    extract.add_argument('--max-width', type=int, default=400,
+                         help='elide messages longer than this (default 400)')
+    extract.set_defaults(func=cmd_extract)
+
+    payloads = subparsers.add_parser('payloads', help='index collector calls')
+    payloads.add_argument('path')
+    payloads.add_argument('--file', help='only files whose name contains this text')
+    payloads.add_argument('--session', type=int)
+    payloads.add_argument('--limit', type=int, default=200)
+    payloads.add_argument('--all', action='store_true',
+                          help='include FINEST "Invoking" lines')
+    payloads.set_defaults(func=cmd_payloads)
+
+    body = subparsers.add_parser('body', help='print one request or response body')
+    body.add_argument('path')
+    body.add_argument('--file', help='only files whose name contains this text')
+    body.add_argument('--request', required=True, help='request guid from "payloads"')
+    body.add_argument('--direction', default='request',
+                      choices=['request', 'response', 'headers'])
+    body.add_argument('--max-bytes', type=int, default=20000)
+    body.add_argument('--raw', action='store_true', help='skip JSON pretty printing')
+    body.set_defaults(func=cmd_body)
+
+    decode = subparsers.add_parser('decode', help='decode a base64 distributed-trace payload')
+    decode.add_argument('--value', help='payload text (default: read stdin)')
+    decode.add_argument('--key', help='encoding_key, for XOR-obfuscated CAT headers')
+    decode.set_defaults(func=cmd_decode)
+
+    profiler = subparsers.add_parser('profiler', help='summarize a profiler log')
+    profiler.add_argument('path')
+    profiler.add_argument('--limit', type=int, default=10)
+    profiler.add_argument('--roster-above', type=int, default=8,
+                          help='summarize as a roster above this many files (default 8)')
+    profiler.set_defaults(func=cmd_profiler)
+
+    instrumented = subparsers.add_parser('instrumented',
+                                         help='list methods the profiler rewrote')
+    instrumented.add_argument('path')
+    instrumented.add_argument('--filter', help='regex over the method signature')
+    instrumented.add_argument('--limit', type=int, default=200)
+    instrumented.set_defaults(func=cmd_instrumented)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/analyze-dotnet-agent-logs/tests/.gitignore
+++ b/.claude/skills/analyze-dotnet-agent-logs/tests/.gitignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/.claude/skills/analyze-dotnet-agent-logs/tests/make_fixtures.py
+++ b/.claude/skills/analyze-dotnet-agent-logs/tests/make_fixtures.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Write synthetic agent and profiler logs for regression-testing nrlog.py.
+
+Usage: make_fixtures.py [output-dir]   (default: <this dir>/fixtures/logs)
+
+Every line matches a format verified against agent source. The license key is
+planted deliberately so a redaction check can grep the derived files for it.
+"""
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'fixtures', 'logs')
+os.makedirs(OUT, exist_ok=True)
+
+KEY = 'abcdefghij0123456789klmnopqrstuvwxyz' + 'NRAL'
+
+
+def line(ts, level, pid, tid, msg):
+    return '%s NewRelic %6s: [pid: %d, tid: %d] %s\n' % (ts, level, pid, tid, msg)
+
+
+rolled = []
+# head-truncated session for pid 8412: starts mid-run, no start banner
+rolled.append(line('2026-08-18 13:58:00,001', 'INFO', 8412, 1,
+                   'Your New Relic Application Name(s): OldApp'))
+rolled.append(line('2026-08-18 13:58:01,002', 'INFO', 8412, 1,
+                   'The New Relic .NET Agent v10.44.0 has shutdown (pid 8412) on app domain '
+                   "'/LM/W3SVC/1/ROOT'"))
+
+with open(os.path.join(OUT, 'newrelic_agent_MyApp_001.log'), 'w') as f:
+    f.writelines(rolled)
+
+main = []
+# full session: both banners, DEBUG level, collector payloads, pid 8412 restart
+main.append(line('2026-08-18 14:03:11,123', 'INFO', 8412, 1,
+                 'The New Relic .NET Agent v10.44.0 started (pid 8412) on app domain '
+                 "'/LM/W3SVC/2/ROOT'"))
+main.append(line('2026-08-18 14:03:11,130', 'INFO', 8412, 1, 'Log level set to DEBUG'))
+main.append(line('2026-08-18 14:03:11,140', 'DEBUG', 8412, 1,
+                 'Environment Variable NEW_RELIC_APP_NAME value: MyApp'))
+main.append(line('2026-08-18 14:03:11,150', 'DEBUG', 8412, 1,
+                 'Environment Variable NEW_RELIC_LICENSE_KEY is configured with a value. '
+                 'Not logging potentially sensitive value'))
+main.append(line('2026-08-18 14:03:12,000', 'FINEST', 8412, 5,
+                 'Request(11111111-1111-1111-1111-111111111111): Invoking "preconnect"'))
+main.append(line('2026-08-18 14:03:12,100', 'DEBUG', 8412, 5,
+                 'Request(11111111-1111-1111-1111-111111111111): Invoked "preconnect" with : '
+                 '[{"high_security":false}]'))
+main.append(line('2026-08-18 14:03:12,200', 'DEBUG', 8412, 5,
+                 'Request(11111111-1111-1111-1111-111111111111): Invocation of "preconnect" '
+                 'yielded response : {"return_value":{"redirect_host":"collector-1.nr.com"}}'))
+main.append(line('2026-08-18 14:03:13,000', 'DEBUG', 8412, 5,
+                 'Request(22222222-2222-2222-2222-222222222222): Invoked "connect" with : '
+                 '[{"pid":8412,"app_name":["MyApp"],'
+                 '"settings":{"agent.license_key.configured":true}}]'))
+main.append(line('2026-08-18 14:03:13,300', 'DEBUG', 8412, 5,
+                 'Request(22222222-2222-2222-2222-222222222222): Invocation of "connect" '
+                 'yielded response : {"return_value":{"agent_run_id":"123456789",'
+                 '"collect_span_events":false,"max_payload_size_in_bytes":1000000}}'))
+main.append(line('2026-08-18 14:03:13,400', 'INFO', 8412, 5,
+                 'Agent MyApp connected to collector-1.nr.com:443'))
+main.append(line('2026-08-18 14:03:13,500', 'INFO', 8412, 5, 'Agent fully connected.'))
+# interleaved second pid inside the same range
+main.append(line('2026-08-18 14:03:14,000', 'INFO', 9100, 1,
+                 'The New Relic .NET Agent v10.44.0 started (pid 9100) on app domain '
+                 "'/LM/W3SVC/3/ROOT'"))
+main.append(line('2026-08-18 14:03:14,100', 'INFO', 9100, 1, 'Log level set to INFO'))
+# error response, then an exception whose text carries the URI and the license key
+main.append(line('2026-08-18 14:04:00,000', 'DEBUG', 8412, 5,
+                 'Request(33333333-3333-3333-3333-333333333333): Received a 401 Unauthorized '
+                 'response invoking method "metric_data" with payload "[\\"123456789\\",[]]"'))
+main.append(line('2026-08-18 14:04:00,010', 'ERROR', 8412, 5,
+                 'Request(33333333-3333-3333-3333-333333333333): An error occurred invoking '
+                 'method "metric_data" with payload "[]": System.Net.WebException: The remote '
+                 'server returned an error while calling '
+                 'https://collector-1.nr.com/agent_listener/invoke_raw_method?method=metric_data'
+                 '&license_key=' + KEY + '&marshal_format=json'))
+main.append('   at NewRelic.Agent.Core.DataTransport.HttpCollectorWire.SendData()\n')
+main.append('   at NewRelic.Agent.Core.DataTransport.DataTransportService.Send()\n')
+main.append(line('2026-08-18 14:05:00,000', 'ERROR', 8412, 5,
+                 'Request(44444444-4444-4444-4444-444444444444): Dropped large payload: '
+                 'size: 2000000, max_payload_size_bytes=1000000'))
+main.append(line('2026-08-18 14:06:00,000', 'FINEST', 8412, 7,
+                 'No transaction, skipping method MyCo.Worker.Poll(System.String)'))
+main.append(line('2026-08-18 14:31:02,881', 'INFO', 8412, 1,
+                 'The New Relic .NET Agent v10.44.0 has shutdown (pid 8412) on app domain '
+                 "'/LM/W3SVC/2/ROOT'"))
+
+with open(os.path.join(OUT, 'newrelic_agent_MyApp.log'), 'w') as f:
+    f.writelines(main)
+
+# multi-app-domain session: one pid, three start banners, one runtime level change
+shared = []
+for index, domain in enumerate(('/', '/DataServices', '/AngularClient')):
+    shared.append(line('2026-08-18 16:00:0%d,000' % index, 'INFO', 6000, 1,
+                       'The New Relic .NET Agent v10.53.0.0 started (pid 6000) on app domain '
+                       "'%s'" % domain))
+    shared.append(line('2026-08-18 16:00:0%d,500' % index, 'INFO', 6000, 1,
+                       'Log level set to INFO'))
+shared.append(line('2026-08-18 16:10:00,000', 'INFO', 6000, 1,
+                   'The log level was updated to FINEST from INFO'))
+shared.append(line('2026-08-18 16:10:00,100', 'FINEST', 6000, 9,
+                   'Trx Noop: Attempting to execute wrapper'))
+
+with open(os.path.join(OUT, 'newrelic_agent_Shared.log'), 'w') as f:
+    f.writelines(shared)
+
+prof = [
+    '[Info ] 2026-08-18 14:03:09 Logger initialized.\n',
+    '[Info ] 2026-08-18 14:03:09 Found newrelic.config at: '
+    'C:\\ProgramData\\New Relic\\.NET Agent\\newrelic.config\n',
+    '[Info ] 2026-08-18 14:03:09 Loading instrumentation from '
+    'C:\\ProgramData\\New Relic\\.NET Agent\\extensions\n',
+    '[Error] 2026-08-18 14:03:09 An exception was thrown while reading instrumentation file: '
+    'C:\\ProgramData\\New Relic\\.NET Agent\\extensions\\custom.xml - ignoring this file.\n',
+    '[Info ] 2026-08-18 14:03:10 Profiler initialized\n',
+    '[Info ] 2026-08-18 14:03:11 Unable to find MyCo.Missing.Class for rejit. HR:-2147483645\n',
+    '[Info ] 2026-08-18 14:03:12 Instrumenting method: MyCo.Worker.Poll(System.String)\n',
+    '[Info ] 2026-08-18 14:03:12 Instrumenting API method: '
+    'NewRelic.Api.Agent.NewRelic.NoticeError(System.Exception)\n',
+    '[Warn ] 2026-08-18 14:03:13 Unable to find the New Relic Agent extensions directory '
+    '(C:\\nope).\n',
+]
+with open(os.path.join(OUT, 'NewRelic.Profiler.8412.log'), 'w') as f:
+    f.writelines(prof)
+
+rejected = [
+    '[Info ] 2026-08-18 15:00:00 This process (C:\\Apps\\MyApp\\MyApp.exe) is not configured '
+    'to be instrumented.\n',
+    '[Info ] 2026-08-18 15:00:00 This process should not be instrumented, unloading profiler.\n',
+]
+with open(os.path.join(OUT, 'NewRelic.Profiler.7777.log'), 'w') as f:
+    f.writelines(rejected)
+
+print('fixtures written to %s' % OUT)
+print('license key planted: %s' % KEY)

--- a/.claude/skills/analyze-dotnet-agent-logs/tests/make_merge_fixtures.py
+++ b/.claude/skills/analyze-dotnet-agent-logs/tests/make_merge_fixtures.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Write rolled-file fixtures that exercise cross-file session merging.
+
+Usage: make_merge_fixtures.py [output-dir]   (default: <this dir>/fixtures)
+
+Creates two directories:
+  merge-yes  one run rolled mid-session; nrlog.py must report ONE session
+  merge-no   same pid resuming after 40 minutes; must report TWO sessions
+"""
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BASE = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'fixtures')
+
+BANNER = ("The New Relic .NET Agent v10.44.0 started (pid 5000) on app domain "
+          "'/LM/W3SVC/9/ROOT'")
+SHUTDOWN = ("The New Relic .NET Agent v10.44.0 has shutdown (pid 5000) on app domain "
+            "'/LM/W3SVC/9/ROOT'")
+
+
+def line(ts, level, pid, tid, msg):
+    return '%s NewRelic %6s: [pid: %d, tid: %d] %s\n' % (ts, level, pid, tid, msg)
+
+
+def write(dirname, files):
+    out = os.path.join(BASE, dirname)
+    os.makedirs(out, exist_ok=True)
+    for name, lines in files.items():
+        with open(os.path.join(out, name), 'w') as handle:
+            handle.writelines(lines)
+    print('wrote %s' % out)
+
+
+older = [
+    line('2026-08-18 10:00:00,000', 'INFO', 5000, 1, BANNER),
+    line('2026-08-18 10:00:00,100', 'INFO', 5000, 1, 'Log level set to INFO'),
+    line('2026-08-18 10:05:00,000', 'INFO', 5000, 1, 'Agent fully connected.'),
+]
+
+# rolled 2 seconds later: one continuous run
+newer = [
+    line('2026-08-18 10:05:02,000', 'INFO', 5000, 1,
+         'Your New Relic Application Name(s): Rolled'),
+    line('2026-08-18 10:09:00,000', 'INFO', 5000, 1, SHUTDOWN),
+]
+write('merge-yes', {'newrelic_agent_Rolled_001.log': older,
+                    'newrelic_agent_Rolled.log': newer})
+
+# resumes 40 minutes later with no banner: two separate sessions
+gapped = [
+    line('2026-08-18 10:45:00,000', 'INFO', 5000, 1,
+         'Your New Relic Application Name(s): Later'),
+    line('2026-08-18 10:46:00,000', 'INFO', 5000, 1, 'Agent fully connected.'),
+]
+write('merge-no', {'newrelic_agent_Rolled_001.log': older,
+                   'newrelic_agent_Rolled.log': gapped})

--- a/.claude/skills/triage-integration-test-failures/SKILL.md
+++ b/.claude/skills/triage-integration-test-failures/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: triage-integration-test-failures
+description: Use when a CI integration, unbounded, or container test job fails intermittently, passes on a rerun, fails identically across every matrix variant, or shows an infra-shaped error (connection timeout, account lock, native crash, docker daemon not ready) rather than a clear assertion diff -- the cause may be environmental, tooling, or a real product defect exposed only sometimes. Classify the failure before proposing any fix.
+---
+
+# Triage integration test failures
+
+## Overview
+
+A failure investigation ends with one of five remedies, not a patch guessed
+under time pressure. Classify the failure first. The category decides the
+remedy; the wrong category produces a fix that treats a symptom.
+
+**REQUIRED BACKGROUND:** superpowers:systematic-debugging governs root-cause
+work in general. This skill adds the classification step and the toolkit
+specific to this repo's CI, agent, and test infrastructure.
+
+## Hard rule: delegate the reading
+
+A CI job log, an `az monitor`/`kubectl` dump, and an agent log are evidence,
+not the deliverable. None of them belongs in the main session.
+
+- Run every command in the toolkit below inside a subagent (Agent tool --
+  general-purpose or Explore), not in the main session. Give the subagent
+  the exact command and the exact question ("did this job fail on a
+  connection error before any agent code ran, or on an assertion diff?");
+  it returns a short verdict with the one or two evidence lines that prove
+  it, never the raw log or the full command output.
+- This applies even to a "quick look" -- a CI log or agent log runs to
+  hundreds of KB or has single lines tens of KB wide, and once that text
+  lands in the main session it is re-billed on every later turn for the
+  rest of the investigation.
+- For agent-log evidence specifically, dispatch a subagent that follows the
+  **analyze-dotnet-agent-logs** skill; do not hand-parse the log yourself
+  even inside that subagent.
+- The main session's job is Steps 2-4: collect verdicts, classify, decide,
+  and record the decision. It holds conclusions, not evidence bytes.
+
+## Step 1: is it even a flake?
+
+- Same PR, same test, one run failed and a rerun passed with no code change:
+  flake. Continue.
+- Fails on every run, or only after a real code change: this is a
+  regression, not a flake. Use superpowers:systematic-debugging instead.
+- Check `gh run list` for the workflow: has this exact test or job failed
+  before on unrelated PRs? Count occurrences of the exact signature across
+  recent scheduled runs, and state the rate as per-run, not per-call -- one
+  occurrence in 100 runs is not proof of absence. A recurring signature
+  across unrelated changes is strong evidence of an environmental cause, not
+  a code bug.
+
+## Step 2: classify by evidence, not guess
+
+Before matching a row, trace the failing message or exception string to the
+code that emits it, and note whether the assertion sits in the test body or
+in fixture setup/teardown (e.g. `RemoteApplicationFixture.TestForKnownProblems`
+is a health check, not the test's own logic) -- this decides which row
+applies.
+
+| Category | Signature | Evidence to pull |
+|---|---|---|
+| **Infra / cluster** | Whole class of tests fails identically across every framework/OS variant in the same run; error is a connection, timeout, or account/lock error thrown before any agent code runs | `az monitor metrics list` on the AKS node and load balancer; `kubectl get pods -n unbounded-services -o wide` for restarts/uptime; does a bare retry pass (transient) or fail identically (persistent server state)? |
+| **Timing / race** | Assertion is a count or an event that "usually" arrives, on a harvest or aggregator cycle; failure shows the right data, late or short by one cycle | The agent log, via **analyze-dotnet-agent-logs** -- confirm the exact interleaving (e.g. Seen vs Sent counts) before touching the test |
+| **Tooling / dependency bug** | Crash signature is inside a third-party tool's native code, not in test or agent code; all tests report `Passed`, only the collector/runner process dies | The crash stack (module name, access-violation code); the tool's own changelog/issue tracker for a fix version already in flight |
+| **External / upstream** | Error surfaces in CI infrastructure setup (runner boot, docker daemon, VM image), not in the app or the agent at all | Search the CI vendor's own issue tracker (e.g. `actions/runner-images`) for the exact error string before assuming it's local |
+| **Product defect, exposed nondeterministically** | The traced assertion is a health check or invariant (fixture setup/teardown), or the emitting code shows a structural hole (missing try/finally, unguarded async race) | The suspect code path traced above; a repro run that proves the path executed (see Toolkit) |
+
+Never conclude "just flaky" without pulling at least one row's evidence. See
+[[feedback_no_guessing]] -- a root cause claim needs a log line, a metric, or
+a matching upstream issue behind it, not a hunch. An assertion that exists to
+catch a product defect is never reclassified as timing/race and its
+threshold is never widened -- trace and fix the defect instead.
+
+## Step 3: pick the remedy for the category
+
+| Category | Remedy | Do NOT |
+|---|---|---|
+| Infra, transient (network blip) | CI-level retry-once on the job, plus raise the client-side timeout that actually stalled; document as an accepted risk | Silently widen unrelated timeouts repo-wide |
+| Infra, persistent server state (account lock, stuck pod) | Operational fix (restart the pod/service); decide explicitly whether to harden the exposure, and record that decision even if the answer is "no, too costly" | Write code to retry around infra state that a retry cannot clear |
+| Timing / race in event-harvest assertions | A race-free wait keyed on the **exact asserted evidence** (e.g. an `AgentLogBase.WaitForMetricAggregateCallCount`-style helper polling the real aggregate) | Bump a harvest-cycle magic number again -- each prior bump on the same test is evidence the race is still there, only the window changed |
+| Tooling bug with no correctness impact | Wait for the upstream version bump already in flight; record the specific version and re-check after it lands | Change unrelated project settings (e.g. PDB format) as a workaround before confirming the bump doesn't already fix it |
+| External/upstream CI regression | Apply the vendor's own recommended workaround inside the repo's CI composite action/step; link the upstream issue in a comment; remove the workaround once fixed upstream | Invent a bespoke workaround when the vendor already published one |
+| Product defect, exposed nondeterministically | Trace the code path, file a ticket, leave the check alone; hand off to superpowers:systematic-debugging with the gathered evidence as the starting hypothesis and stop triage | Reclassify as timing/race, widen the assertion or its timeout, or suppress it to keep CI green |
+
+## Step 4: record the decision
+
+Every one of the categories above ends in a decision someone will ask about
+again ("why don't we just fix the LB exposure", "did coverlet ever get
+bumped"). Capture, in a project memory or handoff note:
+
+1. The failure signature and the run/job that showed it.
+2. The evidence that ruled out the other categories.
+3. The remedy chosen, and what was explicitly rejected and why.
+4. Anything left open (a version to watch for, a follow-up not started).
+
+## Toolkit quick reference
+
+Each row runs inside a subagent per the hard rule above; the main session
+sees only the verdict it returns.
+
+- Both `gh run view --job <id> --log-failed` and `--log` truncate silently
+  past ~889 lines / 168KB, cutting off mid agent-log dump. For the complete
+  text: `gh api repos/<org>/<repo>/actions/jobs/<jobid>/logs`. Copy any log to
+  a file before a step that clears it -- lost evidence cannot be re-created.
+  The pristine agent log also survives as CI artifact
+  `integration-test-results-<matrix>` (`all_solutions.yml` uploads
+  `C:\IntegrationTestWorkingDirectory\**\*.log` unconditionally).
+- `az monitor metrics list --resource <aks-or-lb-id> --metric <name>` --
+  cluster/LB health at the failure timestamp (`MSYS_NO_PATHCONV=1` needed for
+  the slash-prefixed resource ID in Git Bash).
+- `kubectl get pods -n unbounded-services -o wide` -- pod restarts/uptime
+  after `az aks get-credentials`.
+- **analyze-dotnet-agent-logs** skill -- agent-side evidence (harvest
+  timing, Seen/Sent counts, connect sequence) from the test's own log.
+- **run-integration-tests** skill -- reproduce the failing test locally
+  before trusting a fix. A null result only counts if the code path is
+  proven to have executed (log entry/exit counts); when the agent itself is
+  a suspect, rerun once with the agent detached to isolate the confound.
+  Delegate the run itself, per that skill's own subagent guidance; take back
+  the summary, not the console output.
+
+## Common mistakes
+
+- Treating "all variants failed the same way" as proof of a code bug -- it
+  is usually the opposite: identical failure across unrelated variants
+  points at a shared external dependency, not the code under test.
+- This pattern covers whole-class failures across unrelated variants only --
+  a single test failing once, or a fixture health-check assertion firing, is
+  not covered by it and may be the product-defect row instead.
+- Fixing the assertion's timeout/retry count instead of the mechanism that
+  makes the wait racy. If a similar bump has already happened once on this
+  test, that is the signal to stop bumping and find the mechanism.
+- Closing the investigation without writing down why the infra issue was
+  not hardened -- the same question comes back next time the flake recurs.
+- Reading a CI log or agent log directly in the main session "just this
+  once" -- delegate it every time; a single raw read is how a multi-step
+  investigation quietly fills the context window.


### PR DESCRIPTION
Adds two agent skills used while triaging a WCF integration test failure from NR-609087:

- `analyze-dotnet-agent-logs` - parses agent and profiler logs without pulling huge payload lines into context.
- `triage-integration-test-failures` - classifies an intermittent CI failure (infra, timing, tooling, upstream, or a real product defect) before any fix is proposed.