### PR TITLE
ci: run MsSql unbounded tests in parallel

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -892,7 +892,7 @@ jobs:
 
       - name: Install HostableWebCore Feature
         if: | # only install for the required namespaces
-          matrix.namespace == 'MongoDB' || matrix.namespace == 'MsSql' || matrix.namespace == 'Oracle'
+          matrix.namespace == 'MongoDB' || matrix.namespace == 'Oracle'
         run: |
           Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
         shell: powershell
@@ -910,8 +910,24 @@ jobs:
         if: matrix.namespace == 'MsSql'
         run: |
           Write-Host "Installing MSSQL CLI"
-          msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
-          Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
+          $msi = "${{ github.workspace }}\build\Tools\sqlncli.msi"
+
+          # Wait on the installer itself instead of sleeping a fixed interval.
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            '/i', "`"$msi`"", 'IACCEPTSQLNCLILICENSETERMS=YES', '/quiet', '/qn', '/norestart'
+          )
+          if ($proc.ExitCode -ne 0) {
+            throw "msiexec failed with exit code $($proc.ExitCode)."
+          }
+
+          # Assert the provider registered. Without this the job goes green and the failure
+          # resurfaces far away from its cause, inside an OleDb test connection.
+          $providers = (New-Object System.Data.OleDb.OleDbEnumerator).GetElements() | ForEach-Object { $_.SOURCES_NAME }
+          Write-Host "Registered OLE DB providers:"
+          $providers | ForEach-Object { Write-Host "  $_" }
+          if ($providers -notcontains 'SQLNCLI11') {
+            throw "SQLNCLI11 did not register. The OleDb tests connect with PROVIDER=SQLNCLI11."
+          }
         shell: powershell
 
       # SQL Server Native Client 11.0 (installed above) is still needed by the OleDb tests,
@@ -1006,10 +1022,10 @@ jobs:
 
           # Most unbounded tests can run in parallel with pre-built test apps.
           # Some namespaces must remain serial because they use shared external infrastructure
-          # with hard-coded object names (e.g., MsSql tests all query NewRelic.dbo.TeamMembers
-          # with constant values, NServiceBus5 tests share MSMQ queues). To parallelize these,
-          # each test fixture would need isolated resources (per-test databases/tables/queues).
-          $noParallelNamespaces = @("MsSql", "NServiceBus", "NServiceBus5")
+          # with hard-coded object names (e.g., NServiceBus5 tests share MSMQ queues). To
+          # parallelize these, each test fixture would need isolated resources
+          # (per-test databases/tables/queues).
+          $noParallelNamespaces = @("NServiceBus", "NServiceBus5")
           $parallelize = $noParallelNamespaces -notcontains "${{ matrix.namespace }}"
           $json = Get-Content "${{ env.unbounded_tests_path }}/xunit.runner.json" | ConvertFrom-Json
           $json | Add-Member -Name "parallelizeAssembly" -Value $parallelize -MemberType NoteProperty


### PR DESCRIPTION
MsSql unbounded tests ran serially because their fixtures were documented as sharing hard-coded database object names. They no longer do, so the exclusion is obsolete: mutating table and procedure names are Guid-generated, `NewRelic.dbo.TeamMembers` is read-only, and the one fixed database is created under an `IF DB_ID(...) IS NULL` guard.

Measured on this branch (run 32886047181): the MsSql job went from 23m54s to 7m29s, all 49 tests passing in a single attempt with no retry. The full run was green.

Also drops the unused IIS-HostableWebCore install for MsSql (every fixture is a console fixture, none uses IIS) and replaces the blind `Start-Sleep 20` after `sqlncli.msi` with a wait on the installer plus a SQLNCLI11 registration check.
