### PR TITLE
chore: dispatch the instrumented-method hot path through a cached delegate

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -14,7 +14,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.53.1.18"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.53.1.20"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -14,7 +14,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.53.1.20"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.54.0.7"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -14,7 +14,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.53.0.47"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.53.1.18"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
@@ -123,7 +123,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         // library helper injection fails, so it must never call an injected helper.
         void BuildReflectionCall()
         {
-            LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentApi"), _function->GetFunctionName(), _function->GetFunctionId(), GetArrayOfTypeParametersLamdba());
+            LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentApi"), _function->GetFunctionName(), GetArrayOfTypeParametersLamdba());
 
             _instructions->Append(_X("ldnull"));
             BuildObjectArrayOfParameters();

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
@@ -318,39 +318,12 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         }
 
         // Load the MethodInfo instance for the given class and method onto the stack.
-        // The MethodInfo will be cached or not based on the configured agentCallStrategy.
-        // The function id is used as a tie-breaker for overloaded methods when computing the key name for the cache.
-        void LoadMethodInfo(xstring_t assemblyPath, xstring_t className, xstring_t methodName, uintptr_t functionId, std::function<void()> argumentTypesLambda)
+        // Reflection only: it is the graceful-degradation path, so it resolves the target with
+        // self-contained IL and never calls an injected core library helper. AppDomainFallbackCache
+        // dispatches through cached delegates instead and never resolves a MethodInfo per call.
+        void LoadMethodInfo(xstring_t assemblyPath, xstring_t className, xstring_t methodName, std::function<void()> argumentTypesLambda)
         {
-            if (_agentCallStrategy == AgentCallStyle::Strategy::AppDomainFallbackCache)
-            {
-                auto keyName = className + _X(".") + methodName + _X("_") + to_xstring((unsigned long)functionId);
-                _instructions->AppendString(keyName);
-                _instructions->AppendString(assemblyPath);
-                _instructions->AppendString(className);
-                _instructions->AppendString(methodName);
-                if (argumentTypesLambda == NULL)
-                {
-                    _instructions->Append(CEE_LDNULL);
-                }
-                else
-                {
-                    argumentTypesLambda();
-                }
-
-                // Unreachable as of NR-602569: both callers now reach LoadMethodInfo only
-                // under Reflection. Retained pending the adopt-or-revert decision on the
-                // delegate hot path.
-                if (Strings::AreEqualCaseInsensitive(className, _X("NewRelic.Agent.Core.AgentShim")))
-                {
-                    _instructions->Append(CEE_CALL, _X("class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Reflection.MethodInfo [") + _instructions->GetCoreLibAssemblyName() + _X("]System.CannotUnloadAppDomainException::GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow(string,string,string,string,class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Type[])"));
-                }
-                else
-                {
-                    _instructions->Append(CEE_CALL, _X("class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Reflection.MethodInfo [") + _instructions->GetCoreLibAssemblyName() + _X("]System.CannotUnloadAppDomainException::GetMethodFromAppDomainStorageOrReflectionOrThrow(string,string,string,string,class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Type[])"));
-                }
-            }
-            else if (_agentCallStrategy == AgentCallStyle::Strategy::Reflection)
+            if (_agentCallStrategy == AgentCallStyle::Strategy::Reflection)
             {
                 LoadType(assemblyPath, className);
                 LoadMethodInfoFromType(methodName, argumentTypesLambda);

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
@@ -338,11 +338,9 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                     argumentTypesLambda();
                 }
 
-                // Retained deliberately. The generic branch below is the emission path for
-                // any future non-AgentShim caller. As of NR-602576 the Agent API path
-                // dispatches through InvokeAgentMethodInvokerFunc instead of resolving a
-                // MethodInfo here, so AgentShim is the only className that reaches this
-                // fork today.
+                // Unreachable as of NR-602569: both callers now reach LoadMethodInfo only
+                // under Reflection. Retained pending the adopt-or-revert decision on the
+                // delegate hot path.
                 if (Strings::AreEqualCaseInsensitive(className, _X("NewRelic.Agent.Core.AgentShim")))
                 {
                     _instructions->Append(CEE_CALL, _X("class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Reflection.MethodInfo [") + _instructions->GetCoreLibAssemblyName() + _X("]System.CannotUnloadAppDomainException::GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow(string,string,string,string,class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Type[])"));

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
@@ -38,18 +38,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             {
                 BuildStoreMethodInAppDomainStorageOrThrow();
             }
-            else if (_function->GetFunctionName() == _X("GetMethodFromAppDomainStorage"))
-            {
-                BuildGetMethodFromAppDomainStorage();
-            }
-            else if (_function->GetFunctionName() == _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"))
-            {
-                BuildGetMethodFromAppDomainStorageOrReflectionOrThrow();
-            }
-            else if (_function->GetFunctionName() == _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"))
-            {
-                BuildGetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow();
-            }
             else if (_function->GetFunctionName() == _X("GetAgentShimFinishTracerDelegateFunc"))
             {
                 BuildGetAgentShimFinishTracerDelegateFunc();
@@ -150,39 +138,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_RET);
         }
 
-        // MethodInfo GetMethodFromAppDomainStorage(String storageKey)
-        void BuildGetMethodFromAppDomainStorage()
-        {
-            _instructions->Append(CEE_CALL, _X("class System.AppDomain System.AppDomain::get_CurrentDomain()"));
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true);
-            _instructions->Append(CEE_LDARG_0);
-            _instructions->Append(CEE_CALLVIRT, _X("instance object System.AppDomain::GetData(string)"));
-            _instructions->Append(CEE_CASTCLASS, _X("class System.Reflection.MethodInfo"));
-            _instructions->Append(CEE_RET);
-        }
 
-        // MethodInfo GetMethodFromAppDomainStorageOrReflectionOrThrow(String storageKey, String assemblyPath, String typeName, String methodName, Type[] methodParameters)
-        void BuildGetMethodFromAppDomainStorageOrReflectionOrThrow()
-        {
-            _instructions->Append(CEE_LDARG_0);
-            _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodFromAppDomainStorage(string)"));
-
-            _instructions->Append(CEE_DUP);
-            auto methodEnd = _instructions->AppendJump(CEE_BRTRUE);
-
-            _instructions->Append(CEE_POP);
-            _instructions->Append(CEE_LDARG_1);
-            _instructions->Append(CEE_LDARG_2);
-            _instructions->Append(CEE_LDARG_3);
-            _instructions->Append(CEE_LDARG_S, (uint8_t)4);
-            _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodViaReflectionOrThrow(string,string,string,class System.Type[])"));
-            _instructions->Append(CEE_DUP);
-            _instructions->Append(CEE_LDARG_0);
-            _instructions->Append(CEE_CALL, _X("void System.CannotUnloadAppDomainException::StoreMethodInAppDomainStorageOrThrow(object,string)"));
-
-            _instructions->AppendLabel(methodEnd);
-            _instructions->Append(CEE_RET);
-        }
 
         // object GetAgentShimFinishTracerDelegateFunc()
         // Fast-path: reads _agentShimFunc static field; falls back to AppDomain.GetData if null.
@@ -248,30 +204,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_RET);
         }
 
-        // MethodInfo GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow(String storageKey, String assemblyPath, String typeName, String methodName, Type[] methodParameters)
-        // Fast-path: reads _agentShimMethodInfo static field; falls back to GetMethodFromAppDomainStorageOrReflectionOrThrow if null.
-        void BuildGetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow()
-        {
-            _instructions->Append(CEE_LDSFLD, _X("object __NRInitializer__::_agentShimMethodInfo"));
-
-            _instructions->Append(CEE_DUP);
-            auto afterFallback = _instructions->AppendJump(CEE_BRTRUE);
-
-            _instructions->Append(CEE_POP);
-            _instructions->Append(CEE_LDARG_0);
-            _instructions->Append(CEE_LDARG_1);
-            _instructions->Append(CEE_LDARG_2);
-            _instructions->Append(CEE_LDARG_3);
-            _instructions->Append(CEE_LDARG_S, (uint8_t)4);
-            _instructions->Append(CEE_CALL, _X("class System.Reflection.MethodInfo System.CannotUnloadAppDomainException::GetMethodFromAppDomainStorageOrReflectionOrThrow(string,string,string,string,class System.Type[])"));
-
-            _instructions->Append(CEE_DUP);
-            _instructions->Append(CEE_STSFLD, _X("object __NRInitializer__::_agentShimMethodInfo"));
-
-            _instructions->AppendLabel(afterFallback);
-
-            _instructions->Append(CEE_RET);
-        }
 
         // object GetAgentMethodInvokerObject()
         // Fast-path: reads _agentMethodFunc static field; falls back to AppDomain.GetData if null.

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
@@ -58,6 +58,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             {
                 BuildStoreAgentShimFinishTracerDelegateFunc();
             }
+            else if (_function->GetFunctionName() == _X("InvokeAgentShimFinishTracerDelegateFunc"))
+            {
+                BuildInvokeAgentShimFinishTracerDelegateFunc();
+            }
             else if (_function->GetFunctionName() == _X("EnsureInitialized"))
             {
                 BuildEnsureInitializedMethod();
@@ -223,6 +227,24 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_STSFLD, _X("object __NRInitializer__::_agentShimFunc"));
             _instructions->AppendString(_X("__NRInitializer__::_agentShimFunc"));
             _instructions->Append(CEE_CALL, _X("void System.CannotUnloadAppDomainException::StoreMethodInAppDomainStorageOrThrow(object,string)"));
+            _instructions->Append(CEE_RET);
+        }
+
+        // object InvokeAgentShimFinishTracerDelegateFunc(String assemblyPath, object[] parameters)
+        // Initializes unconditionally: this helper is the only entry point to the shim delegate from
+        // the instrumented-method path, so nothing else can be relied on to have populated the field.
+        // In steady state EnsureInitialized reduces to a static field read plus a branch, with no lock.
+        void BuildInvokeAgentShimFinishTracerDelegateFunc()
+        {
+            _instructions->Append(CEE_LDARG_0);
+            _instructions->Append(_X("call void System.CannotUnloadAppDomainException::EnsureInitialized(string)"));
+
+            _instructions->Append(_X("call object System.CannotUnloadAppDomainException::GetAgentShimFinishTracerDelegateFunc()"));
+
+            _instructions->Append(CEE_CASTCLASS, _X("class System.Func`2<object[], class System.Action`2<object, class System.Exception>>"));
+            _instructions->Append(CEE_LDARG_1);
+            _instructions->Append(CEE_CALLVIRT, _X("instance !1 class System.Func`2<object[], class System.Action`2<object, class System.Exception>>::Invoke(!0)"));
+
             _instructions->Append(CEE_RET);
         }
 

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -162,7 +162,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             }
             else
             {
-                LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), 0, nullptr);
+                LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), nullptr);
                 _instructions->Append(_X("ldnull"));
             }
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -151,12 +151,40 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->AppendStoreLocal(_userExceptionLocalIndex);
         }
 
+        // Pushes whatever precedes the argument array for the configured strategy.
+        // AppDomainFallbackCache invokes a cached delegate and needs only the core path.
+        // Reflection resolves a MethodInfo and needs the null invocation target for MethodBase.Invoke.
+        void LoadGetTracerTarget()
+        {
+            if (_agentCallStrategy == AgentCallStyle::Strategy::AppDomainFallbackCache)
+            {
+                _instructions->AppendString(_instrumentationSettings->GetCorePath());
+            }
+            else
+            {
+                LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), 0, nullptr);
+                _instructions->Append(_X("ldnull"));
+            }
+        }
+
+        // Consumes what LoadGetTracerTarget pushed plus the argument array, leaving the tracer delegate.
+        void InvokeGetTracer()
+        {
+            if (_agentCallStrategy == AgentCallStyle::Strategy::AppDomainFallbackCache)
+            {
+                _instructions->Append(CEE_CALL, _X("object [") + _instructions->GetCoreLibAssemblyName() + _X("]System.CannotUnloadAppDomainException::InvokeAgentShimFinishTracerDelegateFunc(string,object[])"));
+            }
+            else
+            {
+                InvokeMethodInfo();
+            }
+        }
+
         void CallGetTracer(NewRelic::Profiler::Configuration::InstrumentationPointPtr instrumentationPoint)
         {
-            LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), 0, nullptr);
-              
-            // tracer = delegates[0].Invoke(null, new object[] { tracerFactoryName, tracerFactoryArgs, metricName, assemblyName, type, typeName, functionName, argumentSignatureString, this, new object[], functionId });
-            _instructions->Append(_X("ldnull"));
+            LoadGetTracerTarget();
+
+            // tracer = <target>(new object[] { tracerFactoryName, tracerFactoryArgs, metricName, assemblyName, type, typeName, functionName, argumentSignatureString, this, new object[], functionId });
             _instructions->Append(_X("ldc.i4.s   11"));
             _instructions->Append(_X("newarr     [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Object"));
             _instructions->Append(_X("dup"));
@@ -212,7 +240,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(_X("box [") + _instructions->GetCoreLibAssemblyName() + _X("]System.UInt64"));
             _instructions->Append(_X("stelem.ref"));
             // make the call to GetTracer
-            InvokeMethodInfo();
+            InvokeGetTracer();
 
             _instructions->AppendStoreLocal(_tracerLocalIndex);
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -148,6 +148,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 function->GetFunctionName() != _X("StoreMethodInAppDomainStorageOrThrow") &&
                 function->GetFunctionName() != _X("GetAgentShimFinishTracerDelegateFunc") &&
                 function->GetFunctionName() != _X("StoreAgentShimFinishTracerDelegateFunc") &&
+                function->GetFunctionName() != _X("InvokeAgentShimFinishTracerDelegateFunc") &&
                 function->GetFunctionName() != _X("InvokeAgentMethodInvokerFunc") &&
                 function->GetFunctionName() != _X("GetAgentMethodInvokerObject") &&
                 function->GetFunctionName() != _X("StoreAgentMethodInvokerFunc") &&

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -142,9 +142,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 function->GetFunctionName() != _X("LoadAssemblyOrThrow") &&
                 function->GetFunctionName() != _X("GetTypeViaReflectionOrThrow") &&
                 function->GetFunctionName() != _X("GetMethodViaReflectionOrThrow") &&
-                function->GetFunctionName() != _X("GetMethodFromAppDomainStorage") &&
-                function->GetFunctionName() != _X("GetMethodFromAppDomainStorageOrReflectionOrThrow") &&
-                function->GetFunctionName() != _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow") &&
                 function->GetFunctionName() != _X("StoreMethodInAppDomainStorageOrThrow") &&
                 function->GetFunctionName() != _X("GetAgentShimFinishTracerDelegateFunc") &&
                 function->GetFunctionName() != _X("StoreAgentShimFinishTracerDelegateFunc") &&

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
@@ -58,6 +58,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
             _instrumentedFunctionNames->emplace(_X("GetAgentMethodInvokerObject"));
             _instrumentedFunctionNames->emplace(_X("GetAgentShimFinishTracerDelegateFunc"));
             _instrumentedFunctionNames->emplace(_X("StoreAgentShimFinishTracerDelegateFunc"));
+            _instrumentedFunctionNames->emplace(_X("InvokeAgentShimFinishTracerDelegateFunc"));
             _instrumentedFunctionNames->emplace(_X("StoreAgentMethodInvokerFunc"));
             _instrumentedFunctionNames->emplace(_X("EnsureInitialized"));
             _instrumentedFunctionNames->emplace(_X("InvokeAgentMethodInvokerFunc"));

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
@@ -48,13 +48,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
             _instrumentedFunctionNames->emplace(_X("GetAppDomainBoolean"));
             _instrumentedFunctionNames->emplace(_X("GetThreadLocalBoolean"));
             _instrumentedFunctionNames->emplace(_X("SetThreadLocalBoolean"));
-            _instrumentedFunctionNames->emplace(_X("GetMethodFromAppDomainStorageOrReflectionOrThrow"));
-            _instrumentedFunctionNames->emplace(_X("GetMethodFromAppDomainStorage"));
             _instrumentedFunctionNames->emplace(_X("GetMethodViaReflectionOrThrow"));
             _instrumentedFunctionNames->emplace(_X("GetTypeViaReflectionOrThrow"));
             _instrumentedFunctionNames->emplace(_X("LoadAssemblyOrThrow"));
             _instrumentedFunctionNames->emplace(_X("StoreMethodInAppDomainStorageOrThrow"));
-            _instrumentedFunctionNames->emplace(_X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"));
             _instrumentedFunctionNames->emplace(_X("GetAgentMethodInvokerObject"));
             _instrumentedFunctionNames->emplace(_X("GetAgentShimFinishTracerDelegateFunc"));
             _instrumentedFunctionNames->emplace(_X("StoreAgentShimFinishTracerDelegateFunc"));

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
@@ -203,6 +203,25 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::AreEqual((uint8_t)0x02, capturedBytes[1]);
         }
 
+        TEST_METHOD(helper_method_InvokeAgentShimFinishTracerDelegateFunc)
+        {
+            auto function = std::make_shared<MockFunction>();
+            function->_functionName = _X("InvokeAgentShimFinishTracerDelegateFunc");
+
+            ByteVector capturedBytes;
+            function->_writeMethodHandler = [&capturedBytes](const ByteVector& bytes) {
+                capturedBytes = bytes;
+            };
+
+            HelperFunctionManipulator manipulator(function, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
+            manipulator.InstrumentHelper();
+
+            // capturedBytes = 1-byte tiny header + IL body
+            // expected IL size: 23 bytes; first IL byte: CEE_LDARG_0 (0x02)
+            Assert::AreEqual((size_t)24, capturedBytes.size());
+            Assert::AreEqual((uint8_t)0x02, capturedBytes[1]);
+        }
+
         TEST_METHOD(helper_method_GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow)
         {
             auto function = std::make_shared<MockFunction>();
@@ -357,6 +376,38 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::IsFalse(tokenizer->Tokenized(_X("GetMethodFromAppDomainStorageOrReflectionOrThrow")), L"API path must no longer resolve a MethodInfo per call");
         }
 
+        // Under AppDomainFallbackCache the instrumented-method path must dispatch GetTracer
+        // through the injected shim delegate helper rather than resolving a MethodInfo and
+        // calling MethodBase.Invoke. That is what removes the per-call reflection invoke.
+        TEST_METHOD(instrumented_method_emits_shim_delegate_invoker_under_app_domain_fallback_cache)
+        {
+            auto function = std::make_shared<MockFunction>();
+            auto tokenizer = std::make_shared<RecordingTokenizer>();
+            function->_tokenizer = tokenizer;
+
+            InstrumentFunctionManipulator manipulator(function, std::make_shared<InstrumentationSettings>(nullptr, _X("C:\\corepath")), false, AgentCallStyle::Strategy::AppDomainFallbackCache);
+            manipulator.InstrumentDefault(CreateInstrumentationPointThatMatchesFunction(function));
+
+            Assert::IsTrue(tokenizer->Tokenized(_X("InvokeAgentShimFinishTracerDelegateFunc")), L"hot path must call the shim delegate helper");
+            Assert::IsFalse(tokenizer->Tokenized(_X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow")), L"hot path must no longer resolve a MethodInfo per call");
+        }
+
+        // Reflection is the graceful-degradation path used when core library helper injection
+        // fails, so it must keep resolving the target itself and must never call an injected
+        // helper. GetMethod comes from LoadMethodInfoFromType.
+        TEST_METHOD(instrumented_method_emits_method_info_invoke_under_reflection)
+        {
+            auto function = std::make_shared<MockFunction>();
+            auto tokenizer = std::make_shared<RecordingTokenizer>();
+            function->_tokenizer = tokenizer;
+
+            InstrumentFunctionManipulator manipulator(function, std::make_shared<InstrumentationSettings>(nullptr, _X("C:\\corepath")), false, AgentCallStyle::Strategy::Reflection);
+            manipulator.InstrumentDefault(CreateInstrumentationPointThatMatchesFunction(function));
+
+            Assert::IsTrue(tokenizer->Tokenized(_X("GetMethod")), L"Reflection path must resolve the target itself");
+            Assert::IsFalse(tokenizer->Tokenized(_X("InvokeAgentShimFinishTracerDelegateFunc")), L"Reflection path must not call injected helpers");
+        }
+
         // Covers the non-void return path. The invoker needs a real System.Type for the
         // return type, not the null used for void. A mismatch here would make CreateDelegate
         // throw on the managed side and fall back silently to the original method body,
@@ -400,6 +451,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
                 _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
                 _X("GetAgentShimFinishTracerDelegateFunc"),
                 _X("StoreAgentShimFinishTracerDelegateFunc"),
+                _X("InvokeAgentShimFinishTracerDelegateFunc"),
                 _X("EnsureInitialized"),
                 _X("GetAgentMethodInvokerObject"),
                 _X("InvokeAgentMethodInvokerFunc"),

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
@@ -31,9 +31,9 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Initialize();
         }
 
-        void CallLoadMethodInfo(xstring_t assemblyPath, xstring_t className, xstring_t methodName, uintptr_t functionId, std::function<void()> argumentTypesLambda)
+        void CallLoadMethodInfo(xstring_t assemblyPath, xstring_t className, xstring_t methodName, std::function<void()> argumentTypesLambda)
         {
-            LoadMethodInfo(assemblyPath, className, methodName, functionId, argumentTypesLambda);
+            LoadMethodInfo(assemblyPath, className, methodName, argumentTypesLambda);
         }
 
         void CallLoadMethodInfoFromType(xstring_t methodName, std::function<void()> argumentTypesLambda)
@@ -220,25 +220,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             // expected IL size: 23 bytes; first IL byte: CEE_LDARG_0 (0x02)
             Assert::AreEqual((size_t)24, capturedBytes.size());
             Assert::AreEqual((uint8_t)0x02, capturedBytes[1]);
-        }
-
-        TEST_METHOD(helper_method_GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow)
-        {
-            auto function = std::make_shared<MockFunction>();
-            function->_functionName = _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow");
-
-            ByteVector capturedBytes;
-            function->_writeMethodHandler = [&capturedBytes](const ByteVector& bytes) {
-                capturedBytes = bytes;
-            };
-
-            HelperFunctionManipulator manipulator(function, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
-            manipulator.InstrumentHelper();
-
-            // capturedBytes = 1-byte tiny header + IL body
-            // expected IL size: 30 bytes; first IL byte: CEE_LDSFLD (0x7E)
-            Assert::AreEqual((size_t)31, capturedBytes.size());
-            Assert::AreEqual((uint8_t)0x7E, capturedBytes[1]);
         }
 
         TEST_METHOD(helper_method_EnsureInitialized)
@@ -446,9 +427,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
                 _X("GetTypeViaReflectionOrThrow"),
                 _X("GetMethodViaReflectionOrThrow"),
                 _X("StoreMethodInAppDomainStorageOrThrow"),
-                _X("GetMethodFromAppDomainStorage"),
-                _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"),
-                _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
                 _X("GetAgentShimFinishTracerDelegateFunc"),
                 _X("StoreAgentShimFinishTracerDelegateFunc"),
                 _X("InvokeAgentShimFinishTracerDelegateFunc"),
@@ -519,34 +497,29 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::IsTrue(tokenizer->Tokenized(_X("Invoke")), L"should dispatch through MethodBase.Invoke(object, object[])");
         }
 
-        // Under AppDomainFallbackCache, LoadMethodInfo special-cases the AgentShim class name to
-        // use a dedicated cache helper; every other caller falls through to the generic
-        // app-domain-cache lookup helper. No current production caller passes a non-AgentShim
-        // class name with this strategy, so this branch needs a direct, synthetic call.
-        TEST_METHOD(load_method_info_uses_generic_app_domain_cache_lookup_for_non_agent_shim_callers)
+        // LoadMethodInfo now serves Reflection only, so AppDomainFallbackCache must take the
+        // error branch rather than emit an injected cache helper.
+        TEST_METHOD(load_method_info_throws_for_app_domain_fallback_cache)
         {
             auto function = std::make_shared<MockFunction>();
-            auto tokenizer = std::make_shared<RecordingTokenizer>();
-            function->_tokenizer = tokenizer;
-
             TestableFunctionManipulator manipulator(function, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
 
-            manipulator.CallLoadMethodInfo(_X("C:\\corepath"), _X("NewRelic.Agent.Core.SomeOtherCaller"), _X("SomeMethod"), 1, std::function<void()>());
+            std::function<void(void)> func = [&manipulator]() {
+                manipulator.CallLoadMethodInfo(_X("C:\\corepath"), _X("NewRelic.Agent.Core.AgentShim"), _X("SomeMethod"), std::function<void()>());
+                };
 
-            Assert::IsTrue(tokenizer->Tokenized(_X("GetMethodFromAppDomainStorageOrReflectionOrThrow")), L"non-AgentShim callers should use the generic app-domain cache lookup helper");
-            Assert::IsFalse(tokenizer->Tokenized(_X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow")), L"the AgentShim-specific helper should not be used for a non-AgentShim caller");
+            Assert::ExpectException<FunctionManipulatorException>(func, L"AppDomainFallbackCache dispatches through cached delegates and must not resolve a MethodInfo.");
         }
 
-        // AgentCallStyle::Strategy has exactly two legitimate values, both handled by
-        // LoadMethodInfo. The else branch is otherwise unreachable, so this forces an
-        // out-of-range strategy through the constructor to exercise it.
+        // The remaining strategy value is out of range. Forcing it through the constructor
+        // exercises the same error branch from the other direction.
         TEST_METHOD(load_method_info_throws_for_an_unsupported_agent_call_strategy)
         {
             auto function = std::make_shared<MockFunction>();
             TestableFunctionManipulator manipulator(function, false, static_cast<AgentCallStyle::Strategy>(-1));
 
             std::function<void(void)> func = [&manipulator]() {
-                manipulator.CallLoadMethodInfo(_X("C:\\corepath"), _X("NewRelic.Agent.Core.AgentApi"), _X("SomeMethod"), 1, std::function<void()>());
+                manipulator.CallLoadMethodInfo(_X("C:\\corepath"), _X("NewRelic.Agent.Core.AgentApi"), _X("SomeMethod"), std::function<void()>());
                 };
 
             Assert::ExpectException<FunctionManipulatorException>(func, L"an unsupported AgentCallStyle::Strategy should not be usable to load method info.");

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstructionSetTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstructionSetTest.cpp
@@ -81,7 +81,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             tokenizer->_fieldDefinitionToken = 0xDEADBEEF;
             auto instructionSet = InstructionSet(tokenizer, nullptr);
 
-            instructionSet.Append(_X("ldsfld object __NRInitializer__::_agentShimMethodInfo"));
+            instructionSet.Append(_X("ldsfld object __NRInitializer__::_agentShimFunc"));
 
             BYTEVECTOR(expectedBytes,
                 CEE_LDSFLD,

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstrumentorsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstrumentorsTest.cpp
@@ -438,32 +438,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
         }
 
-        TEST_METHOD(helper_GetMethodFromAppDomainStorage_fires_and_returns_false)
-        {
-            HelperInstrumentor instr;
-            auto func = MakeHelperFunc(L"GetMethodFromAppDomainStorage");
-            bool result = instr.Instrument(func, nullptr, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
-            Assert::IsFalse(result);
-            Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
-        }
 
-        TEST_METHOD(helper_GetMethodFromAppDomainStorageOrReflectionOrThrow_fires_and_returns_false)
-        {
-            HelperInstrumentor instr;
-            auto func = MakeHelperFunc(L"GetMethodFromAppDomainStorageOrReflectionOrThrow");
-            bool result = instr.Instrument(func, nullptr, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
-            Assert::IsFalse(result);
-            Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
-        }
 
-        TEST_METHOD(helper_GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow_fires_and_returns_false)
-        {
-            HelperInstrumentor instr;
-            auto func = MakeHelperFunc(L"GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow");
-            bool result = instr.Instrument(func, nullptr, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
-            Assert::IsFalse(result);
-            Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
-        }
 
         TEST_METHOD(helper_StoreMethodInAppDomainStorageOrThrow_fires_and_returns_false)
         {

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstrumentorsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/InstrumentorsTest.cpp
@@ -492,6 +492,15 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
         }
 
+        TEST_METHOD(helper_InvokeAgentShimFinishTracerDelegateFunc_fires_and_returns_false)
+        {
+            HelperInstrumentor instr;
+            auto func = MakeHelperFunc(L"InvokeAgentShimFinishTracerDelegateFunc");
+            bool result = instr.Instrument(func, nullptr, false, AgentCallStyle::Strategy::AppDomainFallbackCache);
+            Assert::IsFalse(result);
+            Assert::AreEqual((uint64_t)1, instr.GetHelperFireCount());
+        }
+
         TEST_METHOD(helper_InvokeAgentMethodInvokerFunc_fires_and_returns_false)
         {
             HelperInstrumentor instr;

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
@@ -133,17 +133,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::IsTrue(rewriter->ShouldInstrumentFunction(_X("SetThreadLocalBoolean")));
         }
 
-        TEST_METHOD(ShouldInstrumentFunction_GetMethodFromAppDomainStorageOrReflectionOrThrow_returns_true)
-        {
-            auto rewriter = MakeRewriter();
-            Assert::IsTrue(rewriter->ShouldInstrumentFunction(_X("GetMethodFromAppDomainStorageOrReflectionOrThrow")));
-        }
 
-        TEST_METHOD(ShouldInstrumentFunction_GetMethodFromAppDomainStorage_returns_true)
-        {
-            auto rewriter = MakeRewriter();
-            Assert::IsTrue(rewriter->ShouldInstrumentFunction(_X("GetMethodFromAppDomainStorage")));
-        }
 
         TEST_METHOD(ShouldInstrumentFunction_GetMethodViaReflectionOrThrow_returns_true)
         {

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
@@ -169,6 +169,15 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::IsTrue(rewriter->ShouldInstrumentFunction(_X("StoreMethodInAppDomainStorageOrThrow")));
         }
 
+        // This gate is not compile-checked. If the name is missing from the instrumented set
+        // the helper keeps its injected stub body, gets no real IL, and the hot path silently
+        // stops tracing.
+        TEST_METHOD(ShouldInstrumentFunction_InvokeAgentShimFinishTracerDelegateFunc_returns_true)
+        {
+            auto rewriter = MakeRewriter();
+            Assert::IsTrue(rewriter->ShouldInstrumentFunction(_X("InvokeAgentShimFinishTracerDelegateFunc")));
+        }
+
         TEST_METHOD(ShouldInstrumentFunction_cctor_returns_false)
         {
             // .cctor is no longer an instrumented helper function name, so it must not

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
@@ -40,7 +40,7 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
         {
             // When injecting method REFERENCES into an assembly, theses references should have
             // the external assembly identifier to System.Private.CoreLib
-            constexpr std::array<ManagedMethodToInject, 13> methodReferencesToInjectCoreClr{
+            constexpr std::array<ManagedMethodToInject, 14> methodReferencesToInjectCoreClr{
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,class [System.Private.CoreLib]System.Type[]")),
@@ -53,12 +53,13 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"),_X("EnsureInitialized"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[],class [System.Private.CoreLib]System.Type,object[]")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
-                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("InvokeAgentShimFinishTracerDelegateFunc"), _X("object"), _X("string,object[]"))
             };
 
             // When injecting method REFERENCES into an assembly, theses references should have
             // the external assembly identifier to mscorlib
-            constexpr std::array<ManagedMethodToInject, 13> methodReferencesToInjectNetFramework{
+            constexpr std::array<ManagedMethodToInject, 14> methodReferencesToInjectNetFramework{
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [mscorlib]System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [mscorlib]System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,class [mscorlib]System.Type[]")),
@@ -71,12 +72,13 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("EnsureInitialized"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class [mscorlib]System.Type[],class [mscorlib]System.Type,object[]")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
-                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("InvokeAgentShimFinishTracerDelegateFunc"), _X("object"), _X("string,object[]"))
             };
 
             // When injecting HELPER METHODS into the Core Lib assembly, theses references should be local.
             // They cannot reference an assembly since these methods are being rewritten in the Core Lib so only types available in that lib can be used.
-            constexpr std::array<ManagedMethodToInject, 13> methodImplsToInject{
+            constexpr std::array<ManagedMethodToInject, 14> methodImplsToInject{
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,class System.Type[]")),
@@ -89,7 +91,8 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("EnsureInitialized"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("InvokeAgentMethodInvokerFunc"), _X("object"), _X("string,string,string,string,class System.Type[],class System.Type,object[]")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentMethodInvokerObject"), _X("object"), _X("")),
-                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X(""))
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentShimFinishTracerDelegateFunc"), _X("object"), _X("")),
+                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("InvokeAgentShimFinishTracerDelegateFunc"), _X("object"), _X("string,object[]"))
             };
 
             const auto is_coreLib = module.GetIsThisTheCoreLibAssembly();

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
@@ -40,13 +40,10 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
         {
             // When injecting method REFERENCES into an assembly, theses references should have
             // the external assembly identifier to System.Private.CoreLib
-            constexpr std::array<ManagedMethodToInject, 14> methodReferencesToInjectCoreClr{
+            constexpr std::array<ManagedMethodToInject, 11> methodReferencesToInjectCoreClr{
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,class [System.Private.CoreLib]System.Type[]")),
-                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string")),
-                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[]")),
-                ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [System.Private.CoreLib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [System.Private.CoreLib]System.Type[]")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("[System.Private.CoreLib]System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),
@@ -59,13 +56,10 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
 
             // When injecting method REFERENCES into an assembly, theses references should have
             // the external assembly identifier to mscorlib
-            constexpr std::array<ManagedMethodToInject, 14> methodReferencesToInjectNetFramework{
+            constexpr std::array<ManagedMethodToInject, 11> methodReferencesToInjectNetFramework{
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class [mscorlib]System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class [mscorlib]System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,class [mscorlib]System.Type[]")),
-                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string")),
-                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [mscorlib]System.Type[]")),
-                ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class [mscorlib]System.Reflection.MethodInfo"), _X("string,string,string,string,class [mscorlib]System.Type[]")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("[mscorlib]System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),
@@ -78,13 +72,10 @@ namespace NewRelic { namespace Profiler { namespace ModuleInjector
 
             // When injecting HELPER METHODS into the Core Lib assembly, theses references should be local.
             // They cannot reference an assembly since these methods are being rewritten in the Core Lib so only types available in that lib can be used.
-            constexpr std::array<ManagedMethodToInject, 14> methodImplsToInject{
+            constexpr std::array<ManagedMethodToInject, 11> methodImplsToInject{
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("LoadAssemblyOrThrow"), _X("class System.Reflection.Assembly"), _X("string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetTypeViaReflectionOrThrow"), _X("class System.Type"), _X("string,string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodViaReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,class System.Type[]")),
-                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorage"), _X("class System.Reflection.MethodInfo"), _X("string")),
-                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,string,class System.Type[]")),
-                ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"), _X("class System.Reflection.MethodInfo"), _X("string,string,string,string,class System.Type[]")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreMethodInAppDomainStorageOrThrow"), _X("void"), _X("object,string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreAgentMethodInvokerFunc"), _X("void"), _X("string")),
                 ManagedMethodToInject(_X("System.CannotUnloadAppDomainException"), _X("StoreAgentShimFinishTracerDelegateFunc"), _X("void"), _X("string")),

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
@@ -144,7 +144,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
 
         void AssertHelperMethodsWereInjected(const bool isCoreClr, const bool throwsException)
         {
-            std::array<xstring_t, 13> expectedMethods = {
+            std::array<xstring_t, 14> expectedMethods = {
                 _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
                 _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
                 _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
@@ -157,7 +157,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
                 _X("System.CannotUnloadAppDomainException.GetAgentMethodInvokerObject"),
                 _X("System.CannotUnloadAppDomainException.GetAgentShimFinishTracerDelegateFunc"),
                 _X("System.CannotUnloadAppDomainException.StoreAgentShimFinishTracerDelegateFunc"),
-                _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc")
+                _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc"),
+                _X("System.CannotUnloadAppDomainException.InvokeAgentShimFinishTracerDelegateFunc")
             };
 
             auto modulePtr = std::make_shared<MockModule>();
@@ -194,7 +195,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
         void AssertHelperMethodReferencesWereInjected(const bool isCoreClr, const bool throwsException)
         {
             const xstring_t expectedAssembly = isCoreClr ? _X("[System.Private.CoreLib]") : _X("[mscorlib]");
-            std::array<xstring_t, 13> expectedMethods = {
+            std::array<xstring_t, 14> expectedMethods = {
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
@@ -207,7 +208,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.InvokeAgentMethodInvokerFunc"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentShimFinishTracerDelegateFunc"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreAgentShimFinishTracerDelegateFunc"),
-                expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc")
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreAgentMethodInvokerFunc"),
+                expectedAssembly + _X("System.CannotUnloadAppDomainException.InvokeAgentShimFinishTracerDelegateFunc")
             };
 
             auto modulePtr = std::make_shared<MockModule>();

--- a/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ModuleInjectorTest/ModuleInjectorTest.cpp
@@ -144,13 +144,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
 
         void AssertHelperMethodsWereInjected(const bool isCoreClr, const bool throwsException)
         {
-            std::array<xstring_t, 14> expectedMethods = {
+            std::array<xstring_t, 11> expectedMethods = {
                 _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
                 _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
                 _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
-                _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorage"),
-                _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorageOrReflectionOrThrow"),
-                _X("System.CannotUnloadAppDomainException.GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
                 _X("System.CannotUnloadAppDomainException.StoreMethodInAppDomainStorageOrThrow"),
                 _X("System.CannotUnloadAppDomainException.EnsureInitialized"),
                 _X("System.CannotUnloadAppDomainException.InvokeAgentMethodInvokerFunc"),
@@ -195,13 +192,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
         void AssertHelperMethodReferencesWereInjected(const bool isCoreClr, const bool throwsException)
         {
             const xstring_t expectedAssembly = isCoreClr ? _X("[System.Private.CoreLib]") : _X("[mscorlib]");
-            std::array<xstring_t, 14> expectedMethods = {
+            std::array<xstring_t, 11> expectedMethods = {
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.LoadAssemblyOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetTypeViaReflectionOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodViaReflectionOrThrow"),
-                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorage"),
-                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorageOrReflectionOrThrow"),
-                expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.StoreMethodInAppDomainStorageOrThrow"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.EnsureInitialized"),
                 expectedAssembly + _X("System.CannotUnloadAppDomainException.GetAgentMethodInvokerObject"),

--- a/src/Agent/NewRelic/Profiler/Profiler/Module.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Module.h
@@ -110,7 +110,6 @@ namespace NewRelic { namespace Profiler
             mdFieldDef dataFieldToken;
             ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentMethodFunc"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
             ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentShimFunc"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
-            ThrowOnError(_metaDataEmit->DefineField, nrHelperType, _X("_agentShimMethodInfo"), dataFieldAttributes, dataFieldSignature.data(), (uint32_t)dataFieldSignature.size(), 0, nullptr, 0, &dataFieldToken);
         }
 
         virtual bool VerifyNRHelperTypeInjected() override

--- a/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
@@ -12,6 +12,8 @@ namespace NewRelic.Agent.IntegrationTests.AppDomainCaching;
 public abstract class AppDomainCachingTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
     where TFixture : ConsoleDynamicMethodFixture
 {
+    private const string InstrumentedMethodTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.RootCommands/InstrumentedMethodToStartAgent";
+    private const string ShimDelegateHelperName = "System.CannotUnloadAppDomainException.InvokeAgentShimFinishTracerDelegateFunc";
     private const string TransactionCategory = "AppDomainCachingGroup";
     private const string OriginalTransactionName = "OriginalName";
     private const string RenamedTransactionName = "RenamedName";
@@ -69,6 +71,35 @@ public abstract class AppDomainCachingTestsBase<TFixture> : NewRelicIntegrationT
         // NEW_RELIC_DISABLE_APPDOMAIN_CACHING like .NET Framework: default (unset) => AppDomain Fallback Cache,
         // opt-out (true) => Reflection.
         Assert.Contains($"Calls to the managed agent will use the calling strategy - {_expectedCallingStrategy}", _fixture.ProfilerLog.GetFullLogAsString());
+    }
+
+    [Fact]
+    public void HotPathDispatchesThroughTheStrategySpecificHelper()
+    {
+        // An injected core library helper is only instrumented once the CLR JITs it, and the CLR only
+        // JITs it once something calls it. So the presence of this log line is direct evidence of which
+        // dispatch shape the instrumented-method hot path actually used.
+        var profilerLog = _fixture.ProfilerLog.GetFullLogAsString();
+
+        if (_appDomainCachingDisabled)
+        {
+            Assert.DoesNotContain(ShimDelegateHelperName, profilerLog);
+        }
+        else
+        {
+            Assert.Contains(ShimDelegateHelperName, profilerLog);
+        }
+    }
+
+    [Fact]
+    public void InstrumentedMethodProducesTransactionUnderConfiguredStrategy()
+    {
+        // Covers the instrumented-method hot path on its own. Under AppDomainFallbackCache that path
+        // dispatches GetTracer through an injected core library helper, and a failure there is
+        // swallowed by the try/catch around the call, leaving the method untraced with no log line.
+        var actualMetrics = _fixture.AgentLog.GetMetrics();
+
+        Assert.Contains(actualMetrics, x => x.MetricSpec.Name == InstrumentedMethodTransactionName);
     }
 
     [Fact]


### PR DESCRIPTION
Dispatches the instrumented-method hot path through a cached delegate instead of resolving a `MethodInfo` and calling `MethodBase.Invoke`, from NR-602569.

- **Profiler hot-path dispatch** (`InstrumentFunctionManipulator.h`, `FunctionManipulator.h`, `ApiFunctionManipulator.h`) -- injected IL now loads a cached delegate and invokes it directly. `MethodBase.Invoke` costs a reflection stub, an `object[]` allocation, and argument boxing on every instrumented call, all of which the delegate avoids.
- **Removal of the AppDomain-storage MethodInfo caching chain** (`HelperFunctionManipulator.h`, `Instrumentors.h`, `MethodRewriter.h`, `ModuleInjector.h`, `Module.h`) -- the delegate path no longer resolves a `MethodInfo` per call, so the helpers that cached one in AppDomain storage (`BuildGetMethodFromAppDomainStorage`, `StoreMethodInAppDomainStorageOrThrow`, `BuildGetAgentShimMethodFromAppDomainStorageOrReflectionOrThrow`, `CallLoadMethodInfo`) have nothing left to cache and are deleted. `LoadMethodInfo` and `InvokeMethodInfo` remain: the `Reflection` strategy still uses them, and it is still selected by `NEW_RELIC_DISABLE_APPDOMAIN_CACHING` and by graceful degradation when core-library helper injection does not take.
- **Profiler unit tests** (`FunctionManipulatorTest.cpp`, `InstrumentorsTest.cpp`, `MethodRewriterTest.cpp`, `ModuleInjectorTest.cpp`, `InstructionSetTest.cpp`) -- updated to the new emitted IL shape and to the reduced helper surface, with both strategies covered on the instrument path. 558 profiler tests pass.
- **Integration test coverage** (`AppDomainCachingTests.cs`) -- adds `HotPathDispatchesThroughTheStrategySpecificHelper`, which asserts at runtime which dispatch shape actually ran. Without it, nothing distinguishes the delegate path from the path it replaced once both compile.
- **Profiler NuGet reference** (`Home.csproj`) -- pinned to 10.53.1.20, built from this branch, so CI and the agent home directories consume the profiler these changes produce.

## Verification

Micro-benchmarks: 24-26% per-call improvement.

Realistic web workload on a dedicated Azure host, 5 reps x 3 builds interleaved: **+5.99% requests per second** (operational knee at p99 < 500 ms) over the shipped profiler, with no regression in allocation rate or lock contention. Full data and analysis in the `methodcache-web-bench` harness.