### PR TITLE
test: Various fixes for MongoDB and other tests

### DIFF
--- a/.claude/skills/build-dotnet-agent/SKILL.md
+++ b/.claude/skills/build-dotnet-agent/SKILL.md
@@ -17,6 +17,7 @@ Debug is default -- never pass `-c Release`. It's slow; run in background or tee
 
 - **Never build a single `.csproj`.** `Core.csproj` and its dependents have a post-build step (ILRepack + `AssemblyModifier.exe`) whose ordering only the solution provides. Building one project alone yields `AssemblyModifier.exe not found`, exit code 3, or `$(SolutionDir)`/`*Undefined*` errors.
 - **Debug, never Release** (Release is for CI/releases).
+- **`IntegrationTests.sln` / `UnboundedIntegrationTests.sln` build with VS MSBuild**, not the `dotnet build` above; the `dotnet` SDK cannot build their legacy ASP.NET FW web apps. Invocation and required flags: [tests/CLAUDE.md](../../../tests/CLAUDE.md#building-the-solution).
 - **`Core.UnitTest` from the CLI needs `SolutionDir`** (VS sets it, `dotnet` doesn't), trailing backslash required. Both forms below pass the same value (`<repo-root>\`):
   ```bash
   # bash (Git Bash)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -892,7 +892,7 @@ jobs:
 
       - name: Install HostableWebCore Feature
         if: | # only install for the required namespaces
-          matrix.namespace == 'MongoDB' || matrix.namespace == 'Oracle'
+          matrix.namespace == 'Oracle'
         run: |
           Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
         shell: powershell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,10 @@ generated file. Exact command and caveats in
 Full build: open `FullAgent.sln` in the latest Visual Studio or run its
 MSBuild equivalent.
 
+**`IntegrationTests.sln` and `UnboundedIntegrationTests.sln` need VS MSBuild**
+with publish flags; the `dotnet` SDK cannot build their legacy ASP.NET FW web
+apps. Invocation: [tests/CLAUDE.md](tests/CLAUDE.md#building-the-solution).
+
 **Core.UnitTest** (and any project depending on `Core.csproj`) fails from
 the CLI with `AssemblyModifier.exe` / `*Undefined*` errors unless
 `SolutionDir` is passed explicitly — VS sets it, plain `dotnet` does not:

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Controllers/SecondCallController.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Controllers/SecondCallController.cs
@@ -27,6 +27,8 @@ public class SecondCallController : Controller
 
                 //var result = await httpClient.GetStringAsync(nextUrl);
                 var response = await httpClient.SendAsync(requestMessage);
+                // GetStringAsync used to supply this; SendAsync does not throw on a failure status.
+                response.EnsureSuccessStatusCode();
                 var result = await response.Content.ReadAsStringAsync();
 
                 return result;

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AppDomainCachingContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AppDomainCachingContainerTests.cs
@@ -24,6 +24,7 @@ public abstract class AppDomainCachingContainerTest<T> : NewRelicIntegrationTest
         _fixture.Actions(setupConfiguration: () =>
             {
                 var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.SetLogLevel("finest");
                 configModifier.ConfigureFasterMetricsHarvestCycle(10);
             },
             exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
@@ -20,6 +20,7 @@ public abstract class LinuxContainerTest<T> : NewRelicIntegrationTest<T> where T
         _fixture.Actions(setupConfiguration: () =>
             {
                 var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.SetLogLevel("finest");
                 configModifier.ConfigureFasterMetricsHarvestCycle(10);
             },
             exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -310,6 +310,7 @@ public abstract class RemoteApplicationFixture : IDisposable
                     {
                         TestLogger?.WriteLine("Exception occurred in try number " + (numberOfTries + 1) + " : " + ex.ToString());
                         retryMessage = "Exception thrown.";
+                        retryTest = true;
                     }
                     finally
                     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/RecordDatastoreSegmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/RecordDatastoreSegmentTests.cs
@@ -83,7 +83,11 @@ public abstract class RecordDatastoreSegmentTests<TFixture> : NewRelicIntegratio
         (
             exerciseApplication: () =>
             {
-                _fixture.AgentLog.WaitForLogLine(AgentLogFile.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                if (_allOptions)
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogFile.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                }
+
                 _fixture.AgentLog.WaitForLogLine(AgentLogFile.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
             }
         );

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaDynamoDbEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaDynamoDbEventTest.cs
@@ -27,7 +27,7 @@ public abstract class AwsLambdaDynamoDbEventTest<T> : NewRelicIntegrationTest<T>
             exerciseApplication: () =>
             {
                 _fixture.EnqueueEvent();
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 1);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisEventTest.cs
@@ -27,7 +27,7 @@ public abstract class AwsLambdaKinesisEventTest<T> : NewRelicIntegrationTest<T> 
             exerciseApplication: () =>
             {
                 _fixture.EnqueueEvent();
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 1);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisFirehoseEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisFirehoseEventTest.cs
@@ -27,7 +27,7 @@ public abstract class AwsLambdaKinesisFirehoseEventTest<T> : NewRelicIntegration
             exerciseApplication: () =>
             {
                 _fixture.EnqueueEvent();
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 1);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaScheduledCloudWatchEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaScheduledCloudWatchEventTest.cs
@@ -27,7 +27,7 @@ public abstract class AwsLambdaScheduledCloudWatchEventTest<T> : NewRelicIntegra
             exerciseApplication: () =>
             {
                 _fixture.EnqueueEvent();
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 1);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSesEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSesEventTest.cs
@@ -27,7 +27,7 @@ public abstract class AwsLambdaSesEventTest<T> : NewRelicIntegrationTest<T> wher
             exerciseApplication: () =>
             {
                 _fixture.EnqueueEvent();
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 1);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsSdk/InvokeLambdaTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsSdk/InvokeLambdaTests.cs
@@ -39,7 +39,7 @@ public abstract class InvokeLambdaTestBase<TFixture> : NewRelicIntegrationTest<T
             },
             exerciseApplication: () =>
             {
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2),2);
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2), useAsync ? 2 : 1);
             }
         );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMDisabledTests.cs
@@ -28,11 +28,13 @@ public abstract class LlmDisabledTestsBase<TFixture> : NewRelicIntegrationTest<T
                 new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath)
                     .ForceTransactionTraces()
                     .EnableAiMonitoring(false)
+                    .ConfigureFasterMetricsHarvestCycle(15)
                     .SetLogLevel("finest");
             },
             exerciseApplication: () =>
             {
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2), 2);
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AnalyticsEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("OtherTransaction/all", 1, TimeSpan.FromMinutes(1));
             }
         );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/AuditLogTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/AuditLogTests.cs
@@ -32,7 +32,7 @@ public class AuditLogTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNe
             {
                 _fixture.Get();
 
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(2));
+                _fixture.AuditLog.WaitForLogLine(AuditLogFile.AuditDataReceivedLogLineRegex, TimeSpan.FromMinutes(1));
             }
         );
 
@@ -48,9 +48,10 @@ public class AuditLogTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNe
         var dataSentLogLines =  _fixture.AuditLog.TryGetLogLines(AuditLogFile.AuditDataSentLogLineRegex).ToList();
         var dataReceivedLogLines = _fixture.AuditLog.TryGetLogLines(AuditLogFile.AuditDataReceivedLogLineRegex).ToList();
 
-        Assert.Multiple(() =>
-        {
-            Assert.True(dataSentLogLines.Count == 2 * dataReceivedLogLines.Count); // audit log always contains 2 "sent" lines for every "received" line
-        });
+        Assert.Multiple(
+            () => Assert.NotEmpty(dataSentLogLines),
+            () => Assert.NotEmpty(dataReceivedLogLines),
+            () => Assert.True(dataSentLogLines.Count == 2 * dataReceivedLogLines.Count) // audit log always contains 2 "sent" lines for every "received" line
+        );
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
@@ -48,7 +48,11 @@ public abstract class RejitAddFileBase<TFixture> : NewRelicIntegrationTest<TFixt
                 CommonUtils.AddCustomInstrumentation(createFilePath, "AspNetCoreMvcRejitApplication", "RejitMvcApplication.Controllers.RejitController", "CustomMethodDefaultWrapperAddFile", "NewRelic.Agent.Core.Wrapper.DefaultWrapper", "MyCustomAddMetricName", 7);
                 var destinationFilePath = Path.Combine(_fixture.RemoteApplication.DestinationExtensionsDirectoryPath, "Integration.Testing.AddXmlFileTest.xml");
                 CommonUtils.MoveFile(createFilePath, destinationFilePath, TimeSpan.FromSeconds(5));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationRefreshFileWatcherComplete, TimeSpan.FromMinutes(1));
+                if (!_disableFileSystemWatcher)
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationRefreshFileWatcherComplete, TimeSpan.FromMinutes(1));
+                }
+
                 _fixture.TestAddFile();
             });
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
@@ -62,31 +62,28 @@ public abstract class RejitAddFileBase<TFixture> : NewRelicIntegrationTest<TFixt
     [Fact]
     public void Test()
     {
+        var expectedGetAddFileCallCount = _disableFileSystemWatcher ? 2 : 1;
+
         var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
             //transactions
             new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/Home/Index", CallCountAllHarvests = 1 },
-            new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/Rejit/GetAddFile", CallCountAllHarvests = 1 },
+            new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/Rejit/GetAddFile", CallCountAllHarvests = expectedGetAddFileCallCount },
 
             // Unscoped
             new Assertions.ExpectedMetric { metricName = @"DotNet/HomeController/Index", CallCountAllHarvests = 1 },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 2 },
 
             // Scoped
             new Assertions.ExpectedMetric { metricName = @"DotNet/HomeController/Index", metricScope = "WebTransaction/MVC/Home/Index", CallCountAllHarvests = 1 },
-            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", metricScope = "WebTransaction/MVC/Rejit/GetAddFile", CallCountAllHarvests = 1 }
+            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", metricScope = "WebTransaction/MVC/Rejit/GetAddFile", CallCountAllHarvests = expectedGetAddFileCallCount }
         };
 
-        // Id file system watcher is disabled, these won't exist.
-        if (_disableFileSystemWatcher)
-        {
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 1 });
-        }
-        else
+        if (!_disableFileSystemWatcher)
         {
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"WebTransaction/Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"Custom/MyCustomAddMetricName", metricScope = "WebTransaction/Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 2 });
         }
 
         var metrics = CommonUtils.GetMetrics(_fixture.AgentLog);

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
@@ -61,31 +61,28 @@ public abstract class RejitAddFileBase<TFixture> : NewRelicIntegrationTest<TFixt
     [Fact]
     public void Test()
     {
+        var expectedGetAddFileCallCount = _disableFileSystemWatcher ? 2 : 1;
+
         var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
             //transactions
             new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/HomeController/Index", CallCountAllHarvests = 1 },
-            new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/RejitController/GetAddFile", CallCountAllHarvests = 1 },
+            new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/RejitController/GetAddFile", CallCountAllHarvests = expectedGetAddFileCallCount },
 
             // Unscoped
             new Assertions.ExpectedMetric { metricName = @"DotNet/HomeController/Index", CallCountAllHarvests = 1 },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 2 },
 
             // Scoped
             new Assertions.ExpectedMetric { metricName = @"DotNet/HomeController/Index", metricScope = "WebTransaction/MVC/HomeController/Index", CallCountAllHarvests = 1 },
-            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", metricScope = "WebTransaction/MVC/RejitController/GetAddFile", CallCountAllHarvests = 1 }
+            new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", metricScope = "WebTransaction/MVC/RejitController/GetAddFile", CallCountAllHarvests = expectedGetAddFileCallCount }
         };
 
-        // Id file system watcher is disabled, these won't exist.
-        if (_disableFileSystemWatcher)
-        {
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 1 });
-        }
-        else
+        if (!_disableFileSystemWatcher)
         {
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"WebTransaction/Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"Custom/MyCustomAddMetricName", metricScope = "WebTransaction/Custom/MyCustomAddMetricName", CallCountAllHarvests = 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/RejitController/GetAddFile", CallCountAllHarvests = 2 });
         }
 
         var metrics = CommonUtils.GetMetrics(_fixture.AgentLog);

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
@@ -47,7 +47,11 @@ public abstract class RejitAddFileBase<TFixture> : NewRelicIntegrationTest<TFixt
                 CommonUtils.AddCustomInstrumentation(createFilePath, "RejitMvcApplication", "RejitMvcApplication.Controllers.RejitController", "CustomMethodDefaultWrapperAddFile", "NewRelic.Agent.Core.Wrapper.DefaultWrapper", "MyCustomAddMetricName", 7);
                 var destinationFilePath = _fixture.RemoteApplication.DestinationExtensionsDirectoryPath + @"\Integration.Testing.AddXmlFileTest.xml";
                 CommonUtils.MoveFile(createFilePath, destinationFilePath, TimeSpan.FromSeconds(5));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationRefreshFileWatcherComplete, TimeSpan.FromMinutes(1));
+                if (!_disableFileSystemWatcher)
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationRefreshFileWatcherComplete, TimeSpan.FromMinutes(1));
+                }
+
                 _fixture.TestAddFile();
             });
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -61,6 +61,13 @@ public class MongoDBDriverExerciser
         Client.DropDatabase(databaseName);
     }
 
+    // Tests should call this last so the per-run database does not accumulate on the shared server.
+    [LibraryMethod]
+    public void DropTestDatabase()
+    {
+        Client.DropDatabase(_dbName);
+    }
+
     #endregion Drop
 
     #region Insert

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Oracle/OracleExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Oracle/OracleExerciser.cs
@@ -155,6 +155,8 @@ public class OracleExerciser : IDisposable
 
     private void CreateTable()
     {
+        DropTableIfExists();
+
         var createTable = string.Format(CreateHotelTableOracleSql, _tableName);
 
         var connectionString = OracleConfiguration.OracleConnectionString;
@@ -180,6 +182,17 @@ public class OracleExerciser : IDisposable
         }
     }
 
+    private void DropTableIfExists()
+    {
+        try
+        {
+            DropTable();
+        }
+        catch (OracleException ex) when (ex.Number == 942)
+        {
+        }
+    }
+
     public void Dispose()
     {
         DropTable();
@@ -188,7 +201,7 @@ public class OracleExerciser : IDisposable
         _storedProcedureName = null;
     }
 
-    private readonly string createProcedureStatement = @"CREATE PROCEDURE {0} ({1}) IS BEGIN NULL; END {0};";
+    private readonly string createProcedureStatement = @"CREATE OR REPLACE PROCEDURE {0} ({1}) IS BEGIN NULL; END {0};";
     private readonly string dropProcedureStatement = @"DROP PROCEDURE {0}";
 
     private void CreateProcedure()

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
@@ -34,12 +34,9 @@ public abstract class MongoDBDriverAsyncCursorTestsBase<TFixture> : NewRelicInte
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
@@ -24,9 +24,12 @@ public abstract class MongoDBDriverAsyncCursorTestsBase<TFixture> : NewRelicInte
         _fixture.TestLogger = output;
         _mongoUrl = mongoUrl;
 
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
         _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
         _fixture.AddCommand("MongoDBDriverExerciser GetNextBatch");
         _fixture.AddCommand("MongoDBDriverExerciser GetNextBatchAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser DropTestDatabase");
 
         _fixture.AddActions
         (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -29,6 +29,8 @@ public abstract class MongoDBDriverCollectionTestsBase<TFixture> : NewRelicInteg
         _mongoUrl = mongoUrl;
         _driverVersion = driverVersion;
 
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
         _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
         // Async methods first
         _fixture.AddCommand("MongoDbDriverExerciser AggregateAsync");
@@ -82,6 +84,8 @@ public abstract class MongoDBDriverCollectionTestsBase<TFixture> : NewRelicInteg
             _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollectionAsync");
             _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
         }
+
+        _fixture.AddCommand("MongoDbDriverExerciser DropTestDatabase");
 
         _fixture.AddActions
         (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -89,12 +89,9 @@ public abstract class MongoDBDriverCollectionTestsBase<TFixture> : NewRelicInteg
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -27,6 +27,8 @@ public abstract class MongoDBDriverDatabaseTestsBase<TFixture> : NewRelicIntegra
         _mongoUrl = mongoUrl;
         _driverVersion = driverVersion;
 
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
         _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
         // Async methods first
         _fixture.AddCommand("MongoDBDriverExerciser CreateCollectionAsync");
@@ -56,6 +58,8 @@ public abstract class MongoDBDriverDatabaseTestsBase<TFixture> : NewRelicIntegra
             _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
             _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
         }
+
+        _fixture.AddCommand("MongoDBDriverExerciser DropTestDatabase");
 
         _fixture.AddActions
         (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -63,12 +63,9 @@ public abstract class MongoDBDriverDatabaseTestsBase<TFixture> : NewRelicIntegra
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -24,6 +24,8 @@ public abstract class MongoDBDriverIndexManagerTestsBase<TFixture> : NewRelicInt
         _fixture.TestLogger = output;
         _mongoUrl = mongoUrl;
 
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
         _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
         // Async methods first
         _fixture.AddCommand("MongoDBDriverExerciser CreateManyAsync");
@@ -37,6 +39,7 @@ public abstract class MongoDBDriverIndexManagerTestsBase<TFixture> : NewRelicInt
         _fixture.AddCommand("MongoDBDriverExerciser DropAll");
         _fixture.AddCommand("MongoDBDriverExerciser DropOne");
         _fixture.AddCommand("MongoDBDriverExerciser List");
+        _fixture.AddCommand("MongoDBDriverExerciser DropTestDatabase");
 
         _fixture.AddActions
         (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -44,12 +44,9 @@ public abstract class MongoDBDriverIndexManagerTestsBase<TFixture> : NewRelicInt
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
@@ -35,12 +35,9 @@ public abstract class MongoDBDriverQueryProviderTestsBase<TFixture> : NewRelicIn
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
@@ -25,9 +25,12 @@ public abstract class MongoDBDriverQueryProviderTestsBase<TFixture> : NewRelicIn
         _fixture.TestLogger = output;
         _mongoUrl = mongoUrl;
 
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
         _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
         _fixture.AddCommand("MongoDBDriverExerciser ExecuteModel");
         _fixture.AddCommand("MongoDBDriverExerciser ExecuteModelAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser DropTestDatabase");
 
         _fixture.AddActions
         (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -58,13 +57,9 @@ public class MongoDBLegacyTests : NewRelicIntegrationTest<ConsoleDynamicMethodFi
             {
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(10);
-            },
-            exerciseApplication: () =>
-            {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                _fixture.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                configModifier
+                    .SetLogLevel("FINEST")
+                    .ConfigureFasterMetricsHarvestCycle(10);
             }
         );
         _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -24,6 +25,8 @@ public class MongoDBLegacyTests : NewRelicIntegrationTest<ConsoleDynamicMethodFi
     {
         _fixture = fixture;
         _fixture.TestLogger = output;
+
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
         _fixture.AddCommand($"MongoDBLegacyExerciser SetupClient");
         _fixture.AddCommand($"MongoDBLegacyExerciser Insert");

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
@@ -49,7 +49,7 @@ public abstract class OracleAsyncTestsBase<TFixture> : NewRelicIntegrationTest<T
             exerciseApplication: () =>
             {
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("Datastore/all", 4, TimeSpan.FromMinutes(2));
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleMetadataCommentTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleMetadataCommentTests.cs
@@ -50,7 +50,7 @@ public abstract class OracleMetadataCommentTestsBase<TFixture> : NewRelicIntegra
             exerciseApplication: () =>
             {
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
             }
         );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleSyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleSyncTests.cs
@@ -49,7 +49,7 @@ public abstract class OracleSyncTestsBase<TFixture> : NewRelicIntegrationTest<TF
             exerciseApplication: () =>
             {
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("Datastore/all", 4, TimeSpan.FromMinutes(2));
             }
         );
 


### PR DESCRIPTION
The MongoDB unbounded job was spending most of its time waiting on a log line that could not appear, and hiding the failure. Measured on one fixture: 120.0s of the exercise phase became 27.8s, and the test duration went from 3.7 min to 1.3 min.

- **FINEST log level in the 6 MongoDB classes and 2 container classes.** They waited on `TransactionTransformCompletedLogLineRegex`, which requires the FINEST prefix, while the agent logged at DEBUG. Each wait spent its full 2-minute timeout.
- **Removed the `exerciseApplication` waits from the MongoDB classes.** The app runs to completion and the agent flushes metrics on shutdown.
- **Fixed the swallowed exception in `RemoteApplicationFixture`.** The catch set `retryMessage` but never `retryTest`, so a timed-out wait passed as success with partial data. One line, restoring the evident intent: retry, then fail after `MaxTries`.
- **2-minute fixture timeout in the 6 MongoDB classes.** With the waits gone, the 30-second default became the total budget for the app's work, and `RemoteConsoleApplication.Shutdown` kills the process silently on expiry. Matches the CosmosDB and Elasticsearch precedent.
- **New `DropTestDatabase` command, called last in the 5 driver classes.** The per-run Guid database was never dropped, so every run leaked one database on the shared server.
- **Stopped installing IIS-HostableWebCore for the MongoDB unbounded job.** Every MongoDB fixture is a `ConsoleDynamicMethodFixture`, so the feature is unused.

## Waits the retry fix exposed

Making the swallow loud broke 11 test namespacs. None was a flake: each wait was unsatisfiable in that configuration, and the old code hid it. Every wait below is now keyed on evidence the test actually asserts.

- **AwsLambda** Ses/CloudWatch/DynamoDb/Kinesis/KinesisFirehose waited for 2 serverless payloads while asserting `Assert.Single`. Now 1. The four tests that assert 2 are unchanged.
- **Api** `RecordDatastoreSegment` waited for `sql_trace_data`; the RequiredOnly variant passes no commandText, so no SQL trace is emitted. Guarded with `_allOptions`.
- **ReJit** `RejitAddFile` waited for the file-watcher refresh with the watcher disabled. Guarded with `_disableFileSystemWatcher`.
- **AuditLogTests** waited for the agent shutdown line, which cannot appear during exercise. Now waits for an audit received line, and asserts both audit collections are non-empty -- the old ratio also held at `0 == 2 * 0`.
- **Unbounded Oracle** Async/Sync now wait on the asserted `Datastore/all` aggregate call count, MetadataComment on `sql_trace_data`. The shutdown-line wait had been supplying dwell for a periodic harvest; without it the only `metric_data` snapshot was the one forced at process exit, taken before the metrics transform contributed, so every Oracle datastore metric was missing.
- **`OracleExerciser`** is now idempotent: `CreateTable` drops first and swallows ORA-00942, and the procedure uses `CREATE OR REPLACE`. A retry over state left by a killed try was hitting ORA-00955 22 times.

## Docs

`CLAUDE.md` and the `build-dotnet-agent` skill both described `dotnet build` and omitted that `IntegrationTests.sln` and `UnboundedIntegrationTests.sln` need VS MSBuild -- `dotnet build` fails them with `MSB4019`. Both now cross-reference `tests/CLAUDE.md`, which owns the invocation and its flags.
