### PR TITLE
test: Prevent test methods that need to be instrumented from being inlined or optimized

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AwsSdk/InvokeLambdaExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AwsSdk/InvokeLambdaExerciser.cs
@@ -4,6 +4,7 @@
 using System;
 #endif
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Amazon;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
@@ -16,6 +17,7 @@ public class InvokeLambdaExerciser
 {
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public void InvokeLambdaSync(string function, string payload)
     {
 #if NETFRAMEWORK
@@ -42,6 +44,7 @@ public class InvokeLambdaExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task<string> InvokeLambdaAsync(string function, string payload)
     {
         var client = new Amazon.Lambda.AmazonLambdaClient(RegionEndpoint.USWest2);
@@ -68,6 +71,7 @@ public class InvokeLambdaExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task<string> InvokeLambdaAsyncWithQualifier(string function, string qualifier, string payload)
     {
         var client = new Amazon.Lambda.AmazonLambdaClient(RegionEndpoint.USWest2);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -59,6 +59,7 @@ public class ElasticsearchExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task SearchAsync() => await _client.SearchAsync();
 
     [LibraryMethod]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/FasterEventHarvest.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/FasterEventHarvest.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System.Runtime.CompilerServices;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 
@@ -22,6 +23,7 @@ public static class FasterEventHarvest
     /// start.
     /// </summary>
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     private static void StartAgent()
     {
         ConsoleMFLogger.Info("Instrumented Method to start the Agent");

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/OpenSearch/OpenSearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/OpenSearch/OpenSearchExerciser.cs
@@ -23,6 +23,7 @@ public class OpenSearchExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task SearchAsync() => await _client.SearchAsync();
 
     [LibraryMethod]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/PerformanceMetrics.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/PerformanceMetrics.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
@@ -37,6 +38,7 @@ public static class PerformanceMetrics
     /// start.
     /// </summary>
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     private static void StartAgent()
     {
         ConsoleMFLogger.Info("Instrumented Method to start the Agent");

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
@@ -17,6 +18,7 @@ public class StackExchangeRedisExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public void DoSomeWork()
     {
         using (var redis = ConnectionMultiplexer.Connect(GetRedisConnectionOptions()))
@@ -73,6 +75,7 @@ public class StackExchangeRedisExerciser
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task DoSomeWorkAsync()
     {
         using (var redis = await ConnectionMultiplexer.ConnectAsync(GetRedisConnectionOptions()))

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/RootCommands.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/RootCommands.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
@@ -27,6 +28,7 @@ public static class RootCommands
 
     [LibraryMethod]
     [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public static void InstrumentedMethodToStartAgent()
     {
         // Mission accomplished


### PR DESCRIPTION
During .NET 11 preview evaluation I found an integration test that was failing because .NET 11 is being more aggressive about inlining/optimizing empty/simple methods away than previous SDKs.  This PR applies the `MethodImpl` attributes necessary to prevent all methods that our integration tests require to be instrumented as transactions.