### PR TITLE
ci: add a targeted test workflow and share the build steps

### DIFF
--- a/.github/actions/build-agent/action.yml
+++ b/.github/actions/build-agent/action.yml
@@ -1,0 +1,52 @@
+name: Build Agent
+description: >
+  Builds FullAgent.sln in Release, computes the agent version from the built
+  NewRelic.Agent.Core.dll, and uploads the six agent home directories as the
+  "homefolders" artifact. The caller must check out the repository first.
+
+outputs:
+  agent-version:
+    description: 'FileVersion of the built NewRelic.Agent.Core.dll, e.g. 10.49.0.0'
+    value: ${{ steps.agentVersion.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Cache NuGet packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
+
+    - name: Install latest .NET 10 SDK
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: '10.0.x'
+        dotnet-quality: 'ga'
+
+    - name: Build FullAgent.sln
+      run: |
+        Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ github.workspace }}\FullAgent.sln"
+        dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ github.workspace }}\FullAgent.sln
+      shell: powershell
+
+    - name: Create agentVersion
+      id: agentVersion
+      run: |
+        $agentVersion = (Get-Item "${{ github.workspace }}\src\_build\AnyCPU-Release\NewRelic.Agent.Core\net462\NewRelic.Agent.Core.dll").VersionInfo.FileVersion
+        echo "version=$agentVersion" >> $env:GITHUB_OUTPUT
+      shell: powershell
+        
+    - name: Archive FullAgent Home folders
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: homefolders
+        path: |
+          ${{ github.workspace }}\src\Agent\newrelichome_x64
+          ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr
+          ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr_linux
+          ${{ github.workspace }}\src\Agent\newrelichome_arm64_coreclr_linux
+          ${{ github.workspace }}\src\Agent\newrelichome_x86
+          ${{ github.workspace }}\src\Agent\newrelichome_x86_coreclr
+        if-no-files-found: error

--- a/.github/actions/build-test-solution/action.yml
+++ b/.github/actions/build-test-solution/action.yml
@@ -1,0 +1,123 @@
+name: Build Test Solution
+description: >
+  Restores and builds an integration test solution in Release, pre-publishes its
+  .NET Core test applications so fixtures can copy pre-built output, and uploads
+  the result as a named artifact. The caller must check out the repository first.
+
+inputs:
+  solution-path:
+    description: 'Full path to the .sln to build, e.g. ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln'
+    required: true
+  search-paths:
+    description: 'Space-separated directory names under tests/Agent/IntegrationTests to scan for test apps, e.g. "Applications SharedApplications"'
+    required: true
+  skip-projects:
+    description: 'Space-separated project base names to skip during pre-publish. Empty means skip nothing.'
+    required: false
+    default: ''
+  artifact-name:
+    description: 'Name of the uploaded artifact, e.g. "integrationtests"'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache NuGet packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
+
+    - name: Install latest .NET 10 SDK
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: '10.0.x'
+        dotnet-quality: 'ga'
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+      # if needed for future .NET preview builds:
+      #with:
+      #  vs-prerelease: true
+
+    - name: List SDKS
+      run: dotnet --list-sdks
+      shell: powershell
+
+    - name: Build test solution
+      run: |
+        Write-Host "List NuGet Sources"
+        dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+        Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ inputs.solution-path }}"
+        MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ inputs.solution-path }}
+      shell: powershell
+
+    - name: Pre-publish .NET Core test apps
+      run: |
+        # Pre-publish .NET Core test apps so test fixtures can copy pre-built output
+        # instead of invoking dotnet publish at runtime. This eliminates file-lock
+        # collisions on shared dependency obj/ directories during parallel test execution.
+        # We skip class libraries and Azure Function apps (func.exe requires the original
+        # build output structure, not RID-specific publish output).
+        $runtime = "win-x64"
+        $searchPaths = @("${{ inputs.search-paths }}" -split ' ' | Where-Object { $_ })
+        $basePath = "${{ github.workspace }}\tests\Agent\IntegrationTests"
+        # Azure Function apps are incompatible with pre-publish: func.exe start --no-build
+        # expects framework-dependent build output, not RID-specific publish output
+        $skipProjects = @("${{ inputs.skip-projects }}" -split ' ' | Where-Object { $_ })
+        $published = 0; $skipped = 0; $failed = 0
+        foreach ($searchPath in $searchPaths) {
+          $fullPath = Join-Path $basePath $searchPath
+          if (-not (Test-Path $fullPath)) { continue }
+          $projects = Get-ChildItem -Path $fullPath -Filter "*.csproj" -Recurse
+          foreach ($project in $projects) {
+            $content = Get-Content $project.FullName -Raw
+            # Skip explicit class libraries and excluded projects
+            if ($content -match '<OutputType>\s*Library\s*</OutputType>') { $skipped++; continue }
+            if ($skipProjects -contains $project.BaseName) { $skipped++; continue }
+            if ($content -match '<TargetFrameworks?>(.*?)</TargetFrameworks?>') {
+              $tfms = $Matches[1] -split ';'
+              foreach ($tfm in $tfms) {
+                if ($tfm -match '^net\d+\.\d+$') {
+                  Write-Host "Pre-publishing $($project.Name) for $tfm/$runtime"
+                  $output = dotnet publish --configuration Release --runtime $runtime --framework $tfm $project.FullName 2>&1
+                  if ($LASTEXITCODE -ne 0) {
+                    Write-Warning "Failed to pre-publish $($project.Name) for $tfm/$runtime"
+                    $output | Where-Object { $_ -match "error" } | ForEach-Object { Write-Host "  $_" }
+                    $failed++
+                  } else {
+                    $published++
+                  }
+                }
+              }
+            }
+          }
+        }
+        Write-Host "Pre-publish complete: $published succeeded, $skipped skipped (libraries), $failed failed"
+
+        # Clean up intermediate RID-specific build artifacts to reduce artifact size.
+        # dotnet publish --runtime creates large intermediate files alongside the publish/
+        # subdirectory (including self-contained runtime copies). Only publish/ is needed.
+        $cleaned = 0
+        foreach ($searchPath in $searchPaths) {
+          $fullPath = Join-Path $basePath $searchPath
+          if (-not (Test-Path $fullPath)) { continue }
+          Get-ChildItem -Path $fullPath -Directory -Recurse -Filter $runtime | ForEach-Object {
+            Get-ChildItem -Path $_.FullName -Exclude "publish" | Remove-Item -Recurse -Force
+            $cleaned++
+          }
+        }
+        Write-Host "Cleaned intermediate build artifacts from $cleaned RID directories"
+      shell: powershell
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+          !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+        if-no-files-found: error

--- a/.github/actions/build-test-solution/action.yml
+++ b/.github/actions/build-test-solution/action.yml
@@ -6,7 +6,7 @@ description: >
 
 inputs:
   solution-path:
-    description: 'Full path to the .sln to build, e.g. ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln'
+    description: 'Absolute path to the .sln to build, e.g. <workspace>\tests\Agent\IntegrationTests\IntegrationTests.sln'
     required: true
   search-paths:
     description: 'Space-separated directory names under tests/Agent/IntegrationTests to scan for test apps, e.g. "Applications SharedApplications"'

--- a/.github/scripts/check-workflows.py
+++ b/.github/scripts/check-workflows.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Static checks over the .github workflows the test refactor depends on.
+
+Exits 0 when every check passes, 1 otherwise, printing one line per failure.
+Checks V1b, V1c, and V1f are deliberately absent: they compare against
+pre-change text and can only run once, before the refactor lands.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+TOUCHED = [
+    "all_solutions.yml",
+    "linux_container_tests.yml",
+    "test_selection.yml",
+    "integration_tests.yml",
+    "unbounded_tests.yml",
+    "targeted_tests.yml",
+]
+
+REQUIRED_CONTEXTS = [
+    "Build FullAgent and MSIInstaller",
+    "Check Test Matrix Status",
+    "Run ArtifactBuilder",
+]
+
+NO_CONCURRENCY = ["integration_tests.yml", "unbounded_tests.yml"]
+
+RANK = {"none": 0, "read": 1, "write": 2}
+
+FAILURES = []
+
+_EXTERNAL_CACHE = {}
+
+
+def fail(check, message):
+    FAILURES.append("%s: %s" % (check, message))
+
+
+def load(name):
+    """Parse a workflow. PyYAML turns the unquoted key `on` into True."""
+    try:
+        return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - any parse error is a V1a failure
+        fail("V1a", "%s does not parse: %s" % (name, exc))
+        return None
+
+
+def load_external(name):
+    """Load a workflow outside TOUCHED, on demand, for the V1e ceiling check only.
+
+    Not added to `docs` and not run through the explicit-permissions checks,
+    which stay scoped to TOUCHED.
+    """
+    if name in _EXTERNAL_CACHE:
+        return _EXTERNAL_CACHE[name]
+    path = WORKFLOWS / name
+    if not path.exists():
+        _EXTERNAL_CACHE[name] = None
+        return None
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 - reported by the caller with context
+        _EXTERNAL_CACHE[name] = None
+        return None
+    _EXTERNAL_CACHE[name] = doc
+    return doc
+
+
+def jobs_of(doc):
+    return (doc or {}).get("jobs") or {}
+
+
+def perm_map(value, where, check):
+    """Normalize a permissions value to {scope: level}. A string form fails."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        fail(check, "%s uses the string permissions form '%s'; use an explicit mapping" % (where, value))
+        return {}
+    return {k: str(v) for k, v in value.items()}
+
+
+def check_v1a(docs):
+    doc = docs.get("all_solutions.yml")
+    if doc is None:
+        return
+    ids = set(jobs_of(doc))
+    for jid, job in jobs_of(doc).items():
+        needs = job.get("needs") or []
+        if isinstance(needs, str):
+            needs = [needs]
+        for dep in needs:
+            if dep not in ids:
+                fail("V1a", "job '%s' needs '%s', which is not a job id in all_solutions.yml" % (jid, dep))
+
+
+def check_v1d(docs):
+    doc = docs.get("all_solutions.yml")
+    if doc is None:
+        return
+    bare = {}
+    for jid, job in jobs_of(doc).items():
+        if "uses" not in job and job.get("name"):
+            bare[job["name"]] = jid
+    for context in REQUIRED_CONTEXTS:
+        if context not in bare:
+            fail(
+                "V1d",
+                "required status check '%s' is not a bare top-level job name in all_solutions.yml; "
+                "a caller job reports as '<caller> / <called>' and would detach the check in "
+                "ruleset 'main branch' (id 4599184)" % context,
+            )
+
+
+def check_v1e(docs):
+    for name, doc in docs.items():
+        if doc is None:
+            continue
+        top = perm_map(doc.get("permissions"), "%s top-level" % name, "V1e")
+        if top:
+            writes = sorted(k for k, v in top.items() if RANK.get(v, 0) >= 2)
+            if writes:
+                fail("V1e", "%s top-level permissions grant write scopes %s; move them to the jobs that need them" % (name, writes))
+        for jid, job in jobs_of(doc).items():
+            if "permissions" not in job:
+                fail("V1e", "%s job '%s' has no explicit permissions block" % (name, jid))
+            else:
+                perm_map(job["permissions"], "%s job '%s'" % (name, jid), "V1e")
+
+    for name, doc in docs.items():
+        if doc is None:
+            continue
+        for jid, job in jobs_of(doc).items():
+            uses = job.get("uses") or ""
+            if not uses.startswith("./.github/workflows/"):
+                continue
+            called = uses.rsplit("/", 1)[-1]
+            called_doc = docs.get(called)
+            if called_doc is None:
+                called_doc = load_external(called)
+                if called_doc is None:
+                    fail("V1e", "%s job '%s' calls %s, which does not exist or does not parse" % (name, jid, called))
+                    continue
+            needed = {}
+            for cjob in jobs_of(called_doc).values():
+                for scope, level in (perm_map(cjob.get("permissions"), called, "V1e") or {}).items():
+                    if RANK.get(level, 0) > RANK.get(needed.get(scope, "none"), 0):
+                        needed[scope] = level
+            granted = perm_map(job.get("permissions"), "%s job '%s'" % (name, jid), "V1e") or {}
+            short = {
+                scope: level
+                for scope, level in needed.items()
+                if RANK.get(level, 0) > RANK.get(granted.get(scope, "none"), 0)
+            }
+            if short:
+                fail(
+                    "V1e",
+                    "%s job '%s' grants %s but %s needs at least %s; an under-granted ceiling "
+                    "fails at run time as a 403, not at parse time" % (name, jid, granted or {}, called, short),
+                )
+
+
+def extract_pairs_test_selection():
+    text = (WORKFLOWS / "test_selection.yml").read_text(encoding="utf-8")
+    match = re.search(r"container_all='(\[[^']*\])'", text)
+    if not match:
+        fail("V1g", "could not extract container_all='[...]' from test_selection.yml; the anchor changed")
+        return None
+    try:
+        return [tuple(p.split("/", 1)) for p in json.loads(match.group(1))]
+    except (ValueError, json.JSONDecodeError) as exc:
+        fail("V1g", "container_all in test_selection.yml is not valid JSON: %s" % exc)
+        return None
+
+
+def extract_pairs_container_matrix(docs):
+    doc = docs.get("linux_container_tests.yml")
+    if doc is None:
+        return None
+    job = jobs_of(doc).get("select-matrix")
+    if not job:
+        fail("V1g", "linux_container_tests.yml has no select-matrix job")
+        return None
+    bodies = [s.get("run", "") for s in job.get("steps") or []]
+    for body in bodies:
+        match = re.search(r"all='(\[.*?\])'", body, re.S)
+        if match:
+            try:
+                entries = json.loads(match.group(1))
+            except (ValueError, json.JSONDecodeError) as exc:
+                fail("V1g", "the select-matrix JSON literal is not valid JSON: %s" % exc)
+                return None
+            return [(e["name"], e["arch"]) for e in entries]
+    fail("V1g", "could not extract all='[...]' from the select-matrix job; the anchor changed")
+    return None
+
+
+def check_v1g(docs):
+    left = extract_pairs_test_selection()
+    right = extract_pairs_container_matrix(docs)
+    if left is None or right is None:
+        return
+    if sorted(left) != sorted(right):
+        only_left = sorted(set(left) - set(right))
+        only_right = sorted(set(right) - set(left))
+        fail(
+            "V1g",
+            "container group lists have drifted. Only in test_selection.yml: %s. "
+            "Only in linux_container_tests.yml: %s" % (only_left, only_right),
+        )
+
+
+def check_v1h(docs):
+    for name in NO_CONCURRENCY:
+        doc = docs.get(name)
+        if doc is None:
+            continue
+        if "concurrency" in doc:
+            fail(
+                "V1h",
+                "%s declares concurrency. github.workflow in a called workflow resolves to the "
+                "caller's name, so integration_tests and unbounded_tests would share a group and "
+                "cancel each other inside one run" % name,
+            )
+
+
+def main():
+    docs = {}
+    for name in TOUCHED:
+        path = WORKFLOWS / name
+        if not path.exists():
+            fail("V1a", "%s does not exist" % name)
+            continue
+        docs[name] = load(name)
+
+    check_v1a(docs)
+    check_v1d(docs)
+    check_v1e(docs)
+    check_v1g(docs)
+    check_v1h(docs)
+
+    if FAILURES:
+        print("check-workflows: %d failure(s)" % len(FAILURES))
+        for line in FAILURES:
+            print("  " + line)
+        return 1
+    print("check-workflows: all checks passed (V1a, V1d, V1e, V1g, V1h)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-workflows.py
+++ b/.github/scripts/check-workflows.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-"""Static checks over the .github workflows the test refactor depends on.
+"""Static checks over the .github workflows that drive the test solutions.
 
 Exits 0 when every check passes, 1 otherwise, printing one line per failure.
-Checks V1b, V1c, and V1f are deliberately absent: they compare against
-pre-change text and can only run once, before the refactor lands.
 """
 
 import json
@@ -48,13 +46,13 @@ def load(name):
     """Parse a workflow. PyYAML turns the unquoted key `on` into True."""
     try:
         return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001 - any parse error is a V1a failure
-        fail("V1a", "%s does not parse: %s" % (name, exc))
+    except Exception as exc:  # noqa: BLE001 - any parse error is a workflow-parse failure
+        fail("workflow-parse", "%s does not parse: %s" % (name, exc))
         return None
 
 
 def load_external(name):
-    """Load a workflow outside TOUCHED, on demand, for the V1e ceiling check only.
+    """Load a workflow outside TOUCHED, on demand, for the permissions ceiling check only.
 
     Not added to `docs` and not run through the explicit-permissions checks,
     which stay scoped to TOUCHED.
@@ -88,7 +86,7 @@ def perm_map(value, where, check):
     return {k: str(v) for k, v in value.items()}
 
 
-def check_v1a(docs):
+def check_needs_resolve(docs):
     doc = docs.get("all_solutions.yml")
     if doc is None:
         return
@@ -99,10 +97,10 @@ def check_v1a(docs):
             needs = [needs]
         for dep in needs:
             if dep not in ids:
-                fail("V1a", "job '%s' needs '%s', which is not a job id in all_solutions.yml" % (jid, dep))
+                fail("needs-resolution", "job '%s' needs '%s', which is not a job id in all_solutions.yml" % (jid, dep))
 
 
-def check_v1d(docs):
+def check_required_checks_are_bare_jobs(docs):
     doc = docs.get("all_solutions.yml")
     if doc is None:
         return
@@ -113,27 +111,27 @@ def check_v1d(docs):
     for context in REQUIRED_CONTEXTS:
         if context not in bare:
             fail(
-                "V1d",
+                "required-checks",
                 "required status check '%s' is not a bare top-level job name in all_solutions.yml; "
                 "a caller job reports as '<caller> / <called>' and would detach the check in "
                 "ruleset 'main branch' (id 4599184)" % context,
             )
 
 
-def check_v1e(docs):
+def check_permission_ceilings(docs):
     for name, doc in docs.items():
         if doc is None:
             continue
-        top = perm_map(doc.get("permissions"), "%s top-level" % name, "V1e")
+        top = perm_map(doc.get("permissions"), "%s top-level" % name, "permissions")
         if top:
             writes = sorted(k for k, v in top.items() if RANK.get(v, 0) >= 2)
             if writes:
-                fail("V1e", "%s top-level permissions grant write scopes %s; move them to the jobs that need them" % (name, writes))
+                fail("permissions", "%s top-level permissions grant write scopes %s; move them to the jobs that need them" % (name, writes))
         for jid, job in jobs_of(doc).items():
             if "permissions" not in job:
-                fail("V1e", "%s job '%s' has no explicit permissions block" % (name, jid))
+                fail("permissions", "%s job '%s' has no explicit permissions block" % (name, jid))
             else:
-                perm_map(job["permissions"], "%s job '%s'" % (name, jid), "V1e")
+                perm_map(job["permissions"], "%s job '%s'" % (name, jid), "permissions")
 
     for name, doc in docs.items():
         if doc is None:
@@ -147,14 +145,14 @@ def check_v1e(docs):
             if called_doc is None:
                 called_doc = load_external(called)
                 if called_doc is None:
-                    fail("V1e", "%s job '%s' calls %s, which does not exist or does not parse" % (name, jid, called))
+                    fail("permissions", "%s job '%s' calls %s, which does not exist or does not parse" % (name, jid, called))
                     continue
             needed = {}
             for cjob in jobs_of(called_doc).values():
-                for scope, level in (perm_map(cjob.get("permissions"), called, "V1e") or {}).items():
+                for scope, level in (perm_map(cjob.get("permissions"), called, "permissions") or {}).items():
                     if RANK.get(level, 0) > RANK.get(needed.get(scope, "none"), 0):
                         needed[scope] = level
-            granted = perm_map(job.get("permissions"), "%s job '%s'" % (name, jid), "V1e") or {}
+            granted = perm_map(job.get("permissions"), "%s job '%s'" % (name, jid), "permissions") or {}
             short = {
                 scope: level
                 for scope, level in needed.items()
@@ -162,7 +160,7 @@ def check_v1e(docs):
             }
             if short:
                 fail(
-                    "V1e",
+                    "permissions",
                     "%s job '%s' grants %s but %s needs at least %s; an under-granted ceiling "
                     "fails at run time as a 403, not at parse time" % (name, jid, granted or {}, called, short),
                 )
@@ -172,12 +170,12 @@ def extract_pairs_test_selection():
     text = (WORKFLOWS / "test_selection.yml").read_text(encoding="utf-8")
     match = re.search(r"container_all='(\[[^']*\])'", text)
     if not match:
-        fail("V1g", "could not extract container_all='[...]' from test_selection.yml; the anchor changed")
+        fail("container-lists", "could not extract container_all='[...]' from test_selection.yml; the anchor changed")
         return None
     try:
         return [tuple(p.split("/", 1)) for p in json.loads(match.group(1))]
     except (ValueError, json.JSONDecodeError) as exc:
-        fail("V1g", "container_all in test_selection.yml is not valid JSON: %s" % exc)
+        fail("container-lists", "container_all in test_selection.yml is not valid JSON: %s" % exc)
         return None
 
 
@@ -187,7 +185,7 @@ def extract_pairs_container_matrix(docs):
         return None
     job = jobs_of(doc).get("select-matrix")
     if not job:
-        fail("V1g", "linux_container_tests.yml has no select-matrix job")
+        fail("container-lists", "linux_container_tests.yml has no select-matrix job")
         return None
     bodies = [s.get("run", "") for s in job.get("steps") or []]
     for body in bodies:
@@ -196,14 +194,14 @@ def extract_pairs_container_matrix(docs):
             try:
                 entries = json.loads(match.group(1))
             except (ValueError, json.JSONDecodeError) as exc:
-                fail("V1g", "the select-matrix JSON literal is not valid JSON: %s" % exc)
+                fail("container-lists", "the select-matrix JSON literal is not valid JSON: %s" % exc)
                 return None
             return [(e["name"], e["arch"]) for e in entries]
-    fail("V1g", "could not extract all='[...]' from the select-matrix job; the anchor changed")
+    fail("container-lists", "could not extract all='[...]' from the select-matrix job; the anchor changed")
     return None
 
 
-def check_v1g(docs):
+def check_container_lists_match(docs):
     left = extract_pairs_test_selection()
     right = extract_pairs_container_matrix(docs)
     if left is None or right is None:
@@ -212,27 +210,27 @@ def check_v1g(docs):
         only_left = sorted(set(left) - set(right))
         only_right = sorted(set(right) - set(left))
         fail(
-            "V1g",
+            "container-lists",
             "container group lists have drifted. Only in test_selection.yml: %s. "
             "Only in linux_container_tests.yml: %s" % (only_left, only_right),
         )
 
 
-def check_v1h(docs):
+def check_no_concurrency_in_called_workflows(docs):
     for name in NO_CONCURRENCY:
         doc = docs.get(name)
         if doc is None:
             continue
         if "concurrency" in doc:
             fail(
-                "V1h",
+                "called-workflow-concurrency",
                 "%s declares concurrency. github.workflow in a called workflow resolves to the "
                 "caller's name, so integration_tests and unbounded_tests would share a group and "
                 "cancel each other inside one run" % name,
             )
 
 
-def check_v1i():
+def check_no_expressions_in_action_metadata():
     """No expression in an action.yml's metadata.
 
     The github context is available inside `runs:` but not in the metadata block,
@@ -243,7 +241,7 @@ def check_v1i():
         try:
             doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         except Exception as exc:  # noqa: BLE001 - an unparseable action is a failure
-            fail("V1i", "%s does not parse: %s" % (path.name, exc))
+            fail("action-metadata", "%s does not parse: %s" % (path.name, exc))
             continue
         fields = [(k, doc.get(k)) for k in ("name", "description", "author")]
         for section in ("inputs", "outputs"):
@@ -254,7 +252,7 @@ def check_v1i():
         for where, text in fields:
             if isinstance(text, str) and "${{" in text:
                 fail(
-                    "V1i",
+                    "action-metadata",
                     "%s %s contains an expression; no context is available in action "
                     "metadata, so the runner fails to load the action"
                     % (path.parent.name + "/action.yml", where),
@@ -266,23 +264,26 @@ def main():
     for name in TOUCHED:
         path = WORKFLOWS / name
         if not path.exists():
-            fail("V1a", "%s does not exist" % name)
+            fail("workflow-parse", "%s does not exist" % name)
             continue
         docs[name] = load(name)
 
-    check_v1a(docs)
-    check_v1d(docs)
-    check_v1e(docs)
-    check_v1g(docs)
-    check_v1h(docs)
-    check_v1i()
+    check_needs_resolve(docs)
+    check_required_checks_are_bare_jobs(docs)
+    check_permission_ceilings(docs)
+    check_container_lists_match(docs)
+    check_no_concurrency_in_called_workflows(docs)
+    check_no_expressions_in_action_metadata()
 
     if FAILURES:
         print("check-workflows: %d failure(s)" % len(FAILURES))
         for line in FAILURES:
             print("  " + line)
         return 1
-    print("check-workflows: all checks passed (V1a, V1d, V1e, V1g, V1h, V1i)")
+    print(
+        "check-workflows: all checks passed (needs-resolution, required-checks, "
+        "permissions, container-lists, called-workflow-concurrency, action-metadata)"
+    )
     return 0
 
 

--- a/.github/scripts/check-workflows.py
+++ b/.github/scripts/check-workflows.py
@@ -232,6 +232,35 @@ def check_v1h(docs):
             )
 
 
+def check_v1i():
+    """No expression in an action.yml's metadata.
+
+    The github context is available inside `runs:` but not in the metadata block,
+    so an example path in a description makes the runner refuse to load the action
+    with "Unrecognized named-value: 'github'". PyYAML parses it happily.
+    """
+    for path in sorted((ROOT / ".github" / "actions").glob("*/action.yml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # noqa: BLE001 - an unparseable action is a failure
+            fail("V1i", "%s does not parse: %s" % (path.name, exc))
+            continue
+        fields = [(k, doc.get(k)) for k in ("name", "description", "author")]
+        for section in ("inputs", "outputs"):
+            for item, spec in (doc.get(section) or {}).items():
+                if isinstance(spec, dict):
+                    for key in ("description", "default"):
+                        fields.append(("%s.%s.%s" % (section, item, key), spec.get(key)))
+        for where, text in fields:
+            if isinstance(text, str) and "${{" in text:
+                fail(
+                    "V1i",
+                    "%s %s contains an expression; no context is available in action "
+                    "metadata, so the runner fails to load the action"
+                    % (path.parent.name + "/action.yml", where),
+                )
+
+
 def main():
     docs = {}
     for name in TOUCHED:
@@ -246,13 +275,14 @@ def main():
     check_v1e(docs)
     check_v1g(docs)
     check_v1h(docs)
+    check_v1i()
 
     if FAILURES:
         print("check-workflows: %d failure(s)" % len(FAILURES))
         for line in FAILURES:
             print("  " + line)
         return 1
-    print("check-workflows: all checks passed (V1a, V1d, V1e, V1g, V1h)")
+    print("check-workflows: all checks passed (V1a, V1d, V1e, V1g, V1h, V1i)")
     return 0
 
 

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -62,6 +62,8 @@ jobs:
     name: Validate shell scripts
     needs: check-modified-files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -79,6 +81,8 @@ jobs:
   build-fullagent-msi:
     name: Build FullAgent and MSIInstaller
     runs-on: windows-2022
+    permissions:
+      contents: read
     needs:
       - check-modified-files
       - shellcheck
@@ -90,11 +94,10 @@ jobs:
     if: (github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]') && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
 
     env:
-      fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln
       msi_solution_path: ${{ github.workspace }}\src\Agent\MsiInstaller\MsiInstaller.sln
 
     outputs:
-      agentVersion: ${{ steps.agentVersion.outputs.version }}
+      agentVersion: ${{ steps.build-agent.outputs.agent-version }}
       # Re-exported so the packaging jobs can gate on it: job-level `if` cannot read `env`.
       skipSigning: ${{ env.skip_signing }}
 
@@ -105,44 +108,9 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Cache NuGet packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
-          restore-keys: ${{ runner.os }}-nuget-
-
-      - name: Install latest .NET 10 SDK
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
-
-      - name: Build FullAgent.sln
-        run: |
-          Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
-          dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
-        shell: powershell
-
-      - name: Create agentVersion
-        id: agentVersion
-        run: |
-          $agentVersion = (Get-Item "${{ github.workspace }}\src\_build\AnyCPU-Release\NewRelic.Agent.Core\net462\NewRelic.Agent.Core.dll").VersionInfo.FileVersion
-          echo "version=$agentVersion" >> $env:GITHUB_OUTPUT
-        shell: powershell
-          
-      - name: Archive FullAgent Home folders
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: homefolders
-          path: |
-            ${{ github.workspace }}\src\Agent\newrelichome_x64
-            ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr
-            ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr_linux
-            ${{ github.workspace }}\src\Agent\newrelichome_arm64_coreclr_linux
-            ${{ github.workspace }}\src\Agent\newrelichome_x86
-            ${{ github.workspace }}\src\Agent\newrelichome_x86_coreclr
-          if-no-files-found: error
+      - name: Build agent
+        id: build-agent
+        uses: ./.github/actions/build-agent
 
       # Signing and MSI build are skipped for the Dependabot dispatch (see note above the jobs).
       # The build and homefolders artifact above are all the test suites need.
@@ -197,989 +165,51 @@ jobs:
     uses: ./.github/workflows/linux_container_tests.yml
     with:
       aggregate_payload_data: ${{ inputs.aggregate_payload_data == true || github.event_name == 'schedule' }}
+      groups: ''
     secrets: inherit
     permissions:
       actions: write
       contents: read
         
-  # ---------------------------------------------------------------------------
-  # Compute the set of test namespaces to run, after applying exclusions from
-  # GitHub repo variables.  To skip a namespace, add it to the JSON-array
-  # variable in Settings > Secrets and variables > Actions > Variables:
-  #   INTEGRATION_EXCLUDE_NAMESPACES  (e.g. ["LLM","OpenTelemetry"])
-  #   UNBOUNDED_EXCLUDE_NAMESPACES    (e.g. ["Couchbase"])
-  # ---------------------------------------------------------------------------
   get-test-namespaces:
     name: Get Test Namespaces
     needs: check-modified-files
     if: (github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]') && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-    runs-on: ubuntu-latest
-    outputs:
-      integration-namespaces: ${{ steps.compute.outputs.integration }}
-      unbounded-namespaces: ${{ steps.compute.outputs.unbounded }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          disable-sudo: true
-          egress-policy: audit
-
-      - name: Compute namespace lists
-        id: compute
-        env:
-          INTEGRATION_EXCLUDE: ${{ vars.INTEGRATION_EXCLUDE_NAMESPACES }}
-          UNBOUNDED_EXCLUDE: ${{ vars.UNBOUNDED_EXCLUDE_NAMESPACES }}
-        run: |
-          # ── Canonical namespace lists ──────────────────────────────────
-          # maintain alphabetical order, please!
-          integration_all='[
-            "AgentFeatures",
-            "AgentLogs",
-            "AgentMetrics",
-            "Api",
-            "AppDomainCaching",
-            "AspNetCore",
-            "AwsLambda.AutoInstrumentation",
-            "AwsLambda.CloudWatch",
-            "AwsLambda.Custom",
-            "AwsLambda.DynamoDb",
-            "AwsLambda.General",
-            "AwsLambda.Kinesis",
-            "AwsLambda.S3",
-            "AwsLambda.Ses",
-            "AwsLambda.Sns",
-            "AwsLambda.Sqs",
-            "AwsLambda.WebRequest",
-            "AwsSdk",
-            "AzureFunction",
-            "BasicInstrumentation",
-            "Blazor",
-            "CatInbound",
-            "CatOutbound",
-            "CodeLevelMetrics",
-            "Configuration",
-            "CustomAttributes",
-            "CustomInstrumentation",
-            "DataTransmission",
-            "DistributedTracing",
-            "Errors",
-            "Grpc",
-            "Hangfire",
-            "HSM",
-            "HttpClientInstrumentation",
-            "HybridHttpContextStorage",
-            "InfiniteTracing",
-            "LLM",
-            "Logging.AuditLog",
-            "Logging.ContextData",
-            "Logging.Hsm",
-            "Logging.Labels",
-            "Logging.LocalDecoration",
-            "Logging.LogLevelDetection",
-            "Logging.MaxSamplesStored",
-            "Logging.MetricsAndForwarding",
-            "Logging.StructuredLogArgContextData",
-            "Logging.ZeroMaxSamplesStored",
-            "MassTransit",
-            "MultiAppDomain",
-            "OpenTelemetry",
-            "Owin",
-            "ReJit.NetCore",
-            "ReJit.NetFramework",
-            "RequestHandling",
-            "RequestHeadersCapture.AspNet",
-            "RequestHeadersCapture.AspNetCore",
-            "RequestHeadersCapture.EnvironmentVariables",
-            "RequestHeadersCapture.Owin",
-            "RequestHeadersCapture.WCF",
-            "RestSharp",
-            "WCF.Client.IIS.ASPDisabled",
-            "WCF.Client.IIS.ASPEnabled",
-            "WCF.Client.Self",
-            "WCF.Service.IIS.ASPDisabled",
-            "WCF.Service.IIS.ASPEnabled",
-            "WCF.Service.Self"
-          ]'
-
-          unbounded_all='[
-            "AzureServiceBus",
-            "CosmosDB",
-            "Couchbase",
-            "Elasticsearch",
-            "MongoDB",
-            "Msmq",
-            "MsSql",
-            "MySql",
-            "NServiceBus",
-            "NServiceBus5",
-            "OpenSearch",
-            "Oracle",
-            "Postgres",
-            "RabbitMq",
-            "Redis"
-          ]'
-
-          # ── Read exclusion variables (default to empty array) ─────────
-          integration_exclude="${INTEGRATION_EXCLUDE:-[]}"
-          unbounded_exclude="${UNBOUNDED_EXCLUDE:-[]}"
-
-          # ── Apply exclusions ──────────────────────────────────────────
-          integration=$(jq -c '. - $ex' --argjson ex "$integration_exclude" <<< "$integration_all")
-          unbounded=$(jq -c '. - $ex' --argjson ex "$unbounded_exclude" <<< "$unbounded_all")
-
-          # ── Log what was excluded ─────────────────────────────────────
-          int_removed=$(jq -c '. as $all | $all - ($all - $ex)' --argjson ex "$integration_exclude" <<< "$integration_all")
-          unb_removed=$(jq -c '. as $all | $all - ($all - $ex)' --argjson ex "$unbounded_exclude" <<< "$unbounded_all")
-
-          echo "::group::Integration test namespaces"
-          echo "Excluded: $int_removed"
-          echo "Running:  $integration"
-          echo "::endgroup::"
-
-          echo "::group::Unbounded test namespaces"
-          echo "Excluded: $unb_removed"
-          echo "Running:  $unbounded"
-          echo "::endgroup::"
-
-          echo "integration=$integration" >> "$GITHUB_OUTPUT"
-          echo "unbounded=$unbounded" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-  build-integration-tests:
-    needs: build-fullagent-msi
-    name: Build IntegrationTests
-    runs-on: windows-2025-vs2026 
-
-    env:
-      integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Cache NuGet packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
-          restore-keys: ${{ runner.os }}-nuget-
-
-      - name: Install latest .NET 10 SDK
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
-        # if needed for future .NET preview builds:
-        #with:
-        #  vs-prerelease: true
-
-      - name: List SDKS
-        run: dotnet --list-sdks
-        shell: powershell
-
-      - name: Build IntegrationTests.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
-        shell: powershell
-
-      - name: Pre-publish .NET Core test apps
-        run: |
-          # Pre-publish .NET Core test apps so test fixtures can copy pre-built output
-          # instead of invoking dotnet publish at runtime. This eliminates file-lock
-          # collisions on shared dependency obj/ directories during parallel test execution.
-          # We skip class libraries and Azure Function apps (func.exe requires the original
-          # build output structure, not RID-specific publish output).
-          $runtime = "win-x64"
-          $searchPaths = @("Applications", "SharedApplications")
-          $basePath = "${{ github.workspace }}\tests\Agent\IntegrationTests"
-          # Azure Function apps are incompatible with pre-publish: func.exe start --no-build
-          # expects framework-dependent build output, not RID-specific publish output
-          $skipProjects = @("AzureFunctionApplication", "AzureFunctionInProcApplication")
-          $published = 0; $skipped = 0; $failed = 0
-          foreach ($searchPath in $searchPaths) {
-            $fullPath = Join-Path $basePath $searchPath
-            if (-not (Test-Path $fullPath)) { continue }
-            $projects = Get-ChildItem -Path $fullPath -Filter "*.csproj" -Recurse
-            foreach ($project in $projects) {
-              $content = Get-Content $project.FullName -Raw
-              # Skip explicit class libraries and excluded projects
-              if ($content -match '<OutputType>\s*Library\s*</OutputType>') { $skipped++; continue }
-              if ($skipProjects -contains $project.BaseName) { $skipped++; continue }
-              if ($content -match '<TargetFrameworks?>(.*?)</TargetFrameworks?>') {
-                $tfms = $Matches[1] -split ';'
-                foreach ($tfm in $tfms) {
-                  if ($tfm -match '^net\d+\.\d+$') {
-                    Write-Host "Pre-publishing $($project.Name) for $tfm/$runtime"
-                    $output = dotnet publish --configuration Release --runtime $runtime --framework $tfm $project.FullName 2>&1
-                    if ($LASTEXITCODE -ne 0) {
-                      Write-Warning "Failed to pre-publish $($project.Name) for $tfm/$runtime"
-                      $output | Where-Object { $_ -match "error" } | ForEach-Object { Write-Host "  $_" }
-                      $failed++
-                    } else {
-                      $published++
-                    }
-                  }
-                }
-              }
-            }
-          }
-          Write-Host "Pre-publish complete: $published succeeded, $skipped skipped (libraries), $failed failed"
-
-          # Clean up intermediate RID-specific build artifacts to reduce artifact size.
-          # dotnet publish --runtime creates large intermediate files alongside the publish/
-          # subdirectory (including self-contained runtime copies). Only publish/ is needed.
-          $cleaned = 0
-          foreach ($searchPath in $searchPaths) {
-            $fullPath = Join-Path $basePath $searchPath
-            if (-not (Test-Path $fullPath)) { continue }
-            Get-ChildItem -Path $fullPath -Directory -Recurse -Filter $runtime | ForEach-Object {
-              Get-ChildItem -Path $_.FullName -Exclude "publish" | Remove-Item -Recurse -Force
-              $cleaned++
-            }
-          }
-          Write-Host "Cleaned intermediate build artifacts from $cleaned RID directories"
-        shell: powershell
-
-      - name: Archive Artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integrationtests
-          path: |
-            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-          if-no-files-found: error
-
-  build-unbounded-tests:
-    needs: build-fullagent-msi
-    name: Build UnboundedIntegrationTests
-    runs-on: windows-2025-vs2026
-
-    env:
-      unbounded_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Cache NuGet packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
-          restore-keys: ${{ runner.os }}-nuget-
-
-      - name: Install latest .NET 10 SDK
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
-        # if needed for future .NET preview builds:
-        #with:
-        #  vs-prerelease: true
-
-      - name: Build UnboundedIntegrationTests.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
-        shell: powershell
-
-      - name: Pre-publish .NET Core test apps
-        run: |
-          # Pre-publish .NET Core test apps so test fixtures can copy pre-built output
-          # instead of invoking dotnet publish at runtime. This eliminates file-lock
-          # collisions on shared dependency obj/ directories during parallel test execution.
-          # We skip class libraries (OutputType=Library or netstandard-only targets).
-          $runtime = "win-x64"
-          $searchPaths = @("UnboundedApplications", "SharedApplications")
-          $basePath = "${{ github.workspace }}\tests\Agent\IntegrationTests"
-          $published = 0; $skipped = 0; $failed = 0
-          foreach ($searchPath in $searchPaths) {
-            $fullPath = Join-Path $basePath $searchPath
-            if (-not (Test-Path $fullPath)) { continue }
-            $projects = Get-ChildItem -Path $fullPath -Filter "*.csproj" -Recurse
-            foreach ($project in $projects) {
-              $content = Get-Content $project.FullName -Raw
-              # Skip explicit class libraries
-              if ($content -match '<OutputType>\s*Library\s*</OutputType>') { $skipped++; continue }
-              if ($content -match '<TargetFrameworks?>(.*?)</TargetFrameworks?>') {
-                $tfms = $Matches[1] -split ';'
-                foreach ($tfm in $tfms) {
-                  if ($tfm -match '^net\d+\.\d+$') {
-                    Write-Host "Pre-publishing $($project.Name) for $tfm/$runtime"
-                    $output = dotnet publish --configuration Release --runtime $runtime --framework $tfm $project.FullName 2>&1
-                    if ($LASTEXITCODE -ne 0) {
-                      Write-Warning "Failed to pre-publish $($project.Name) for $tfm/$runtime"
-                      $output | Where-Object { $_ -match "error" } | ForEach-Object { Write-Host "  $_" }
-                      $failed++
-                    } else {
-                      $published++
-                    }
-                  }
-                }
-              }
-            }
-          }
-          Write-Host "Pre-publish complete: $published succeeded, $skipped skipped (libraries), $failed failed"
-
-          # Clean up intermediate RID-specific build artifacts to reduce artifact size.
-          $cleaned = 0
-          foreach ($searchPath in $searchPaths) {
-            $fullPath = Join-Path $basePath $searchPath
-            if (-not (Test-Path $fullPath)) { continue }
-            Get-ChildItem -Path $fullPath -Directory -Recurse -Filter $runtime | ForEach-Object {
-              Get-ChildItem -Path $_.FullName -Exclude "publish" | Remove-Item -Recurse -Force
-              $cleaned++
-            }
-          }
-          Write-Host "Cleaned intermediate build artifacts from $cleaned RID directories"
-        shell: powershell
-
-      - name: Archive Artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unboundedintegrationtests
-          path: |
-            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-          if-no-files-found: error
+    uses: ./.github/workflows/test_selection.yml
+    permissions: {}
+    with:
+      mode: all
 
   run-integration-tests:
-    needs: [build-integration-tests, get-test-namespaces]
     name: Run IntegrationTests
-    runs-on: windows-2025-vs2026
+    needs: [build-fullagent-msi, get-test-namespaces]
+    uses: ./.github/workflows/integration_tests.yml
     permissions:
-      contents: read   # required: a job-level block replaces the workflow-level one
-      id-token: write  # required for OIDC role assumption (LLM namespace only)
-    strategy:
-      matrix:
-        namespace: ${{ fromJson(needs.get-test-namespaces.outputs.integration-namespaces) }}
-      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
-
-    env:
-      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      integration_tests_path: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net10.0
-      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-      enhanced_logging: false
-      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
-      NR_DOTNET_TEST_PREBUILT_APPS: 1 # use pre-published test app output instead of dotnet publish at runtime
-      azure_func_exe_path: C:\ProgramData\chocolatey\lib\azure-functions-core-tools\tools\func.exe
-      NEW_RELIC_AZURE_FUNCTION_LOG_LEVEL_OVERRIDE: 1 # enables profiler debug logs when testing an azure function
-      # Set an environment variable that the tests will use to set the application name.
-      CI_NEW_RELIC_APP_NAME: ${{ github.event_name == 'schedule' && 'DotNetIngestTracking' || '' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Disable TLS 1.3
-        run: |
-          $registryPath = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
-          if(!(Test-Path $registryPath)) {
-            New-Item -Path $registryPath -Force
-          }
-          New-ItemProperty -Path $registryPath -Name "DisabledByDefault" -Value "1" -PropertyType DWORD -Force
-          New-ItemProperty -Path $registryPath -Name "Enabled" -Value "0" -PropertyType DWORD -Force
-        shell: powershell
-
-      - name: Create and trust .NET development SSL certificate
-        run: |
-          dotnet dev-certs https --clean
-          dotnet dev-certs https --export-path ./devcert.pfx --password "password1"
-          $pwd = ConvertTo-SecureString -String "password1" -Force -AsPlainText
-          Import-PfxCertificate -FilePath ./devcert.pfx -CertStoreLocation Cert:\LocalMachine\Root -Password $pwd
-          dotnet dev-certs https --check --trust
-        shell: powershell
-
-      - name: Set up secrets
-        env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-        run: |
-          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
-
-      # Bedrock tests authenticate via short-lived OIDC credentials rather than a
-      # long-lived access key (NR-601301).  Gated to the LLM namespace so that no
-      # other matrix job ever holds AWS credentials in its environment.
-      - name: Configure AWS credentials for Bedrock
-        if: matrix.namespace == 'LLM'
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.AWS_BEDROCK_TEST_ROLE_ARN }}
-          role-duration-seconds: 900
-          # Must match DefaultSetting.AwsRegion in TEST_SECRETS.  A mismatch fails
-          # confusingly: STS succeeds in one region while the SDK calls Bedrock in
-          # another.
-          aws-region: us-west-2
-
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: homefolders
-          path: src/Agent
-
-      - name: Download Integration Test Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: integrationtests
-          # Should not need a path because the integration test artifacts are archived with the full directory structure
-
-      - name: Install HostableWebCore Feature
-        if: | # only install for the required namespaces
-          matrix.namespace == 'AgentFeatures' || matrix.namespace == 'AgentLogs' || matrix.namespace == 'AgentMetrics' || matrix.namespace == 'BasicInstrumentation' || 
-          matrix.namespace == 'CatInbound' || matrix.namespace == 'CatOutbound' || matrix.namespace == 'CodeLevelMetrics' ||
-          matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
-          matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HSM' || matrix.namespace == 'HttpClientInstrumentation' || matrix.namespace == 'HybridHttpContextStorage' ||
-          matrix.namespace == 'LLM' || matrix.namespace == 'MultiAppDomain' || matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
-          matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables' ||
-          matrix.namespace == 'RequestHeadersCapture.WCF' || matrix.namespace == 'WCF.Client.IIS.ASPDisabled' ||
-          matrix.namespace == 'WCF.Client.IIS.ASPEnabled' || matrix.namespace == 'WCF.Service.IIS.ASPDisabled' ||
-          matrix.namespace == 'WCF.Service.IIS.ASPEnabled'
-        run: |
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-        shell: powershell
-
-      - name: Install Azure Functions Core Tools
-        if: matrix.namespace == 'AzureFunction'
-        run: |
-          choco install azure-functions-core-tools -y --params "'/x64'"
-        shell: powershell
-
-      - name: Install latest .NET 10 SDK
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
-
-      - name: Run Integration Tests
-        run: |
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "List ports in use"
-            netstat -no
-          }
-
-          Write-Host "Run tests"
-
-          # Most integration tests can run in parallel with pre-built test apps.
-          # Some namespaces must remain serial because they use shared external tools
-          # that don't support concurrent instances (e.g., Azure Functions Core Tools
-          # func.exe crashes when multiple instances launch simultaneously due to shared
-          # state in storage emulator/lock files). To parallelize these, the shared tool
-          # contention would need to be resolved.
-          $noParallelNamespaces = @("AzureFunction")
-          $parallelize = "${{ inputs.parallelize_integration_tests }}"
-          if ($parallelize -eq "" -or $parallelize -eq "true") { $parallelize = $true } else { $parallelize = $false }
-          if ($noParallelNamespaces -contains "${{ matrix.namespace }}") { $parallelize = $false }
-          $json = Get-Content "${{ env.integration_tests_path }}/xunit.runner.json" | ConvertFrom-Json
-          $json | Add-Member -Name "parallelizeAssembly" -Value $parallelize -MemberType NoteProperty
-          $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
-          $json | ConvertTo-Json | Out-File "${{ env.integration_tests_path }}/xunit.runner.json"
-
-          # Retry once on failure to absorb transient infrastructure blips (e.g. port
-          # contention, SSL cert / tooling startup races, or a flaky test-app launch) that
-          # can surface as a spurious failure while the code under test is healthy. A
-          # retried-but-passing job still emits a ::warning:: so genuine regressions /
-          # flake churn stay visible in the UI.
-          $maxAttempts = 2
-          $attempt = 1
-          while ($true) {
-            & "${{ env.integration_tests_path }}/NewRelic.Agent.IntegrationTests.exe" -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
-            $exitCode = $LASTEXITCODE
-            if ($exitCode -eq 0) {
-              if ($attempt -gt 1) {
-                Write-Host "::warning::Integration tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
-                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
-                # failure-artifact upload globs never collect. Reporting runs in the separate
-                # step below so that no secret is in scope for this step: HostedWebCore and
-                # other test hosts launched here write their environment to the console, and
-                # that console output is captured into the test results.
-                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
-                @{ testType = "integrationTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
-              }
-              break
-            }
-            if ($attempt -ge $maxAttempts) {
-              Write-Host "Integration tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
-              exit $exitCode
-            }
-            Write-Host "Integration tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
-            $attempt++
-            Start-Sleep -Seconds 10
-          }
-
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "Get HostableWebCore errors (if any)"
-            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
-
-            Write-Host "Get .NET Runtime errors (if any)"
-            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
-          }
-        shell: powershell
-
-      - name: Report flaky retry telemetry
-        if: always()
-        continue-on-error: true
-        env:
-          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
-          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
-          CI_BRANCH: ${{ github.ref_name }}
-          CI_COMMIT: ${{ github.sha }}
-          CI_RUN_ID: ${{ github.run_id }}
-          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CI_TRIGGER: ${{ github.event_name }}
-        run: |
-          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
-          if (Test-Path $marker) {
-            $info = Get-Content $marker | ConvertFrom-Json
-            $Env:RETRY_TEST_TYPE = $info.testType
-            $Env:RETRY_TEST_GROUP = $info.testGroup
-            & bash build/Scripts/report-flaky-retry.sh
-            Remove-Item $marker -Force -ErrorAction Ignore
-          }
-        shell: powershell
-
-      - name: Extract payload bytes log from TRX
-        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
-        run: |
-          $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
-          $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
-          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
-
-          Write-Host "Checking for TRX file at: $trxFile"
-
-          $executedTests = 0
-
-          if (Test-Path $trxFile) {
-            $fileSize = (Get-Item $trxFile).Length
-            Write-Host "TRX file found. Size: $fileSize bytes"
-
-            # Read TRX file and extract lines containing payload information from Message elements
-            [xml]$trxContent = Get-Content $trxFile
-            $messageElements = $trxContent.SelectNodes("//*[local-name()='Output']/*[local-name()='TextMessages']/*[local-name()='Message']")
-
-            $payloadData = @{}
-            foreach ($message in $messageElements) {
-              foreach ($line in ($message.InnerText -split "\r?\n")) {
-                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
-                  $className = $Matches[1].Trim()
-                  $category  = $Matches[2]
-                  $byteCount = [int]$Matches[3]
-                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
-                  if ($payloadData[$className].ContainsKey($category)) {
-                    $payloadData[$className][$category] += $byteCount
-                  } else {
-                    $payloadData[$className][$category] = $byteCount
-                  }
-                }
-              }
-            }
-
-            Write-Host "Found $($payloadData.Count) payload log entries"
-
-            if ($payloadData.Count -gt 0) {
-              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
-              Write-Host "Extracted payload logs to $payloadLog"
-              Write-Host "Content:"
-              Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
-            } else {
-              Write-Host "No payload byte logs found in TRX file"
-              @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
-            }
-
-            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
-            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
-            # (any outcome), excluding skipped / not-executed.
-            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
-            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
-          } else {
-            Write-Host "TRX file not found"
-            @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
-          }
-
-          Write-Host "Executed test count: $executedTests"
-          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
-        shell: powershell
-
-      - name: Upload payload bytes log
-        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-payload-bytes-${{ matrix.namespace }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
-            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
-          if-no-files-found: warn
-
-      - name: Archive integration test results on failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-test-results-${{ matrix.namespace }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-          if-no-files-found: error
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      namespaces: ${{ needs.get-test-namespaces.outputs.integration-namespaces }}
+      aggregate_payload_data: ${{ inputs.aggregate_payload_data == true || github.event_name == 'schedule' }}
+      parallelize: ${{ inputs.parallelize_integration_tests == true || github.event_name != 'workflow_dispatch' }}
 
   run-unbounded-tests:
-    needs: [build-unbounded-tests, get-test-namespaces]
     name: Run Unbounded Tests
-    runs-on: windows-2025-vs2026
-    strategy:
-      matrix:
-        namespace: ${{ fromJson(needs.get-test-namespaces.outputs.unbounded-namespaces) }}
-      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
-
-    env:
-      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      unbounded_tests_path: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net10.0
-      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
-      NR_DOTNET_TEST_PREBUILT_APPS: 1 # use pre-published test app output instead of dotnet publish at runtime
-      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-      enhanced_logging: false
-      # Set an environment variable that the tests will use to set the application name.
-      CI_NEW_RELIC_APP_NAME: ${{ github.event_name == 'schedule' && 'DotNetIngestTracking' || '' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: homefolders
-          path: src/Agent
-
-      - name: Download Unbounded Integration Test Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: unboundedintegrationtests
-          # Should not need a path because the integration test artifacts are archived with the full directory structure
-
-      - name: Disable TLS 1.3
-        run: |
-          $registryPath = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
-          if(!(Test-Path $registryPath)) {
-            New-Item -Path $registryPath -Force
-          }
-          New-ItemProperty -Path $registryPath -Name "DisabledByDefault" -Value "1" -PropertyType DWORD -Force
-          New-ItemProperty -Path $registryPath -Name "Enabled" -Value "0" -PropertyType DWORD -Force
-        shell: powershell
-
-      - name: Install HostableWebCore Feature
-        if: | # only install for the required namespaces
-          matrix.namespace == 'MongoDB' || matrix.namespace == 'Oracle'
-        run: |
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-        shell: powershell
-
-      - name: Install MSMQ dependencies
-        if: matrix.namespace == 'Msmq'
-        run: |
-          Write-Host "Installing Msmq Features"
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
-        shell: powershell
-
-      - name: Install MsSql dependencies
-        if: matrix.namespace == 'MsSql'
-        run: |
-          Write-Host "Installing MSSQL CLI"
-          $msi = "${{ github.workspace }}\build\Tools\sqlncli.msi"
-
-          # Wait on the installer itself instead of sleeping a fixed interval.
-          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
-            '/i', "`"$msi`"", 'IACCEPTSQLNCLILICENSETERMS=YES', '/quiet', '/qn', '/norestart'
-          )
-          if ($proc.ExitCode -ne 0) {
-            throw "msiexec failed with exit code $($proc.ExitCode)."
-          }
-
-          # Assert the provider registered. Without this the job goes green and the failure
-          # resurfaces far away from its cause, inside an OleDb test connection.
-          $providers = (New-Object System.Data.OleDb.OleDbEnumerator).GetElements() | ForEach-Object { $_.SOURCES_NAME }
-          Write-Host "Registered OLE DB providers:"
-          $providers | ForEach-Object { Write-Host "  $_" }
-          if ($providers -notcontains 'SQLNCLI11') {
-            throw "SQLNCLI11 did not register. The OleDb tests connect with PROVIDER=SQLNCLI11."
-          }
-        shell: powershell
-
-      # SQL Server Native Client 11.0 (installed above) is still needed by the OleDb tests,
-      # which connect with PROVIDER=SQLNCLI11, so this adds a driver rather than replacing one.
-      #
-      # The ODBC tests connect with DRIVER={ODBC Driver 18 for SQL Server}. The runner image
-      # ships the Visual Studio component Microsoft.VisualStudio.Component.MSODBC.SQL, but the
-      # image readme records only that component's Visual Studio version, never the ODBC driver
-      # version it delivers, and the readme's standalone driver list carries OLE DB drivers
-      # rather than ODBC ones. So probe for the driver by the exact name the connection string
-      # asks for and install only when it is missing: no-op on an image that already has it,
-      # self-repairing on one that does not. The listing also records what the image really
-      # provides, which is otherwise undocumented.
-      - name: Ensure Microsoft ODBC Driver 18 for SQL Server
-        if: matrix.namespace == 'MsSql'
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # Invoke-WebRequest is very slow on Windows PowerShell while it renders progress.
-          $ProgressPreference = 'SilentlyContinue'
-          $driverName = 'ODBC Driver 18 for SQL Server'
-
-          Write-Host "Registered 64-bit ODBC drivers on this image:"
-          Get-OdbcDriver -Platform '64-bit' | ForEach-Object { Write-Host "  $($_.Name)" }
-
-          if (Get-OdbcDriver -Name $driverName -Platform '64-bit' -ErrorAction SilentlyContinue) {
-            Write-Host "$driverName is already present. Nothing to install."
-            exit 0
-          }
-
-          # x64 only: the ODBC test fixtures (FWLatest, CoreLatest) both run 64-bit. This link
-          # resolves to the latest GA 18.x, so the installed patch version can move without
-          # notice. Pin the download.microsoft.com URL it redirects to if that ever matters.
-          $url = 'https://go.microsoft.com/fwlink/?linkid=2358430'
-          $msi = Join-Path $env:RUNNER_TEMP 'msodbcsql18.msi'
-
-          Write-Host "$driverName not found. Downloading from $url"
-          Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
-
-          # A wrong or redirected-to-HTML URL yields a small text file that msiexec silently
-          # refuses, so fail here instead of hours later with a confusing IM002 in a test log.
-          $size = (Get-Item $msi).Length
-          Write-Host "Downloaded $size bytes"
-          if ($size -lt 1MB) {
-            throw "Expected an MSI of several MB but got $size bytes. The download URL is probably wrong."
-          }
-
-          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
-            '/i', "`"$msi`"", '/quiet', '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
-          )
-          if ($proc.ExitCode -ne 0) {
-            throw "msiexec failed with exit code $($proc.ExitCode)."
-          }
-
-          # Assert it registered. Without this the job goes green and the failure resurfaces as
-          # ERROR [IM002] Data source name not found, far away from its cause.
-          if (-not (Get-OdbcDriver -Name $driverName -Platform '64-bit' -ErrorAction SilentlyContinue)) {
-            Write-Host "Registered 64-bit ODBC drivers after install:"
-            Get-OdbcDriver -Platform '64-bit' | ForEach-Object { Write-Host "  $($_.Name)" }
-            throw "$driverName did not register. Try adding ADDLOCAL=ALL to the msiexec arguments."
-          }
-          Write-Host "$driverName installed."
-        shell: powershell
-
-      - name: Set up secrets
-        env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-        run: |
-          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
-        
-# save in case we move back to using the emulator
-#      - name: Start Local CosmosDB Emulator for CosmosDB Tests
-#        if: matrix.namespace == 'CosmosDB'
-#        run: |
-#          Write-Host "Launching Cosmos DB Emulator"
-#          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-#          Start-CosmosDbEmulator
-#        shell: pwsh
-
-      - name: Install latest .NET 10 SDK
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
-  
-      - name: Run Unbounded Integration Tests
-        run: |
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "List ports in use"
-            netstat -no
-          }
-
-          # Most unbounded tests can run in parallel with pre-built test apps.
-          # Some namespaces must remain serial because they use shared external infrastructure
-          # with hard-coded object names (e.g., NServiceBus5 tests share MSMQ queues). To
-          # parallelize these, each test fixture would need isolated resources
-          # (per-test databases/tables/queues).
-          $noParallelNamespaces = @("NServiceBus", "NServiceBus5")
-          $parallelize = $noParallelNamespaces -notcontains "${{ matrix.namespace }}"
-          $json = Get-Content "${{ env.unbounded_tests_path }}/xunit.runner.json" | ConvertFrom-Json
-          $json | Add-Member -Name "parallelizeAssembly" -Value $parallelize -MemberType NoteProperty
-          $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
-          $json | ConvertTo-Json | Out-File "${{ env.unbounded_tests_path }}/xunit.runner.json"
-
-          # Retry once on failure to absorb transient WAN/infra blips between the GitHub-hosted
-          # runner and the Azure-hosted unbounded services (e.g. brief packet loss surfacing as a
-          # client command timeout while the service itself is healthy). A retried-but-passing job
-          # still emits a ::warning:: so genuine regressions / flake churn stay visible in the UI.
-          $maxAttempts = 2
-          $attempt = 1
-          while ($true) {
-            & "${{ env.unbounded_tests_path }}/NewRelic.Agent.UnboundedIntegrationTests.exe" -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
-            $exitCode = $LASTEXITCODE
-            if ($exitCode -eq 0) {
-              if ($attempt -gt 1) {
-                Write-Host "::warning::Unbounded tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
-                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
-                # failure-artifact upload globs never collect. Reporting runs in the separate
-                # step below so that no secret is in scope for this step: HostedWebCore and
-                # other test hosts launched here write their environment to the console, and
-                # that console output is captured into the test results.
-                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
-                @{ testType = "unboundedTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
-              }
-              break
-            }
-            if ($attempt -ge $maxAttempts) {
-              Write-Host "Unbounded tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
-              exit $exitCode
-            }
-            Write-Host "Unbounded tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
-            $attempt++
-            Start-Sleep -Seconds 10
-          }
-
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "Get HostableWebCore errors (if any)"
-            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
-
-            Write-Host "Get .NET Runtime errors (if any)"
-            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
-          }
-        shell: powershell
-
-      - name: Report flaky retry telemetry
-        if: always()
-        continue-on-error: true
-        env:
-          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
-          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
-          CI_BRANCH: ${{ github.ref_name }}
-          CI_COMMIT: ${{ github.sha }}
-          CI_RUN_ID: ${{ github.run_id }}
-          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CI_TRIGGER: ${{ github.event_name }}
-        run: |
-          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
-          if (Test-Path $marker) {
-            $info = Get-Content $marker | ConvertFrom-Json
-            $Env:RETRY_TEST_TYPE = $info.testType
-            $Env:RETRY_TEST_GROUP = $info.testGroup
-            & bash build/Scripts/report-flaky-retry.sh
-            Remove-Item $marker -Force -ErrorAction Ignore
-          }
-        shell: powershell
-
-      - name: Extract payload bytes log from TRX
-        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
-        run: |
-          $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
-          $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
-          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
-
-          Write-Host "Checking for TRX file at: $trxFile"
-
-          $executedTests = 0
-
-          if (Test-Path $trxFile) {
-            $fileSize = (Get-Item $trxFile).Length
-            Write-Host "TRX file found. Size: $fileSize bytes"
-
-            # Read TRX file and extract lines containing payload information from Message elements
-            [xml]$trxContent = Get-Content $trxFile
-            $messageElements = $trxContent.SelectNodes("//*[local-name()='Output']/*[local-name()='TextMessages']/*[local-name()='Message']")
-
-            $payloadData = @{}
-            foreach ($message in $messageElements) {
-              foreach ($line in ($message.InnerText -split "\r?\n")) {
-                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
-                  $className = $Matches[1].Trim()
-                  $category  = $Matches[2]
-                  $byteCount = [int]$Matches[3]
-                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
-                  if ($payloadData[$className].ContainsKey($category)) {
-                    $payloadData[$className][$category] += $byteCount
-                  } else {
-                    $payloadData[$className][$category] = $byteCount
-                  }
-                }
-              }
-            }
-
-            Write-Host "Found $($payloadData.Count) payload log entries"
-
-            if ($payloadData.Count -gt 0) {
-              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
-              Write-Host "Extracted payload logs to $payloadLog"
-              Write-Host "Content:"
-              Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
-            } else {
-              Write-Host "No payload byte logs found in TRX file"
-              @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
-            }
-
-            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
-            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
-            # (any outcome), excluding skipped / not-executed.
-            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
-            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
-          } else {
-            Write-Host "TRX file not found"
-            @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
-          }
-
-          Write-Host "Executed test count: $executedTests"
-          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
-        shell: powershell
-
-      - name: Upload payload bytes log
-        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unbounded-payload-bytes-${{ matrix.namespace }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
-            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
-          if-no-files-found: warn
-
-      - name: Archive unbounded test results on failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unbounded-test-working-directory-${{ matrix.namespace }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-          if-no-files-found: error
+    needs: [build-fullagent-msi, get-test-namespaces]
+    uses: ./.github/workflows/unbounded_tests.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      namespaces: ${{ needs.get-test-namespaces.outputs.unbounded-namespaces }}
+      aggregate_payload_data: ${{ inputs.aggregate_payload_data == true || github.event_name == 'schedule' }}
 
   create-package-rpm:
     needs: build-fullagent-msi
     name: Create RPM Package
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     # Skipped for the Dependabot dispatch: signs with NEW_GPG_KEY, and needs an MSI artifact
     # that run does not produce. Compared against 'false' so an unresolved output skips this
     # job rather than running it with the signing key.
@@ -1249,6 +279,8 @@ jobs:
     needs: build-fullagent-msi
     name: Create Debian package
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     # Skipped for the Dependabot dispatch: signs with NEW_GPG_KEY, and needs an MSI artifact
     # that run does not produce. Compared against 'false' so an unresolved output skips this
     # job rather than running it with the signing key.
@@ -1304,6 +336,8 @@ jobs:
     needs: [create-package-rpm, create-package-deb]
     name: Run ArtifactBuilder
     runs-on: windows-2022
+    permissions:
+      contents: read
     # No explicit gate needed: both packaging jobs it needs are skipped for the Dependabot
     # dispatch, which skips this job with them.
 
@@ -1362,6 +396,7 @@ jobs:
   integration-test-status:
     name: Check Test Matrix Status
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [run-linux-container-tests, run-integration-tests, run-unbounded-tests]
     if: always()
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,321 @@
+name: Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      namespaces:
+        description: 'JSON array of integration test namespaces to run, e.g. ["Api","Errors"]'
+        type: string
+        required: true
+      aggregate_payload_data:
+        description: 'Collect and upload payload data artifacts for later aggregation'
+        type: boolean
+        required: false
+        default: false
+      parallelize:
+        description: 'Enable parallel test execution within each namespace'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build IntegrationTests
+    runs-on: windows-2025-vs2026
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Build test solution
+        uses: ./.github/actions/build-test-solution
+        with:
+          solution-path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
+          search-paths: Applications SharedApplications
+          skip-projects: AzureFunctionApplication AzureFunctionInProcApplication
+          artifact-name: integrationtests
+
+  run-integration-tests:
+    needs: build
+    name: Run IntegrationTests
+    runs-on: windows-2025-vs2026
+    permissions:
+      contents: read   # required: a job-level block replaces the workflow-level one
+      id-token: write  # required for OIDC role assumption (LLM namespace only)
+    strategy:
+      matrix:
+        namespace: ${{ fromJson(inputs.namespaces) }}
+      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+
+    env:
+      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      integration_tests_path: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net10.0
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: false
+      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
+      NR_DOTNET_TEST_PREBUILT_APPS: 1 # use pre-published test app output instead of dotnet publish at runtime
+      azure_func_exe_path: C:\ProgramData\chocolatey\lib\azure-functions-core-tools\tools\func.exe
+      NEW_RELIC_AZURE_FUNCTION_LOG_LEVEL_OVERRIDE: 1 # enables profiler debug logs when testing an azure function
+      # Set an environment variable that the tests will use to set the application name.
+      CI_NEW_RELIC_APP_NAME: ${{ github.event_name == 'schedule' && 'DotNetIngestTracking' || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Disable TLS 1.3
+        run: |
+          $registryPath = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
+          if(!(Test-Path $registryPath)) {
+            New-Item -Path $registryPath -Force
+          }
+          New-ItemProperty -Path $registryPath -Name "DisabledByDefault" -Value "1" -PropertyType DWORD -Force
+          New-ItemProperty -Path $registryPath -Name "Enabled" -Value "0" -PropertyType DWORD -Force
+        shell: powershell
+
+      - name: Create and trust .NET development SSL certificate
+        run: |
+          dotnet dev-certs https --clean
+          dotnet dev-certs https --export-path ./devcert.pfx --password "password1"
+          $pwd = ConvertTo-SecureString -String "password1" -Force -AsPlainText
+          Import-PfxCertificate -FilePath ./devcert.pfx -CertStoreLocation Cert:\LocalMachine\Root -Password $pwd
+          dotnet dev-certs https --check --trust
+        shell: powershell
+
+      - name: Set up secrets
+        env:
+          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+        run: |
+          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+
+      # Bedrock tests authenticate via short-lived OIDC credentials rather than a
+      # long-lived access key (NR-601301).  Gated to the LLM namespace so that no
+      # other matrix job ever holds AWS credentials in its environment.
+      - name: Configure AWS credentials for Bedrock
+        if: matrix.namespace == 'LLM'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_TEST_ROLE_ARN }}
+          role-duration-seconds: 900
+          # Must match DefaultSetting.AwsRegion in TEST_SECRETS.  A mismatch fails
+          # confusingly: STS succeeds in one region while the SDK calls Bedrock in
+          # another.
+          aws-region: us-west-2
+
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: homefolders
+          path: src/Agent
+
+      - name: Download Integration Test Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: integrationtests
+          # Should not need a path because the integration test artifacts are archived with the full directory structure
+
+      - name: Install HostableWebCore Feature
+        if: | # only install for the required namespaces
+          matrix.namespace == 'AgentFeatures' || matrix.namespace == 'AgentLogs' || matrix.namespace == 'AgentMetrics' || matrix.namespace == 'BasicInstrumentation' || 
+          matrix.namespace == 'CatInbound' || matrix.namespace == 'CatOutbound' || matrix.namespace == 'CodeLevelMetrics' ||
+          matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
+          matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HSM' || matrix.namespace == 'HttpClientInstrumentation' || matrix.namespace == 'HybridHttpContextStorage' ||
+          matrix.namespace == 'LLM' || matrix.namespace == 'MultiAppDomain' || matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
+          matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables' ||
+          matrix.namespace == 'RequestHeadersCapture.WCF' || matrix.namespace == 'WCF.Client.IIS.ASPDisabled' ||
+          matrix.namespace == 'WCF.Client.IIS.ASPEnabled' || matrix.namespace == 'WCF.Service.IIS.ASPDisabled' ||
+          matrix.namespace == 'WCF.Service.IIS.ASPEnabled'
+        run: |
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+        shell: powershell
+
+      - name: Install Azure Functions Core Tools
+        if: matrix.namespace == 'AzureFunction'
+        run: |
+          choco install azure-functions-core-tools -y --params "'/x64'"
+        shell: powershell
+
+      - name: Install latest .NET 10 SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'ga'
+
+      - name: Run Integration Tests
+        run: |
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "List ports in use"
+            netstat -no
+          }
+
+          Write-Host "Run tests"
+
+          # Most integration tests can run in parallel with pre-built test apps.
+          # Some namespaces must remain serial because they use shared external tools
+          # that don't support concurrent instances (e.g., Azure Functions Core Tools
+          # func.exe crashes when multiple instances launch simultaneously due to shared
+          # state in storage emulator/lock files). To parallelize these, the shared tool
+          # contention would need to be resolved.
+          $noParallelNamespaces = @("AzureFunction")
+          $parallelize = [System.Convert]::ToBoolean("${{ inputs.parallelize }}")
+          if ($noParallelNamespaces -contains "${{ matrix.namespace }}") { $parallelize = $false }
+          $json = Get-Content "${{ env.integration_tests_path }}/xunit.runner.json" | ConvertFrom-Json
+          $json | Add-Member -Name "parallelizeAssembly" -Value $parallelize -MemberType NoteProperty
+          $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
+          $json | ConvertTo-Json | Out-File "${{ env.integration_tests_path }}/xunit.runner.json"
+
+          # Retry once on failure to absorb transient infrastructure blips (e.g. port
+          # contention, SSL cert / tooling startup races, or a flaky test-app launch) that
+          # can surface as a spurious failure while the code under test is healthy. A
+          # retried-but-passing job still emits a ::warning:: so genuine regressions /
+          # flake churn stay visible in the UI.
+          $maxAttempts = 2
+          $attempt = 1
+          while ($true) {
+            & "${{ env.integration_tests_path }}/NewRelic.Agent.IntegrationTests.exe" -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -eq 0) {
+              if ($attempt -gt 1) {
+                Write-Host "::warning::Integration tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
+                # failure-artifact upload globs never collect. Reporting runs in the separate
+                # step below so that no secret is in scope for this step: HostedWebCore and
+                # other test hosts launched here write their environment to the console, and
+                # that console output is captured into the test results.
+                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+                @{ testType = "integrationTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
+              }
+              break
+            }
+            if ($attempt -ge $maxAttempts) {
+              Write-Host "Integration tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
+              exit $exitCode
+            }
+            Write-Host "Integration tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
+            $attempt++
+            Start-Sleep -Seconds 10
+          }
+
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "Get HostableWebCore errors (if any)"
+            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+
+            Write-Host "Get .NET Runtime errors (if any)"
+            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
+          }
+        shell: powershell
+
+      - name: Report flaky retry telemetry
+        if: always()
+        continue-on-error: true
+        env:
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
+          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
+        run: |
+          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+          if (Test-Path $marker) {
+            $info = Get-Content $marker | ConvertFrom-Json
+            $Env:RETRY_TEST_TYPE = $info.testType
+            $Env:RETRY_TEST_GROUP = $info.testGroup
+            & bash build/Scripts/report-flaky-retry.sh
+            Remove-Item $marker -Force -ErrorAction Ignore
+          }
+        shell: powershell
+
+      - name: Extract payload bytes log from TRX
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        run: |
+          $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+          $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
+          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
+
+          Write-Host "Checking for TRX file at: $trxFile"
+
+          $executedTests = 0
+
+          if (Test-Path $trxFile) {
+            $fileSize = (Get-Item $trxFile).Length
+            Write-Host "TRX file found. Size: $fileSize bytes"
+
+            # Read TRX file and extract lines containing payload information from Message elements
+            [xml]$trxContent = Get-Content $trxFile
+            $messageElements = $trxContent.SelectNodes("//*[local-name()='Output']/*[local-name()='TextMessages']/*[local-name()='Message']")
+
+            $payloadData = @{}
+            foreach ($message in $messageElements) {
+              foreach ($line in ($message.InnerText -split "\r?\n")) {
+                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
+                  $className = $Matches[1].Trim()
+                  $category  = $Matches[2]
+                  $byteCount = [int]$Matches[3]
+                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
+                  if ($payloadData[$className].ContainsKey($category)) {
+                    $payloadData[$className][$category] += $byteCount
+                  } else {
+                    $payloadData[$className][$category] = $byteCount
+                  }
+                }
+              }
+            }
+
+            Write-Host "Found $($payloadData.Count) payload log entries"
+
+            if ($payloadData.Count -gt 0) {
+              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
+              Write-Host "Extracted payload logs to $payloadLog"
+              Write-Host "Content:"
+              Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
+            } else {
+              Write-Host "No payload byte logs found in TRX file"
+              @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+            }
+
+            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
+            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
+            # (any outcome), excluding skipped / not-executed.
+            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
+            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
+          } else {
+            Write-Host "TRX file not found"
+            @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+          }
+
+          Write-Host "Executed test count: $executedTests"
+          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
+        shell: powershell
+
+      - name: Upload payload bytes log
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-payload-bytes-${{ matrix.namespace }}
+          path: |
+            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
+          if-no-files-found: warn
+
+      - name: Archive integration test results on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-test-results-${{ matrix.namespace }}
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+          if-no-files-found: error
+

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # Single source of truth for runner and filter. test_selection.yml holds
           # only the name/arch pairs, for early validation; .github/scripts/check-workflows.py
-          # check V1g asserts the two lists match.
+          # asserts the two lists match.
           all='[
             {"arch":"amd64","name":"Ubuntu","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Ubuntu"},
             {"arch":"amd64","name":"Alpine","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Alpine"},
@@ -99,7 +99,7 @@ jobs:
           jq -r '.[] | "  " + .name + "/" + .arch + "  " + .filter' <<< "$matrix"
 
           if [ "$count" -eq 0 ]; then
-            echo "::error::No container group matched. Validation happens in test_selection.yml, so reaching this means the two lists have drifted; check V1g should have caught it."
+            echo "::error::No container group matched. Validation happens in test_selection.yml, so reaching this means the two lists have drifted; check-workflows.py should have caught it."
             exit 1
           fi
 

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: false
         required: false
+      groups:
+        description: 'Comma-separated container groups to run as name/arch, e.g. "Ubuntu/amd64,Core/amd64". Empty runs all of them.'
+        type: string
+        default: ''
+        required: false
   workflow_dispatch:
     inputs:
       run_id:
@@ -20,6 +25,11 @@ on:
         description: 'Build and aggregate payload data'
         type: boolean
         default: false
+        required: false
+      groups:
+        description: 'Comma-separated container groups to run as name/arch, e.g. "Ubuntu/amd64,Core/amd64". Empty runs all of them.'
+        type: string
+        default: ''
         required: false
 
 env:
@@ -37,65 +47,76 @@ permissions:
 
 jobs:
 
+  select-matrix:
+    name: Select Container Matrix
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Select requested groups
+        id: select
+        env:
+          REQUESTED_GROUPS: ${{ inputs.groups }}
+        run: |
+          # Single source of truth for runner and filter. test_selection.yml holds
+          # only the name/arch pairs, for early validation; .github/scripts/check-workflows.py
+          # check V1g asserts the two lists match.
+          all='[
+            {"arch":"amd64","name":"Ubuntu","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Ubuntu"},
+            {"arch":"amd64","name":"Alpine","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Alpine"},
+            {"arch":"amd64","name":"Centos","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Centos"},
+            {"arch":"amd64","name":"Amazon","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Amazon"},
+            {"arch":"amd64","name":"Fedora","runner":"ubuntu-latest","filter":"Architecture=amd64&Distro=Fedora"},
+            {"arch":"arm64","name":"Ubuntu","runner":"ubuntu-24.04-arm","filter":"Architecture=arm64&Distro=Ubuntu"},
+            {"arch":"arm64","name":"Amazon","runner":"ubuntu-24.04-arm","filter":"Architecture=arm64&Distro=Amazon"},
+            {"arch":"arm64","name":"Fedora","runner":"ubuntu-24.04-arm","filter":"Architecture=arm64&Distro=Fedora"},
+            {"arch":"amd64","name":"Core","runner":"ubuntu-latest","filter":"Architecture=amd64&TestArea=Core"},
+            {"arch":"amd64","name":"Messaging","runner":"ubuntu-latest","filter":"Architecture=amd64&TestArea=Messaging"},
+            {"arch":"amd64","name":"Aws","runner":"ubuntu-latest","filter":"Architecture=amd64&TestArea=Aws"},
+            {"arch":"amd64","name":"Datastore","runner":"ubuntu-latest","filter":"Architecture=amd64&TestArea=Datastore"}
+          ]'
+
+          requested=$(jq -Rc 'split(",") | map(gsub("^[ \t]+|[ \t]+$"; "")) | map(select(length > 0))' <<< "$REQUESTED_GROUPS")
+
+          if [ "$requested" = "[]" ]; then
+            matrix=$(jq -c '.' <<< "$all")
+            echo "Running all container groups."
+          else
+            matrix=$(jq -c --argjson req "$requested" \
+              'map(select((.name + "/" + .arch) as $k | $req | index($k)))' <<< "$all")
+            echo "Requested: $requested"
+          fi
+
+          count=$(jq 'length' <<< "$matrix")
+          echo "Selected $count container group(s):"
+          jq -r '.[] | "  " + .name + "/" + .arch + "  " + .filter' <<< "$matrix"
+
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No container group matched. Validation happens in test_selection.yml, so reaching this means the two lists have drifted; check V1g should have caught it."
+            exit 1
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+        shell: bash
+
   linux-container-tests:
     name: Container Test (${{ matrix.name }}/${{ matrix.arch }})
+    needs: select-matrix
     # Runner chosen per matrix entry
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # amd64 OS compatibility distros
-          - arch: amd64
-            name: Ubuntu
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&Distro=Ubuntu"
-          - arch: amd64
-            name: Alpine
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&Distro=Alpine"
-          - arch: amd64
-            name: Centos
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&Distro=Centos"
-          - arch: amd64
-            name: Amazon
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&Distro=Amazon"
-          - arch: amd64
-            name: Fedora
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&Distro=Fedora"
-          # arm64 OS compatibility distros (subset of tests implemented)
-          - arch: arm64
-            name: Ubuntu
-            runner: ubuntu-24.04-arm
-            filter: "Architecture=arm64&Distro=Ubuntu"
-          - arch: arm64
-            name: Amazon
-            runner: ubuntu-24.04-arm
-            filter: "Architecture=arm64&Distro=Amazon"
-          - arch: arm64
-            name: Fedora
-            runner: ubuntu-24.04-arm
-            filter: "Architecture=arm64&Distro=Fedora"
-          # amd64 feature-area groupings (moved off Distro=Ubuntu to spread load)
-          - arch: amd64
-            name: Core
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&TestArea=Core"
-          - arch: amd64
-            name: Messaging
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&TestArea=Messaging"
-          - arch: amd64
-            name: Aws
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&TestArea=Aws"
-          - arch: amd64
-            name: Datastore
-            runner: ubuntu-latest
-            filter: "Architecture=amd64&TestArea=Datastore"
+        include: ${{ fromJson(needs.select-matrix.outputs.matrix) }}
 
     env:
       test_results_path: tests/TestResults

--- a/.github/workflows/targeted_tests.yml
+++ b/.github/workflows/targeted_tests.yml
@@ -1,0 +1,91 @@
+name: Targeted Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      integration_namespaces:
+        description: 'Integration test namespaces, comma-separated (e.g. "Errors, Api"). Leave empty to run none.'
+        type: string
+        required: false
+        default: ''
+      unbounded_namespaces:
+        description: 'Unbounded test namespaces, comma-separated (e.g. "MsSql, Redis"). Leave empty to run none.'
+        type: string
+        required: false
+        default: ''
+      container_groups:
+        description: 'Container groups as name/arch, comma-separated (e.g. "Ubuntu/amd64, Core/amd64"). Leave empty to run none.'
+        type: string
+        required: false
+        default: ''
+      parallelize_integration_tests:
+        description: 'Enable parallel integration test execution'
+        type: boolean
+        required: false
+        default: true
+
+permissions: {}
+
+jobs:
+  resolve:
+    name: Resolve Test Selection
+    uses: ./.github/workflows/test_selection.yml
+    permissions: {}
+    with:
+      mode: requested
+      integration_request: ${{ inputs.integration_namespaces }}
+      unbounded_request: ${{ inputs.unbounded_namespaces }}
+      container_request: ${{ inputs.container_groups }}
+
+  build-agent:
+    name: Build Agent
+    needs: resolve
+    runs-on: windows-2022
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Build agent
+        uses: ./.github/actions/build-agent
+
+  integration:
+    name: Run IntegrationTests
+    needs: [resolve, build-agent]
+    if: needs.resolve.outputs.integration-namespaces != '[]'
+    uses: ./.github/workflows/integration_tests.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      namespaces: ${{ needs.resolve.outputs.integration-namespaces }}
+      parallelize: ${{ inputs.parallelize_integration_tests }}
+
+  unbounded:
+    name: Run Unbounded Tests
+    needs: [resolve, build-agent]
+    if: needs.resolve.outputs.unbounded-namespaces != '[]'
+    uses: ./.github/workflows/unbounded_tests.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      namespaces: ${{ needs.resolve.outputs.unbounded-namespaces }}
+
+  container:
+    name: Run Linux Container Tests
+    needs: [resolve, build-agent]
+    if: needs.resolve.outputs.container-groups != ''
+    uses: ./.github/workflows/linux_container_tests.yml
+    permissions:
+      actions: write
+      contents: read
+    secrets: inherit
+    with:
+      external_call: true
+      groups: ${{ needs.resolve.outputs.container-groups }}

--- a/.github/workflows/test_selection.yml
+++ b/.github/workflows/test_selection.yml
@@ -1,0 +1,275 @@
+name: Test Selection
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: 'all = canonical lists minus repo exclusion variables. requested = validate and intersect the three request inputs.'
+        type: string
+        required: false
+        default: 'all'
+      integration_request:
+        description: 'Comma-separated integration test namespace names. Read in requested mode only.'
+        type: string
+        required: false
+        default: ''
+      unbounded_request:
+        description: 'Comma-separated unbounded test namespace names. Read in requested mode only.'
+        type: string
+        required: false
+        default: ''
+      container_request:
+        description: 'Comma-separated container groups as name/arch, e.g. "Ubuntu/amd64,Core/amd64". Read in requested mode only.'
+        type: string
+        required: false
+        default: ''
+    outputs:
+      integration-namespaces:
+        description: 'JSON array of integration test namespaces to run.'
+        value: ${{ jobs.compute.outputs.integration }}
+      unbounded-namespaces:
+        description: 'JSON array of unbounded test namespaces to run.'
+        value: ${{ jobs.compute.outputs.unbounded }}
+      container-groups:
+        description: 'Comma-separated container groups to run. Empty means all of them.'
+        value: ${{ jobs.compute.outputs.containers }}
+
+permissions: {}
+
+jobs:
+  compute:
+    name: Compute Test Selection
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      integration: ${{ steps.compute.outputs.integration }}
+      unbounded: ${{ steps.compute.outputs.unbounded }}
+      containers: ${{ steps.compute.outputs.containers }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Compute namespace lists
+        id: compute
+        env:
+          INTEGRATION_EXCLUDE: ${{ vars.INTEGRATION_EXCLUDE_NAMESPACES }}
+          UNBOUNDED_EXCLUDE: ${{ vars.UNBOUNDED_EXCLUDE_NAMESPACES }}
+          MODE: ${{ inputs.mode }}
+          INTEGRATION_REQUEST: ${{ inputs.integration_request }}
+          UNBOUNDED_REQUEST: ${{ inputs.unbounded_request }}
+          CONTAINER_REQUEST: ${{ inputs.container_request }}
+        run: |
+          # ── Canonical namespace lists ──────────────────────────────────
+          # maintain alphabetical order, please!
+          integration_all='[
+            "AgentFeatures",
+            "AgentLogs",
+            "AgentMetrics",
+            "Api",
+            "AppDomainCaching",
+            "AspNetCore",
+            "AwsLambda.AutoInstrumentation",
+            "AwsLambda.CloudWatch",
+            "AwsLambda.Custom",
+            "AwsLambda.DynamoDb",
+            "AwsLambda.General",
+            "AwsLambda.Kinesis",
+            "AwsLambda.S3",
+            "AwsLambda.Ses",
+            "AwsLambda.Sns",
+            "AwsLambda.Sqs",
+            "AwsLambda.WebRequest",
+            "AwsSdk",
+            "AzureFunction",
+            "BasicInstrumentation",
+            "Blazor",
+            "CatInbound",
+            "CatOutbound",
+            "CodeLevelMetrics",
+            "Configuration",
+            "CustomAttributes",
+            "CustomInstrumentation",
+            "DataTransmission",
+            "DistributedTracing",
+            "Errors",
+            "Grpc",
+            "Hangfire",
+            "HSM",
+            "HttpClientInstrumentation",
+            "HybridHttpContextStorage",
+            "InfiniteTracing",
+            "LLM",
+            "Logging.AuditLog",
+            "Logging.ContextData",
+            "Logging.Hsm",
+            "Logging.Labels",
+            "Logging.LocalDecoration",
+            "Logging.LogLevelDetection",
+            "Logging.MaxSamplesStored",
+            "Logging.MetricsAndForwarding",
+            "Logging.StructuredLogArgContextData",
+            "Logging.ZeroMaxSamplesStored",
+            "MassTransit",
+            "MultiAppDomain",
+            "OpenTelemetry",
+            "Owin",
+            "ReJit.NetCore",
+            "ReJit.NetFramework",
+            "RequestHandling",
+            "RequestHeadersCapture.AspNet",
+            "RequestHeadersCapture.AspNetCore",
+            "RequestHeadersCapture.EnvironmentVariables",
+            "RequestHeadersCapture.Owin",
+            "RequestHeadersCapture.WCF",
+            "RestSharp",
+            "WCF.Client.IIS.ASPDisabled",
+            "WCF.Client.IIS.ASPEnabled",
+            "WCF.Client.Self",
+            "WCF.Service.IIS.ASPDisabled",
+            "WCF.Service.IIS.ASPEnabled",
+            "WCF.Service.Self"
+          ]'
+
+          unbounded_all='[
+            "AzureServiceBus",
+            "CosmosDB",
+            "Couchbase",
+            "Elasticsearch",
+            "MongoDB",
+            "Msmq",
+            "MsSql",
+            "MySql",
+            "NServiceBus",
+            "NServiceBus5",
+            "OpenSearch",
+            "Oracle",
+            "Postgres",
+            "RabbitMq",
+            "Redis"
+          ]'
+
+          # Container groups, as name/arch. This list is validated against the
+          # select-matrix list in linux_container_tests.yml by .github/scripts/check-workflows.py (V1g).
+          container_all='[
+            "Ubuntu/amd64",
+            "Alpine/amd64",
+            "Centos/amd64",
+            "Amazon/amd64",
+            "Fedora/amd64",
+            "Ubuntu/arm64",
+            "Amazon/arm64",
+            "Fedora/arm64",
+            "Core/amd64",
+            "Messaging/amd64",
+            "Aws/amd64",
+            "Datastore/amd64"
+          ]'
+
+          if [ "$MODE" = "all" ]; then
+            # ── Read exclusion variables (default to empty array) ─────────
+            integration_exclude="${INTEGRATION_EXCLUDE:-[]}"
+            unbounded_exclude="${UNBOUNDED_EXCLUDE:-[]}"
+  
+            # ── Apply exclusions ──────────────────────────────────────────
+            integration=$(jq -c '. - $ex' --argjson ex "$integration_exclude" <<< "$integration_all")
+            unbounded=$(jq -c '. - $ex' --argjson ex "$unbounded_exclude" <<< "$unbounded_all")
+  
+            # ── Log what was excluded ─────────────────────────────────────
+            int_removed=$(jq -c '. as $all | $all - ($all - $ex)' --argjson ex "$integration_exclude" <<< "$integration_all")
+            unb_removed=$(jq -c '. as $all | $all - ($all - $ex)' --argjson ex "$unbounded_exclude" <<< "$unbounded_all")
+  
+            echo "::group::Integration test namespaces"
+            echo "Excluded: $int_removed"
+            echo "Running:  $integration"
+            echo "::endgroup::"
+  
+            echo "::group::Unbounded test namespaces"
+            echo "Excluded: $unb_removed"
+            echo "Running:  $unbounded"
+            echo "::endgroup::"
+  
+            echo "integration=$integration" >> "$GITHUB_OUTPUT"
+            echo "unbounded=$unbounded" >> "$GITHUB_OUTPUT"
+            containers=""
+            echo "containers=$containers" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$MODE" != "requested" ]; then
+            echo "::error::Unknown mode '$MODE'. Valid values: all, requested."
+            exit 1
+          fi
+
+          # ---- requested mode ----------------------------------------------
+          # Exclusion variables do NOT apply here. Targeted mode is how an
+          # excluded namespace gets re-tested, so an explicit request wins.
+
+          split_request() {
+            jq -Rc 'split(",") | map(gsub("^[ \t]+|[ \t]+$"; "")) | map(select(length > 0))' <<< "$1"
+          }
+
+          report_unknown() {
+            local label="$1" all="$2" unknown="$3" name suggestion
+            echo "::error::Unknown $label: $(jq -r 'join(", ")' <<< "$unknown")"
+            while IFS= read -r name; do
+              suggestion=$(jq -r --arg n "$name" \
+                'map(select(ascii_downcase | startswith(($n | ascii_downcase)[0:2]))) | join(", ")' <<< "$all")
+              if [ -n "$suggestion" ]; then
+                echo "::error::  $name - nearest match: $suggestion"
+              else
+                echo "::error::  $name - no near match. Valid values: $(jq -r 'join(", ")' <<< "$all")"
+              fi
+            done < <(jq -r '.[]' <<< "$unknown")
+          }
+
+          errors=0
+
+          integration_req=$(split_request "$INTEGRATION_REQUEST")
+          unbounded_req=$(split_request "$UNBOUNDED_REQUEST")
+          container_req=$(split_request "$CONTAINER_REQUEST")
+
+          integration_unknown=$(jq -c --argjson all "$integration_all" '. - $all' <<< "$integration_req")
+          unbounded_unknown=$(jq -c --argjson all "$unbounded_all" '. - $all' <<< "$unbounded_req")
+          container_unknown=$(jq -c --argjson all "$container_all" '. - $all' <<< "$container_req")
+
+          if [ "$integration_unknown" != "[]" ]; then
+            report_unknown "integration namespace(s)" "$integration_all" "$integration_unknown"
+            errors=1
+          fi
+          if [ "$unbounded_unknown" != "[]" ]; then
+            report_unknown "unbounded namespace(s)" "$unbounded_all" "$unbounded_unknown"
+            errors=1
+          fi
+          if [ "$container_unknown" != "[]" ]; then
+            report_unknown "container group(s)" "$container_all" "$container_unknown"
+            errors=1
+          fi
+
+          if [ "$errors" -ne 0 ]; then
+            echo "::error::Selection failed. Fix the names above and dispatch again."
+            exit 1
+          fi
+
+          # Intersect in canonical order, so the matrix leg order is stable.
+          integration=$(jq -c --argjson req "$integration_req" '. - (. - $req)' <<< "$integration_all")
+          unbounded=$(jq -c --argjson req "$unbounded_req" '. - (. - $req)' <<< "$unbounded_all")
+          containers=$(jq -r --argjson req "$container_req" '. - (. - $req) | join(",")' <<< "$container_all")
+
+          if [ "$integration" = "[]" ] && [ "$unbounded" = "[]" ] && [ -z "$containers" ]; then
+            echo "::error::No tests requested. Set at least one of integration_namespaces, unbounded_namespaces, or container_groups."
+            exit 1
+          fi
+
+          echo "::group::Requested test selection"
+          echo "Integration: $integration"
+          echo "Unbounded:   $unbounded"
+          echo "Containers:  $containers"
+          echo "::endgroup::"
+
+          echo "integration=$integration" >> "$GITHUB_OUTPUT"
+          echo "unbounded=$unbounded" >> "$GITHUB_OUTPUT"
+          echo "containers=$containers" >> "$GITHUB_OUTPUT"
+        shell: bash

--- a/.github/workflows/test_selection.yml
+++ b/.github/workflows/test_selection.yml
@@ -152,7 +152,7 @@ jobs:
           ]'
 
           # Container groups, as name/arch. This list is validated against the
-          # select-matrix list in linux_container_tests.yml by .github/scripts/check-workflows.py (V1g).
+          # select-matrix list in linux_container_tests.yml by .github/scripts/check-workflows.py.
           container_all='[
             "Ubuntu/amd64",
             "Alpine/amd64",

--- a/.github/workflows/unbounded_tests.yml
+++ b/.github/workflows/unbounded_tests.yml
@@ -1,0 +1,375 @@
+name: Unbounded Tests
+
+on:
+  workflow_call:
+    inputs:
+      namespaces:
+        description: 'JSON array of unbounded test namespaces to run, e.g. ["MsSql","Redis"]'
+        type: string
+        required: true
+      aggregate_payload_data:
+        description: 'Collect and upload payload data artifacts for later aggregation'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build UnboundedIntegrationTests
+    runs-on: windows-2025-vs2026
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Build test solution
+        uses: ./.github/actions/build-test-solution
+        with:
+          solution-path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
+          search-paths: UnboundedApplications SharedApplications
+          skip-projects: ''
+          artifact-name: unboundedintegrationtests
+
+  run-unbounded-tests:
+    needs: build
+    name: Run Unbounded Tests
+    runs-on: windows-2025-vs2026
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        namespace: ${{ fromJson(inputs.namespaces) }}
+      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+
+    env:
+      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      unbounded_tests_path: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net10.0
+      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
+      NR_DOTNET_TEST_PREBUILT_APPS: 1 # use pre-published test app output instead of dotnet publish at runtime
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: false
+      # Set an environment variable that the tests will use to set the application name.
+      CI_NEW_RELIC_APP_NAME: ${{ github.event_name == 'schedule' && 'DotNetIngestTracking' || '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: homefolders
+          path: src/Agent
+
+      - name: Download Unbounded Integration Test Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: unboundedintegrationtests
+          # Should not need a path because the integration test artifacts are archived with the full directory structure
+
+      - name: Disable TLS 1.3
+        run: |
+          $registryPath = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
+          if(!(Test-Path $registryPath)) {
+            New-Item -Path $registryPath -Force
+          }
+          New-ItemProperty -Path $registryPath -Name "DisabledByDefault" -Value "1" -PropertyType DWORD -Force
+          New-ItemProperty -Path $registryPath -Name "Enabled" -Value "0" -PropertyType DWORD -Force
+        shell: powershell
+
+      - name: Install HostableWebCore Feature
+        if: | # only install for the required namespaces
+          matrix.namespace == 'MongoDB' || matrix.namespace == 'Oracle'
+        run: |
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+        shell: powershell
+
+      - name: Install MSMQ dependencies
+        if: matrix.namespace == 'Msmq'
+        run: |
+          Write-Host "Installing Msmq Features"
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
+        shell: powershell
+
+      - name: Install MsSql dependencies
+        if: matrix.namespace == 'MsSql'
+        run: |
+          Write-Host "Installing MSSQL CLI"
+          $msi = "${{ github.workspace }}\build\Tools\sqlncli.msi"
+
+          # Wait on the installer itself instead of sleeping a fixed interval.
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            '/i', "`"$msi`"", 'IACCEPTSQLNCLILICENSETERMS=YES', '/quiet', '/qn', '/norestart'
+          )
+          if ($proc.ExitCode -ne 0) {
+            throw "msiexec failed with exit code $($proc.ExitCode)."
+          }
+
+          # Assert the provider registered. Without this the job goes green and the failure
+          # resurfaces far away from its cause, inside an OleDb test connection.
+          $providers = (New-Object System.Data.OleDb.OleDbEnumerator).GetElements() | ForEach-Object { $_.SOURCES_NAME }
+          Write-Host "Registered OLE DB providers:"
+          $providers | ForEach-Object { Write-Host "  $_" }
+          if ($providers -notcontains 'SQLNCLI11') {
+            throw "SQLNCLI11 did not register. The OleDb tests connect with PROVIDER=SQLNCLI11."
+          }
+        shell: powershell
+
+      # SQL Server Native Client 11.0 (installed above) is still needed by the OleDb tests,
+      # which connect with PROVIDER=SQLNCLI11, so this adds a driver rather than replacing one.
+      #
+      # The ODBC tests connect with DRIVER={ODBC Driver 18 for SQL Server}. The runner image
+      # ships the Visual Studio component Microsoft.VisualStudio.Component.MSODBC.SQL, but the
+      # image readme records only that component's Visual Studio version, never the ODBC driver
+      # version it delivers, and the readme's standalone driver list carries OLE DB drivers
+      # rather than ODBC ones. So probe for the driver by the exact name the connection string
+      # asks for and install only when it is missing: no-op on an image that already has it,
+      # self-repairing on one that does not. The listing also records what the image really
+      # provides, which is otherwise undocumented.
+      - name: Ensure Microsoft ODBC Driver 18 for SQL Server
+        if: matrix.namespace == 'MsSql'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Invoke-WebRequest is very slow on Windows PowerShell while it renders progress.
+          $ProgressPreference = 'SilentlyContinue'
+          $driverName = 'ODBC Driver 18 for SQL Server'
+
+          Write-Host "Registered 64-bit ODBC drivers on this image:"
+          Get-OdbcDriver -Platform '64-bit' | ForEach-Object { Write-Host "  $($_.Name)" }
+
+          if (Get-OdbcDriver -Name $driverName -Platform '64-bit' -ErrorAction SilentlyContinue) {
+            Write-Host "$driverName is already present. Nothing to install."
+            exit 0
+          }
+
+          # x64 only: the ODBC test fixtures (FWLatest, CoreLatest) both run 64-bit. This link
+          # resolves to the latest GA 18.x, so the installed patch version can move without
+          # notice. Pin the download.microsoft.com URL it redirects to if that ever matters.
+          $url = 'https://go.microsoft.com/fwlink/?linkid=2358430'
+          $msi = Join-Path $env:RUNNER_TEMP 'msodbcsql18.msi'
+
+          Write-Host "$driverName not found. Downloading from $url"
+          Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
+
+          # A wrong or redirected-to-HTML URL yields a small text file that msiexec silently
+          # refuses, so fail here instead of hours later with a confusing IM002 in a test log.
+          $size = (Get-Item $msi).Length
+          Write-Host "Downloaded $size bytes"
+          if ($size -lt 1MB) {
+            throw "Expected an MSI of several MB but got $size bytes. The download URL is probably wrong."
+          }
+
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            '/i', "`"$msi`"", '/quiet', '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
+          )
+          if ($proc.ExitCode -ne 0) {
+            throw "msiexec failed with exit code $($proc.ExitCode)."
+          }
+
+          # Assert it registered. Without this the job goes green and the failure resurfaces as
+          # ERROR [IM002] Data source name not found, far away from its cause.
+          if (-not (Get-OdbcDriver -Name $driverName -Platform '64-bit' -ErrorAction SilentlyContinue)) {
+            Write-Host "Registered 64-bit ODBC drivers after install:"
+            Get-OdbcDriver -Platform '64-bit' | ForEach-Object { Write-Host "  $($_.Name)" }
+            throw "$driverName did not register. Try adding ADDLOCAL=ALL to the msiexec arguments."
+          }
+          Write-Host "$driverName installed."
+        shell: powershell
+
+      - name: Set up secrets
+        env:
+          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+        run: |
+          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+        
+# save in case we move back to using the emulator
+#      - name: Start Local CosmosDB Emulator for CosmosDB Tests
+#        if: matrix.namespace == 'CosmosDB'
+#        run: |
+#          Write-Host "Launching Cosmos DB Emulator"
+#          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+#          Start-CosmosDbEmulator
+#        shell: pwsh
+
+      - name: Install latest .NET 10 SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'ga'
+  
+      - name: Run Unbounded Integration Tests
+        run: |
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "List ports in use"
+            netstat -no
+          }
+
+          # Most unbounded tests can run in parallel with pre-built test apps.
+          # Some namespaces must remain serial because they use shared external infrastructure
+          # with hard-coded object names (e.g., NServiceBus5 tests share MSMQ queues). To
+          # parallelize these, each test fixture would need isolated resources
+          # (per-test databases/tables/queues).
+          $noParallelNamespaces = @("NServiceBus", "NServiceBus5")
+          $parallelize = $noParallelNamespaces -notcontains "${{ matrix.namespace }}"
+          $json = Get-Content "${{ env.unbounded_tests_path }}/xunit.runner.json" | ConvertFrom-Json
+          $json | Add-Member -Name "parallelizeAssembly" -Value $parallelize -MemberType NoteProperty
+          $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
+          $json | ConvertTo-Json | Out-File "${{ env.unbounded_tests_path }}/xunit.runner.json"
+
+          # Retry once on failure to absorb transient WAN/infra blips between the GitHub-hosted
+          # runner and the Azure-hosted unbounded services (e.g. brief packet loss surfacing as a
+          # client command timeout while the service itself is healthy). A retried-but-passing job
+          # still emits a ::warning:: so genuine regressions / flake churn stay visible in the UI.
+          $maxAttempts = 2
+          $attempt = 1
+          while ($true) {
+            & "${{ env.unbounded_tests_path }}/NewRelic.Agent.UnboundedIntegrationTests.exe" -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -eq 0) {
+              if ($attempt -gt 1) {
+                Write-Host "::warning::Unbounded tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+                # Record the flaky retry to a marker file under RUNNER_TEMP, which the
+                # failure-artifact upload globs never collect. Reporting runs in the separate
+                # step below so that no secret is in scope for this step: HostedWebCore and
+                # other test hosts launched here write their environment to the console, and
+                # that console output is captured into the test results.
+                $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+                @{ testType = "unboundedTests"; testGroup = "${{ matrix.namespace }}" } | ConvertTo-Json | Out-File -FilePath $marker -Encoding UTF8
+              }
+              break
+            }
+            if ($attempt -ge $maxAttempts) {
+              Write-Host "Unbounded tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
+              exit $exitCode
+            }
+            Write-Host "Unbounded tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
+            $attempt++
+            Start-Sleep -Seconds 10
+          }
+
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "Get HostableWebCore errors (if any)"
+            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+
+            Write-Host "Get .NET Runtime errors (if any)"
+            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
+          }
+        shell: powershell
+
+      - name: Report flaky retry telemetry
+        if: always()
+        continue-on-error: true
+        env:
+          NR_CI_INGEST_KEY: ${{ secrets.NR_CI_INGEST_KEY }}
+          NR_CI_ACCOUNT_ID: ${{ secrets.NR_CI_ACCOUNT_ID }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
+        run: |
+          $marker = "$Env:RUNNER_TEMP\flaky-retry-${{ matrix.namespace }}.json"
+          if (Test-Path $marker) {
+            $info = Get-Content $marker | ConvertFrom-Json
+            $Env:RETRY_TEST_TYPE = $info.testType
+            $Env:RETRY_TEST_GROUP = $info.testGroup
+            & bash build/Scripts/report-flaky-retry.sh
+            Remove-Item $marker -Force -ErrorAction Ignore
+          }
+        shell: powershell
+
+      - name: Extract payload bytes log from TRX
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        run: |
+          $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+          $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
+          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
+
+          Write-Host "Checking for TRX file at: $trxFile"
+
+          $executedTests = 0
+
+          if (Test-Path $trxFile) {
+            $fileSize = (Get-Item $trxFile).Length
+            Write-Host "TRX file found. Size: $fileSize bytes"
+
+            # Read TRX file and extract lines containing payload information from Message elements
+            [xml]$trxContent = Get-Content $trxFile
+            $messageElements = $trxContent.SelectNodes("//*[local-name()='Output']/*[local-name()='TextMessages']/*[local-name()='Message']")
+
+            $payloadData = @{}
+            foreach ($message in $messageElements) {
+              foreach ($line in ($message.InnerText -split "\r?\n")) {
+                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
+                  $className = $Matches[1].Trim()
+                  $category  = $Matches[2]
+                  $byteCount = [int]$Matches[3]
+                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
+                  if ($payloadData[$className].ContainsKey($category)) {
+                    $payloadData[$className][$category] += $byteCount
+                  } else {
+                    $payloadData[$className][$category] = $byteCount
+                  }
+                }
+              }
+            }
+
+            Write-Host "Found $($payloadData.Count) payload log entries"
+
+            if ($payloadData.Count -gt 0) {
+              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
+              Write-Host "Extracted payload logs to $payloadLog"
+              Write-Host "Content:"
+              Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
+            } else {
+              Write-Host "No payload byte logs found in TRX file"
+              @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+            }
+
+            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
+            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
+            # (any outcome), excluding skipped / not-executed.
+            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
+            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
+          } else {
+            Write-Host "TRX file not found"
+            @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+          }
+
+          Write-Host "Executed test count: $executedTests"
+          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
+        shell: powershell
+
+      - name: Upload payload bytes log
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unbounded-payload-bytes-${{ matrix.namespace }}
+          path: |
+            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
+          if-no-files-found: warn
+
+      - name: Archive unbounded test results on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unbounded-test-working-directory-${{ matrix.namespace }}
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+          if-no-files-found: error
+

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -1,0 +1,32 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+jobs:
+  check-workflows:
+    name: Check Workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+        shell: bash
+
+      - name: Run workflow checks
+        run: python3 .github/scripts/check-workflows.py
+        shell: bash

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -193,6 +193,44 @@ Agent-overhead harness under `tests/Agent/PerformanceTests/` -- Python-orchestra
 
 GitHub Actions runs unit + integration tests on every PR via [`all_solutions.yml`](../.github/workflows/all_solutions.yml); coverage to Codecov.
 
+### Targeted CI runs (`targeted_tests.yml`)
+
+`all_solutions.yml` runs all 93 test legs plus the MSI, both Linux packages, and
+ArtifactBuilder. To run a few namespaces in CI, dispatch
+[`targeted_tests.yml`](../.github/workflows/targeted_tests.yml) instead. It builds
+the agent fresh from the branch and runs only what you name; no MSI, no packages,
+no ArtifactBuilder.
+
+Three inputs, each a comma-separated list, each defaulting to empty:
+
+- `integration_namespaces` - e.g. `Errors, Api`. Validated against the 66
+  canonical integration namespaces.
+- `unbounded_namespaces` - e.g. `MsSql`. Validated against the 15 canonical
+  unbounded namespaces. These still contend for the shared AKS
+  `UnboundedServices` deployment, so two runs at once can interfere.
+- `container_groups` - `name/arch` pairs, e.g. `Ubuntu/amd64, Core/amd64`. The 12
+  valid pairs are the `name` and `arch` values listed in the `select-matrix` job
+  in [`linux_container_tests.yml`](../.github/workflows/linux_container_tests.yml).
+
+How the inputs behave:
+
+- **Empty means none**, per input. There is no `all` keyword; running everything
+  is what `all_solutions.yml` is for. All three empty fails the run.
+- **An unknown name fails the run before the agent build starts**, and the error
+  names the unknown value, often with a nearest match. Container groups are
+  validated too, so a typo there also fails early.
+- **The repo exclusion variables do not apply.** `INTEGRATION_EXCLUDE_NAMESPACES`
+  and `UNBOUNDED_EXCLUDE_NAMESPACES` gate the nightly, not a targeted run, so this
+  is how an excluded namespace gets re-tested.
+- **Selection is by namespace only.** There is no test-name filter, and no
+  payload-data aggregation.
+
+The canonical lists live in
+[`test_selection.yml`](../.github/workflows/test_selection.yml), which both
+`all_solutions.yml` and `targeted_tests.yml` call. `.github/scripts/check-workflows.py`
+runs on any pull request touching `.github/**` and asserts, among other things,
+that the container list there matches the `select-matrix` list.
+
 ## Related
 
 - Skills: `run-integration-tests` (run them), `build-dotnet-agent` (build first)


### PR DESCRIPTION
* Refactors existing `all_solutions.yml` workflow to extract reusable workflows and composite actions. Behavior of the workflow is unchanged.
* Adds `targeted_tests.yml`, that uses the extracted workflows  to build the agent and run only the named integration namespaces, unbounded namespaces, and container groups - no MSI, no Linux packages, no ArtifactBuilder. Usage is documented in `tests/CLAUDE.md`. **NOTE:** The new workflow is untested in this branch, since it has to exist in `main` before it can be invoked manually. So there may be a follow-up PR to correct any issues that are found.
* New `workflow_lint.yml` and companion `check-workflows.py` adds several static checks that run  on any PR touching `.github/**` to catch drift that might silently break the workflows (i.e., a change in container test namespaces).

Successful `all_solutions.yml` run: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/33099846775/job/98619666048