### PR TITLE
chore: Pin specific images in Linux package testing containers

### DIFF
--- a/build/Linux/test/distros/debian/Dockerfile
+++ b/build/Linux/test/distros/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c
 
 WORKDIR /data
 

--- a/build/Linux/test/distros/rockylinux/Dockerfile
+++ b/build/Linux/test/distros/rockylinux/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM rockylinux:9@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6
 
 WORKDIR /data
 


### PR DESCRIPTION
Fixes the following code scanning issues:
https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/682
https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/683
