### PR TITLE
feat: Allow setting the application name per IIS application pool in `newrelic.config`

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -5674,6 +5674,8 @@ namespace NewRelic.Agent.Core.Config
         
         private bool instrumentField;
         
+        private string appNameField;
+        
         /// <summary>
         /// Fully qualified class name of an exception, such as "System.IO.FileNotFoundException".
         /// </summary>
@@ -5700,6 +5702,19 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.instrumentField = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string appName
+        {
+            get
+            {
+                return this.appNameField;
+            }
+            set
+            {
+                this.appNameField = value;
             }
         }
         

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -359,6 +359,8 @@
                                         Set this to be the name of your application as you'd like it to show up in New Relic. New Relic will then auto-map instances of your application into an "application" on your home dashboard page.
 
                                         If youw ant to map this instance onto multiple applications, like "AJAX Requests" and "All UI", then specify up to three distinct names.
+
+                                        This element takes precedence over the appName attribute of an applicationPool element. Remove this element to name applications by application pool instead.
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
@@ -1860,6 +1862,14 @@
                                         <xs:annotation>
                                             <xs:documentation>
                                                 True indicates that this application pool will be instrumented.	False indicates that this pool will not be instrumented.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="appName" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Reports this application pool to New Relic under the given application name. The application/name element takes precedence over this attribut
+e, so remove that element to use this mapping.
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -340,16 +340,12 @@ public class DefaultConfiguration : IConfiguration
             return true;
         }
 
-        // Resolved before step 8 so that step 8 can report when it shadows a mapping.
-        var appPoolId = GetAppPoolId();
-        var pooledAppName = TryGetApplicationNameForApplicationPool(appPoolId);
-
         // 8. newrelic.config
         if (_localConfiguration.application.name.Count > 0)
         {
-            if (pooledAppName != null)
+            if (HasApplicationPoolMapping())
             {
-                Log.Warn("Application pool '{0}' is mapped to application name '{1}' in newrelic.config, but the application/name element takes precedence. Remove that element to use the application pool mapping.", appPoolId, pooledAppName);
+                Log.Warn("An applicationPool appName mapping is configured in newrelic.config, but the application/name element takes precedence. Remove that element to use the application pool mapping.");
             }
 
             Log.Info("Application name from newrelic.config.");
@@ -358,7 +354,10 @@ public class DefaultConfiguration : IConfiguration
             return true;
         }
 
+        var appPoolId = GetAppPoolId();
+
         // 9. newrelic.config application pool mapping
+        var pooledAppName = TryGetApplicationNameForApplicationPool(appPoolId);
         if (pooledAppName != null)
         {
             Log.Info("Application name from application pool mapping in newrelic.config.");
@@ -388,6 +387,12 @@ public class DefaultConfiguration : IConfiguration
         // Failure path
         names = null;
         return false;
+    }
+
+    private bool HasApplicationPoolMapping()
+    {
+        var pools = _localConfiguration.applicationPools?.applicationPool;
+        return pools != null && pools.Any(pool => !string.IsNullOrWhiteSpace(pool.appName));
     }
 
     private string TryGetApplicationNameForApplicationPool(string appPoolId)

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -357,7 +357,7 @@ public class DefaultConfiguration : IConfiguration
         var appPoolId = GetAppPoolId();
 
         // 9. newrelic.config application pool mapping
-        var pooledAppName = TryGetApplicationNameForApplicationPool(appPoolId);
+        var pooledAppName = TryGetMappedApplicationNameForApplicationPool(appPoolId);
         if (pooledAppName != null)
         {
             Log.Info("Application name from application pool mapping in newrelic.config.");
@@ -395,7 +395,7 @@ public class DefaultConfiguration : IConfiguration
         return pools != null && pools.Any(pool => !string.IsNullOrWhiteSpace(pool.appName));
     }
 
-    private string TryGetApplicationNameForApplicationPool(string appPoolId)
+    private string TryGetMappedApplicationNameForApplicationPool(string appPoolId)
     {
         if (string.IsNullOrWhiteSpace(appPoolId))
         {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -340,26 +340,43 @@ public class DefaultConfiguration : IConfiguration
             return true;
         }
 
+        // Resolved before step 8 so that step 8 can report when it shadows a mapping.
+        var appPoolId = GetAppPoolId();
+        var pooledAppName = TryGetApplicationNameForApplicationPool(appPoolId);
+
         // 8. newrelic.config
         if (_localConfiguration.application.name.Count > 0)
         {
+            if (pooledAppName != null)
+            {
+                Log.Warn("Application pool '{0}' is mapped to application name '{1}' in newrelic.config, but the application/name element takes precedence. Remove that element to use the application pool mapping.", appPoolId, pooledAppName);
+            }
+
             Log.Info("Application name from newrelic.config.");
             _applicationNamesSource = "NewRelic Config";
             names = _localConfiguration.application.name;
             return true;
         }
 
-        // 9. Application Pool
-        appName = GetAppPoolId();
-        if (!string.IsNullOrWhiteSpace(appName))
+        // 9. newrelic.config application pool mapping
+        if (pooledAppName != null)
         {
-            Log.Info("Application name from Application Pool name.");
-            _applicationNamesSource = "Application Pool";
-            names = appName.Split(StringSeparators.Comma);
+            Log.Info("Application name from application pool mapping in newrelic.config.");
+            _applicationNamesSource = "NewRelic Config (Application Pool)";
+            names = [pooledAppName];
             return true;
         }
 
-        // 10. Process name (only when AppDomain virtual path is null)
+        // 10. Application Pool
+        if (!string.IsNullOrWhiteSpace(appPoolId))
+        {
+            Log.Info("Application name from Application Pool name.");
+            _applicationNamesSource = "Application Pool";
+            names = appPoolId.Split(StringSeparators.Comma);
+            return true;
+        }
+
+        // 11. Process name (only when AppDomain virtual path is null)
         if (_httpRuntimeStatic.AppDomainAppVirtualPath == null)
         {
             Log.Info("Application name from process name.");
@@ -371,6 +388,39 @@ public class DefaultConfiguration : IConfiguration
         // Failure path
         names = null;
         return false;
+    }
+
+    private string TryGetApplicationNameForApplicationPool(string appPoolId)
+    {
+        if (string.IsNullOrWhiteSpace(appPoolId))
+        {
+            return null;
+        }
+
+        var pools = _localConfiguration.applicationPools?.applicationPool;
+        if (pools == null)
+        {
+            return null;
+        }
+
+        string mappedName = null;
+        foreach (var pool in pools)
+        {
+            if (string.IsNullOrWhiteSpace(pool.appName) || !string.Equals(pool.name, appPoolId, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (mappedName != null)
+            {
+                Log.Warn("Application pool '{0}' has more than one appName mapping in newrelic.config. Using '{1}'.", appPoolId, mappedName);
+                break;
+            }
+
+            mappedName = pool.appName.Trim();
+        }
+
+        return mappedName;
     }
 
     private string GetAppPoolId()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 
 namespace NewRelic.Agent.IntegrationTestHelpers;
 
@@ -673,6 +674,46 @@ public class NewRelicConfigModifier
     public NewRelicConfigModifier SetOpenTelemetryMetricsExportTimeout(int timeoutMs)
     {
         CommonUtils.SetConfigAppSetting(_configFilePath, "OpenTelemetryMetricsExportTimeout", timeoutMs.ToString(), "urn:newrelic-config");
+        return this;
+    }
+
+    public NewRelicConfigModifier DeleteApplicationName()
+    {
+        CommonUtils.DeleteXmlNodeFromNewRelicConfig(_configFilePath, new[] { "configuration", "application" }, "name");
+        return this;
+    }
+
+    public NewRelicConfigModifier AddApplicationPoolMapping(string poolName, string appName)
+    {
+        const string newRelicConfigNamespace = "urn:newrelic-config";
+
+        var document = new XmlDocument();
+        document.Load(_configFilePath);
+
+        var configurationNode = document.DocumentElement;
+
+        var applicationPoolsNode = document.CreateElement("applicationPools", newRelicConfigNamespace);
+        var applicationPoolNode = document.CreateElement("applicationPool", newRelicConfigNamespace);
+        applicationPoolNode.SetAttribute("name", poolName);
+        applicationPoolNode.SetAttribute("instrument", "true");
+        applicationPoolNode.SetAttribute("appName", appName);
+        applicationPoolsNode.AppendChild(applicationPoolNode);
+
+        var namespaceManager = new XmlNamespaceManager(document.NameTable);
+        namespaceManager.AddNamespace("nr", newRelicConfigNamespace);
+        var threadProfilingNode = configurationNode.SelectSingleNode("nr:threadProfiling", namespaceManager);
+
+        // applicationPools must precede threadProfiling per the config XSD sequence
+        if (threadProfilingNode != null)
+        {
+            configurationNode.InsertBefore(applicationPoolsNode, threadProfilingNode);
+        }
+        else
+        {
+            configurationNode.AppendChild(applicationPoolsNode);
+        }
+
+        document.Save(_configFilePath);
         return this;
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Configuration/ApplicationPoolApplicationNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Configuration/ApplicationPoolApplicationNameTests.cs
@@ -1,0 +1,120 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.Configuration;
+
+public abstract class ApplicationPoolApplicationNameTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
+{
+    private const string PoolName = "IntegrationTestAppPool";
+    private const string MappedAppName = "IntegrationTestPoolMappedAppName";
+
+    private readonly TFixture _fixture;
+
+    protected ApplicationPoolApplicationNameTestsBase(TFixture fixture, string appPoolEnvironmentVariableName, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.RemoteApplication.SetAdditionalEnvironmentVariable(appPoolEnvironmentVariableName, PoolName);
+
+        _fixture.AddCommand("HttpClientDriver Get");
+
+        _fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                _fixture.RemoteApplication.NewRelicConfig
+                    .DeleteApplicationName()
+                    .AddApplicationPoolMapping(PoolName, MappedAppName);
+
+                RemoveAppNameFromExecutableConfig();
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedLogLineRegexes = new[]
+        {
+            @"Application name from application pool mapping in newrelic\.config\.",
+            @".+ Your New Relic Application Name\(s\): " + MappedAppName
+        };
+
+        var actualLogLines = _fixture.AgentLog.GetFileLines();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.LogLinesExist(expectedLogLineRegexes, actualLogLines)
+        );
+    }
+
+    // the harness stamps a NewRelic.AppName setting that outranks the application pool mapping
+    private void RemoveAppNameFromExecutableConfig()
+    {
+        var applicationDirectoryPath = _fixture.RemoteApplication.DestinationApplicationDirectoryPath;
+
+        if (_fixture.RemoteApplication.IsCoreApp)
+        {
+            var appSettingsFilePath = Path.Combine(applicationDirectoryPath, "appsettings.json");
+            if (!File.Exists(appSettingsFilePath))
+            {
+                return;
+            }
+
+            var jsonObj = JObject.Parse(File.ReadAllText(appSettingsFilePath));
+            jsonObj.Remove("NewRelic.AppName");
+
+            using (var file = File.CreateText(appSettingsFilePath))
+            using (var writer = new JsonTextWriter(file))
+            {
+                jsonObj.WriteTo(writer);
+            }
+
+            return;
+        }
+
+        var appConfigFilePath = Directory.GetFiles(applicationDirectoryPath, "*.exe.config").FirstOrDefault();
+        if (appConfigFilePath == null)
+        {
+            return;
+        }
+
+        var document = new XmlDocument();
+        document.Load(appConfigFilePath);
+
+        var settingNode = document.SelectSingleNode("/configuration/appSettings/add[@key='NewRelic.AppName']");
+        settingNode?.ParentNode?.RemoveChild(settingNode);
+
+        document.Save(appConfigFilePath);
+    }
+}
+
+public class ApplicationPoolApplicationNameFWLatestTests : ApplicationPoolApplicationNameTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public ApplicationPoolApplicationNameFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, "APP_POOL_ID", output)
+    {
+    }
+}
+
+public class ApplicationPoolApplicationNameCoreLatestTests : ApplicationPoolApplicationNameTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public ApplicationPoolApplicationNameCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, "ASPNETCORE_IIS_APP_POOL_ID", output)
+    {
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1965,6 +1965,248 @@ public class DefaultConfigurationTests
         );
     }
 
+    private void ArrangeApplicationNameFallthrough(string appPoolId)
+    {
+        _runTimeConfig.ApplicationNames = new List<string>();
+        Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+        Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+        _localConfig.application.name = new List<string>();
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns(appPoolId);
+        Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
+        Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherProcessName");
+    }
+
+    private void AddApplicationPoolMapping(string poolName, string appName)
+    {
+        _localConfig.applicationPools.applicationPool.Add(new configurationApplicationPoolsApplicationPool
+        {
+            name = poolName,
+            instrument = true,
+            appName = appName
+        });
+    }
+
+    [Test]
+    public void ApplicationNamePullsFromApplicationPoolMapping()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("UnifiedApp")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config (Application Pool)"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingRollsMultiplePoolsIntoOneName()
+    {
+        ArrangeApplicationNameFallthrough("PoolTwo");
+        AddApplicationPoolMapping("PoolOne", "UnifiedApp");
+        AddApplicationPoolMapping("PoolTwo", "UnifiedApp");
+        AddApplicationPoolMapping("PoolThree", "UnifiedApp");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("UnifiedApp")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config (Application Pool)"))
+        );
+    }
+
+    [TestCase("MYPOOL", "mypool")]
+    [TestCase("mypool", "MYPOOL")]
+    [TestCase("MyPool", "MyPool")]
+    public void ApplicationPoolMappingMatchesPoolNameWithoutRegardToCase(string configuredName, string actualPoolId)
+    {
+        ArrangeApplicationNameFallthrough(actualPoolId);
+        AddApplicationPoolMapping(configuredName, "UnifiedApp");
+
+        Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("UnifiedApp"));
+    }
+
+    [Test]
+    public void ApplicationPoolMappingTrimsTheConfiguredName()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "  UnifiedApp  ");
+
+        Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("UnifiedApp"));
+    }
+
+    [Test]
+    public void ApplicationPoolMappingUsesFirstEntryWhenDuplicated()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "FirstName");
+        AddApplicationPoolMapping("MyPool", "SecondName");
+
+        Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("FirstName"));
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsShadowedByNewRelicConfigApplicationName()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+        _localConfig.application.name = new List<string> { "FromApplicationElement" };
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("FromApplicationElement")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsOutrankedByAppNameEnvironmentVariable()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+        Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_APP_NAME")).Returns("FromEnvironmentVariable");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("FromEnvironmentVariable")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (NEW_RELIC_APP_NAME)"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsOutrankedByApplicationConfig()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+        Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns("FromWebConfig");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("FromWebConfig")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Config"))
+        );
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void ApplicationPoolMappingIsIgnoredWhenAppNameIsBlank(string blankAppName)
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", blankAppName);
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyPool")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Pool"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsIgnoredWhenNoEntryMatches()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("SomeOtherPool", "UnifiedApp");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyPool")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Pool"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsIgnoredWhenNoPoolsAreConfigured()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyPool")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Pool"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingIsIgnoredWhenAppPoolIdIsBlank()
+    {
+        ArrangeApplicationNameFallthrough(null);
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+        Mock.Arrange(() => _environment.GetCommandLineArgs()).Returns(new[] { "MyProcess.exe" });
+        Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns<string>(null);
+        Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("MyProcess");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyProcess")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Process Name"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolMappingMatchesPoolIdFromCommandLine()
+    {
+        ArrangeApplicationNameFallthrough(null);
+        AddApplicationPoolMapping("MyPool", "UnifiedApp");
+        Mock.Arrange(() => _environment.GetCommandLineArgs()).Returns("w3wp.exe -ap MyPool".Split(new[] { ' ' }));
+        Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns<string>(null);
+        Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("W3WP");
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("UnifiedApp")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config (Application Pool)"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolAppNameBindsFromXml()
+    {
+        _runTimeConfig.ApplicationNames = new List<string>();
+        Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+        Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("CallCenterService_Pool");
+        Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
+        Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("w3wp");
+
+        var xml = @"<?xml version=""1.0""?>
+<configuration xmlns=""urn:newrelic-config"">
+  <service licenseKey=""dude"" />
+  <application />
+  <applicationPools>
+    <applicationPool name=""ComfortSite_Pool"" instrument=""true"" appName=""ComfortSite"" />
+    <applicationPool name=""CallCenterService_Pool"" instrument=""true"" appName=""ComfortSite"" />
+    <applicationPool name=""Uninstrumented_Pool"" instrument=""false"" />
+  </applicationPools>
+</configuration>";
+
+        var config = GenerateConfigFromXml(xml);
+
+        NrAssert.Multiple(
+            () => Assert.That(config.ApplicationNames.Count(), Is.EqualTo(1)),
+            () => Assert.That(config.ApplicationNames.FirstOrDefault(), Is.EqualTo("ComfortSite")),
+            () => Assert.That(config.ApplicationNamesSource, Is.EqualTo("NewRelic Config (Application Pool)"))
+        );
+    }
+
+    [Test]
+    public void ApplicationPoolWithoutAppNameStillBindsFromXml()
+    {
+        _runTimeConfig.ApplicationNames = new List<string>();
+        Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+        Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("LegacyPool");
+        Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
+        Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("w3wp");
+
+        var xml = @"<?xml version=""1.0""?>
+<configuration xmlns=""urn:newrelic-config"">
+  <service licenseKey=""dude"" />
+  <application />
+  <applicationPools>
+    <defaultBehavior instrument=""false"" />
+    <applicationPool name=""LegacyPool"" instrument=""true"" />
+  </applicationPools>
+</configuration>";
+
+        var config = GenerateConfigFromXml(xml);
+
+        NrAssert.Multiple(
+            () => Assert.That(config.ApplicationNames.FirstOrDefault(), Is.EqualTo("LegacyPool")),
+            () => Assert.That(config.ApplicationNamesSource, Is.EqualTo("Application Pool"))
+        );
+    }
+
     [Test]
     public void ApplicationNamesPullsNameFromProcessIdIfAppDomainAppVirtualPathIsNull()
     {

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2057,6 +2057,19 @@ public class DefaultConfigurationTests
     }
 
     [Test]
+    public void NewRelicConfigApplicationNameWinsWhenNoPoolCarriesAnAppName()
+    {
+        ArrangeApplicationNameFallthrough("MyPool");
+        AddApplicationPoolMapping("MyPool", null);
+        _localConfig.application.name = new List<string> { "FromApplicationElement" };
+
+        NrAssert.Multiple(
+            () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("FromApplicationElement")),
+            () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
+        );
+    }
+
+    [Test]
     public void ApplicationPoolMappingIsOutrankedByAppNameEnvironmentVariable()
     {
         ArrangeApplicationNameFallthrough("MyPool");


### PR DESCRIPTION
Adds an optional `appName` attribute to the `applicationPool` element in `newrelic.config`. It resolves as a new step directly below the `application/name` element, so unmapped pools still fall through to their own pool name.

```xml
<configuration xmlns="urn:newrelic-config">
  <!-- the mapping only applies when this element carries no name -->
  <application />

  <applicationPools>
    <applicationPool name="StorefrontPool" instrument="true" appName="Storefront" />
    <applicationPool name="CheckoutPool" instrument="true" appName="Storefront" />
    <applicationPool name="ReportingPool" instrument="true" appName="Reporting" />
    <!-- no appName, so this pool reports under its own name -->
    <applicationPool name="LegacyPool" instrument="true" />
  </applicationPools>
</configuration>
```

`StorefrontPool` and `CheckoutPool` roll up into one application. `instrument` is still required, and `appName` does not change whether a pool is instrumented. Matching is case-insensitive on the pool name, and `appName` is a single name rather than a comma-separated list.

Covered by unit tests for resolution and precedence, and by an integration test that maps a pool through the real config file on .NET Framework and .NET Core. From NR-605854.
