### PR TITLE
chore: preserve debug symbols in the AssemblyModifier post-build step

### DIFF
--- a/src/Agent/NewRelic/AssemblyModifier/Program.cs
+++ b/src/Agent/NewRelic/AssemblyModifier/Program.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 if (args.Length == 0)
 {
@@ -30,10 +31,16 @@ try
     var parameters = new ReaderParameters
     {
         AssemblyResolver = resolver,
-        ReadWrite = true
+        ReadWrite = true,
+        ReadSymbols = true,
+        ThrowIfSymbolsAreNotMatching = false,
+        SymbolReaderProvider = new DefaultSymbolReaderProvider(throwIfNoSymbol: false)
     };
 
     using ModuleDefinition module = ModuleDefinition.ReadModule(assemblyPath, parameters);
+
+    var hasEmbeddedPdb = module.GetDebugHeader().Entries
+        .Any(e => e.Directory.Type == ImageDebugType.EmbeddedPortablePdb);
 
     IEnumerable<IModificationJob> jobs = [new InternalizeMetricsEventSourceName(logger)];
 
@@ -47,8 +54,22 @@ try
         }
     }
 
-    // Save the modified assembly
-    module.Write();
+    // Save the modified assembly, preserving whatever debug info the input carried.
+    // Writing without symbols drops the PE debug directory entirely.
+    if (module.HasSymbols)
+    {
+        var writerParameters = new WriterParameters { WriteSymbols = true };
+        if (hasEmbeddedPdb)
+        {
+            writerParameters.SymbolWriterProvider = new EmbeddedPortablePdbWriterProvider();
+        }
+
+        module.Write(writerParameters);
+    }
+    else
+    {
+        module.Write();
+    }
 }
 catch (Exception ex)
 {


### PR DESCRIPTION
The `AssemblyModifier` post-build step read the ILRepacked assembly with Mono.Cecil without symbols and wrote it back with no symbol writer, so Cecil emitted no PE debug directory. `Core.csproj` builds Debug with `DebugType=embedded`, so this deleted the embedded portable PDB on every Debug build and Visual Studio reported `NewRelic.Agent.Core.dll` as having no debug information. The step now reads and writes symbols, keeping the embedded format. ILRepack is not involved -- run alone it preserves the embedded PDB.

Regression window: `AssemblyModifier` was added in #3526 and first shipped in v10.51.0.

Verified by inspecting the PE debug directory of `src/Agent/newrelichome_x64/NewRelic.Agent.Core.dll` before and after a Debug build of `FullAgent.sln`, and by stepping into the assembly in the local debugger.
